### PR TITLE
Added pdb_delinsertions to (selectively) delete insertion codes.

### DIFF
--- a/pdbtools/pdb_delinsertion.py
+++ b/pdbtools/pdb_delinsertion.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 João Pedro Rodrigues
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Deletes insertion codes in a PDB file, shifting the residue numbering of
+downstream residues. Allows for picking specific residues to delete insertion
+codes for.
+
+Usage:
+    python pdb_delicode.py [-<option>] <pdb file>
+
+Example:
+    python pdb_delicode.py 1CTF.pdb  # delete ALL insertion codes EVERYWHERE
+    python pdb_delicode.py -A99,B12 1CTF.pdb  # deletes ins. codes for residue
+                                              # 99 of chain A and 12 of chain B.
+
+This program is part of the `pdb-tools` suite of utilities and should not be
+distributed isolatedly. The `pdb-tools` were created to quickly manipulate PDB
+files using the terminal, and can be used sequentially, with one tool streaming
+data to another. They are based on old FORTRAN77 code that was taking too much
+effort to maintain and compile. RIP.
+"""
+
+import os
+import sys
+
+__author__ = "Joao Rodrigues"
+__email__ = "j.p.g.l.m.rodrigues@gmail.com"
+
+
+def check_input(args):
+    """Checks whether to read from stdin/file and validates user input/options.
+    """
+
+    # Defaults
+    option = ''
+    fh = sys.stdin  # file handle
+
+    if not len(args):
+        # Reading from pipe with default option
+        if sys.stdin.isatty():
+            sys.stderr.write(__doc__)
+            sys.exit(1)
+
+    elif len(args) == 1:
+        # One of two options: option & Pipe OR file & default option
+        if args[0].startswith('-'):
+            option = args[0][1:]
+            if sys.stdin.isatty():  # ensure the PDB data is streamed in
+                emsg = 'ERROR!! No data to process!\n'
+                sys.stderr.write(emsg)
+                sys.stderr.write(__doc__)
+                sys.exit(1)
+
+        else:
+            if not os.path.isfile(args[0]):
+                emsg = 'ERROR!! File not found or not readable: \'{}\'\n'
+                sys.stderr.write(emsg.format(args[0]))
+                sys.stderr.write(__doc__)
+                sys.exit(1)
+
+            fh = open(args[0], 'r')
+
+    elif len(args) == 2:
+        # Two options: option & File
+        if not args[0].startswith('-'):
+            emsg = 'ERROR! First argument is not an option: \'{}\'\n'
+            sys.stderr.write(emsg.format(args[0]))
+            sys.stderr.write(__doc__)
+            sys.exit(1)
+
+        if not os.path.isfile(args[1]):
+            emsg = 'ERROR!! File not found or not readable: \'{}\'\n'
+            sys.stderr.write(emsg.format(args[1]))
+            sys.stderr.write(__doc__)
+            sys.exit(1)
+
+        option = args[0][1:]
+        fh = open(args[1], 'r')
+
+    else:  # Whatever ...
+        sys.stderr.write(__doc__)
+        sys.exit(1)
+
+    # Validate option
+    option_list = [o for o in option.split(',') if o.strip()]
+    if option_list:
+        for o in option_list:
+            if len(o) < 2 or not o[1:].isdigit():
+                emsg = 'ERROR!! Option invalid: \'{}\''
+                sys.stderr.write(emsg.format(o))
+                sys.exit(1)
+
+    return (option_list, fh)
+
+
+def delete_insertions(fhandle, option_list):
+    """Deletes insertion codes (at specific residues).
+
+    By default, removes ALL insertion codes on ALL residues. Also bumps the
+    residue numbering of residues downstream of each insertion.
+    """
+
+    if not option_list:  # Delete all
+        has_option = False
+    else:  # turn into set
+        option_set = set(option_list)
+        has_option = True
+
+    # Keep track of residue numbering
+    # Keep track of residues read (chain, resname, resid)
+    offset = 0
+    prev_resi = None
+    seen_ids = set()
+    clean_icode = False
+    records = ('ATOM', 'HETATM', 'ANISOU', 'TER')
+    for line in fhandle:
+
+        if line.startswith(records):
+            res_uid = line[17:26]  # resname, chain, resid
+            id_res = line[21] + line[22:26].strip()  # A99, B12
+            icode = line[26]
+
+            # unfortunately, this is messy but not all PDB files follow a nice
+            # order of ' ', 'A', 'B', ... when it comes to insertion codes..
+            if prev_resi != res_uid:  # new residue
+                # Have we seen this chain + resid combination
+                # catch insertions WITHOUT icode ('A' ... ' ' ... 'B')
+                if id_res in seen_ids:
+                    # Should we do something about it?
+                    if has_option and id_res not in option_set:
+                        clean_icode = False
+                    else:
+                        clean_icode = True
+                        line = line[:26] + ' ' + line[27:]  # clear icode
+                        offset += 1
+                # Do we have an explicit icode?
+                elif icode != ' ':
+                    if has_option and id_res not in option_set:
+                        pass
+                    else:
+                        if id_res in seen_ids:  # never saw this, do not offset!
+                            offset += 1
+                        clean_icode = True
+                        line = line[:26] + ' ' + line[27:]  # clear icode
+                else:
+                    clean_icode = False
+
+                prev_resi = res_uid
+
+            if clean_icode:
+                line = line[:26] + ' ' + line[27:]
+
+            resid = int(line[22:26]) + offset
+            line = line[:22] + str(resid).rjust(4) + line[26:]
+            seen_ids.add(id_res)
+
+            # Reset offset on TER
+            if line.startswith('TER'):
+                offset = 0
+
+        yield line
+
+
+def main():
+    # Check Input
+    option_list, pdbfh = check_input(sys.argv[1:])
+
+    # Do the job
+    new_pdb = delete_insertions(pdbfh, option_list)
+
+    try:
+        _buffer = []
+        _buffer_size = 5000  # write N lines at a time
+        for lineno, line in enumerate(new_pdb):
+            if not (lineno % _buffer_size):
+                sys.stdout.write(''.join(_buffer))
+                _buffer = []
+            _buffer.append(line)
+
+        sys.stdout.write(''.join(_buffer))
+        sys.stdout.flush()
+    except IOError:
+        # This is here to catch Broken Pipes
+        # for example to use 'head' or 'tail' without
+        # the error message showing up
+        pass
+
+    # last line of the script
+    # We can close it even if it is sys.stdin
+    pdbfh.close()
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/data/dummy_insertions.pdb
+++ b/tests/data/dummy_insertions.pdb
@@ -1,0 +1,214 @@
+HEADER    THIS A DUMMY PDB FOR PDB-TOOLS TESTING                                
+TITLE     A RANDOM PDB                                                          
+COMPND    MOL_ID: 1;                                                            
+SOURCE    MOL_ID: 1;                                                            
+KEYWDS    PDB-TOOLS, TEST-PDB                                                   
+REMARK    THIS STRUCTURE CONTAINS 4 CHAINS                                      
+REMARK    ALL ATOM SERIAL NUMBERS ARE 1 FOR ATOM
+REMARK    CHAIN A HAS SEGID Z
+REMARK    CHAIN A CONTAINS AN INSERTION
+REMARK    DOUBLE OCCUPANCIES ON THE FIRST RESIDUE OF CHAIN A
+REMARK    CHAIN B HAS NON-CONTINUOUS RESIDUES (SHOULD HAVE A TER STATEMENT)
+REMARK    CHAIN B HAS AN INSERTION
+REMARK    CHAIN C DOES NOT HAVE ELEMENTS FOR LAST RESIDUE
+REMARK    CHAIN C CONTAINS RESIDUES OUT OF ORDER
+REMARK    CHAIN D IS NUCLEIC ACID AND LACKS A TER STATEMENT
+ATOM      1  N   ARG B   4A     36.898  42.175  -2.688  1.00  0.00           N  
+ATOM      2  H   ARG B   4A     37.673  41.570  -2.916  1.00  0.00           H  
+ATOM      3  H2  ARG B   4A     35.929  41.470  -2.758  1.00  0.00           H  
+ATOM      3  H3  ARG B   4A     37.099  42.392  -1.524  1.00  0.00           H  
+ATOM      3  CA  ARG B   4A     37.080  43.455  -3.421  1.00  0.00           C  
+ATOM      3  HA  ARG B   4A     38.102  43.960  -3.065  1.00  0.00           H  
+ATOM      3  CB  ARG B   4A     37.064  43.172  -4.926  1.00  0.00           C  
+ATOM      3  HB2 ARG B   4A     36.937  44.238  -5.450  1.00  0.00           H  
+ATOM      3  HB3 ARG B   4A     36.146  42.550  -5.381  1.00  0.00           H  
+ATOM      3  CG  ARG B   4A     38.366  42.367  -5.167  1.00  0.00           C  
+ATOM      3  HG2 ARG B   4A     38.044  41.263  -5.501  1.00  0.00           H  
+ATOM      3  HG3 ARG B   4A     39.214  42.156  -4.350  1.00  0.00           H  
+ATOM      3  CD  ARG B   4A     39.191  43.008  -6.234  1.00  0.00           C  
+ATOM      3  HD2 ARG B   4A     39.652  44.053  -5.873  1.00  0.00           H  
+ATOM      3  HD3 ARG B   4A     40.211  42.425  -6.479  1.00  0.00           H  
+ATOM      3  NE  ARG B   4A     38.557  43.081  -7.486  1.00  0.00           N  
+ATOM      3  HE  ARG B   4A     38.421  41.980  -7.920  1.00  0.00           H  
+ATOM      3  CZ  ARG B   4A     38.266  43.951  -8.427  1.00  0.00           C  
+ATOM      3  NH1 ARG B   4A     38.554  45.234  -8.396  1.00  0.00           N  
+ATOM      3 HH11 ARG B   4A     39.085  45.950  -7.607  1.00  0.00           H  
+ATOM      3 HH12 ARG B   4A     38.392  45.917  -9.359  1.00  0.00           H  
+ATOM      3  NH2 ARG B   4A     37.609  43.458  -9.493  1.00  0.00           N  
+ATOM      3 HH21 ARG B   4A     36.480  43.750  -9.739  1.00  0.00           H  
+ATOM      3 HH22 ARG B   4A     38.086  42.813 -10.373  1.00  0.00           H  
+ATOM      3  C   ARG B   4A     36.102  44.524  -2.998  1.00  0.00           C  
+ATOM      3  O   ARG B   4A     36.577  45.677  -2.879  1.00  0.00           O  
+ATOM      3  N   GLY B   4      18.174  73.436  46.371  1.00 56.74           N  
+ATOM      3  CA  GLY B   4      17.078  72.516  46.537  1.00 55.46           C  
+ATOM      3  C   GLY B   4      16.958  71.566  45.373  1.00 53.73           C  
+ATOM      3  O   GLY B   4      16.508  71.938  44.301  1.00 54.24           O  
+ATOM      3  N   GLU B   6      34.849  44.167  -2.710  1.00  0.00           N  
+ATOM      3  H   GLU B   6      34.444  43.155  -3.175  1.00  0.00           H  
+ATOM      3  CA  GLU B   6      33.861  45.127  -2.233  1.00  0.00           C  
+ATOM      3  HA  GLU B   6      33.871  46.090  -2.939  1.00  0.00           H  
+ATOM      3  CB  GLU B   6      32.480  44.538  -2.041  1.00  0.00           C  
+ATOM      3  HB2 GLU B   6      32.305  43.781  -1.133  1.00  0.00           H  
+ATOM      3  HB3 GLU B   6      31.793  45.504  -1.851  1.00  0.00           H  
+ATOM      3  CG  GLU B   6      31.968  43.831  -3.261  1.00  0.00           C  
+ATOM      3  HG2 GLU B   6      32.228  42.682  -3.461  1.00  0.00           H  
+ATOM      3  HG3 GLU B   6      32.059  44.448  -4.281  1.00  0.00           H  
+ATOM      3  CD  GLU B   6      30.440  43.676  -3.190  1.00  0.00           C  
+ATOM      3  OE1 GLU B   6      29.816  44.208  -2.210  1.00  0.00           O  
+ATOM      3  OE2 GLU B   6      30.005  43.060  -4.204  1.00  0.00           O  
+ATOM      3  C   GLU B   6      34.180  45.629  -0.820  1.00  0.00           C  
+ATOM      3  O   GLU B   6      33.914  46.775  -0.464  1.00  0.00           O  
+ATOM      3  N   ALA B   7      34.725  44.679  -0.087  1.00  0.00           N  
+ATOM      3  H   ALA B   7      34.813  43.714  -0.371  1.00  0.00           H  
+ATOM      3  CA  ALA B   7      35.081  45.036   1.305  1.00  0.00           C  
+ATOM      3  HA  ALA B   7      34.200  45.604   1.876  1.00  0.00           H  
+ATOM      3  CB  ALA B   7      35.381  43.810   2.140  1.00  0.00           C  
+ATOM      3  HB1 ALA B   7      34.382  43.229   2.456  1.00  0.00           H  
+ATOM      3  HB2 ALA B   7      36.167  42.973   1.802  1.00  0.00           H  
+ATOM      3  HB3 ALA B   7      35.847  44.180   3.181  1.00  0.00           H  
+ATOM      3  C   ALA B   7      36.213  46.067   1.258  1.00  0.00           C  
+ATOM      3  O   ALA B   7      36.287  47.046   2.028  1.00  0.00           O  
+TER       3      ALA B   7
+ATOM      3  N   ASN A   1A     22.066  40.557   0.420  1.00  0.00           N  
+ATOM      3  H   ASN A   1A     21.629  41.305  -0.098  1.00  0.00           H  
+ATOM      3  H2  ASN A   1A     23.236  40.798   0.369  1.00  0.00           H  
+ATOM      3  H3  ASN A   1A     21.866  40.736   1.590  1.00  0.00           H  
+ATOM      3  CA BASN A   1A     20.000  30.000   0.005  0.60  0.00           C  
+ATOM      3  CA AASN A   1A     21.411  39.311   0.054  0.40  0.00           C  
+ATOM      3  HA  ASN A   1A     21.274  38.560   0.973  1.00  0.00           H  
+ATOM      3  CB  ASN A   1A     19.994  39.763  -0.371  1.00  0.00           C  
+ATOM      3  HB2 ASN A   1A     19.390  40.329   0.493  1.00  0.00           H  
+ATOM      3  HB3 ASN A   1A     19.951  40.426  -1.365  1.00  0.00           H  
+ATOM      3  CG  ASN A   1A     18.956  38.712  -0.677  1.00  0.00           C  
+ATOM      3  OD1 ASN A   1A     19.093  37.685   0.011  1.00  0.00           O  
+ATOM      3  ND2 ASN A   1A     17.958  38.797  -1.531  1.00  0.00           N  
+ATOM      3 HD21 ASN A   1A     17.073  39.590  -1.490  1.00  0.00           H  
+ATOM      3 HD22 ASN A   1A     17.746  37.948  -2.337  1.00  0.00           H  
+ATOM      3  C   ASN A   1A     22.143  38.629  -1.102  1.00  0.00           C  
+ATOM      3  O   ASN A   1A     21.581  38.297  -2.176  1.00  0.00           O  
+ATOM      3  N   GLY A   1      18.174  73.436  46.371  1.00 56.74           N  
+ATOM      3  CA  GLY A   1      17.078  72.516  46.537  1.00 55.46           C  
+ATOM      3  C   GLY A   1      16.958  71.566  45.373  1.00 53.73           C  
+ATOM      3  O   GLY A   1      16.508  71.938  44.301  1.00 54.24           O  
+ATOM      3  N   ARG A   2      23.408  38.395  -0.829  1.00  0.00           N  
+ATOM      3  H   ARG A   2      23.683  38.199   0.313  1.00  0.00           H  
+ATOM      3  CA  ARG A   2      24.384  37.823  -1.757  1.00  0.00           C  
+ATOM      3  HA  ARG A   2      24.282  38.422  -2.786  1.00  0.00           H  
+ATOM      3  CB  ARG A   2      25.810  37.966  -1.211  1.00  0.00           C  
+ATOM      3  HB2 ARG A   2      26.567  37.565  -2.049  1.00  0.00           H  
+ATOM      3  HB3 ARG A   2      26.001  37.209  -0.306  1.00  0.00           H  
+ATOM      3  CG  ARG A   2      26.164  39.436  -0.931  1.00  0.00           C  
+ATOM      3  HG2 ARG A   2      26.305  39.921  -2.015  1.00  0.00           H  
+ATOM      3  HG3 ARG A   2      25.398  40.159  -0.373  1.00  0.00           H  
+ATOM      3  CD  ARG A   2      27.434  39.527  -0.075  1.00  0.00           C  
+ATOM      3  HD2 ARG A   2      27.330  38.901   0.945  1.00  0.00           H  
+ATOM      3  HD3 ARG A   2      28.442  39.042  -0.507  1.00  0.00           H  
+ATOM      3  NE  ARG A   2      27.571  40.926   0.442  1.00  0.00           N  
+ATOM      3  HE  ARG A   2      27.306  41.176   1.574  1.00  0.00           H  
+ATOM      3  CZ  ARG A   2      28.171  41.856  -0.298  1.00  0.00           C  
+ATOM      3  NH1 ARG A   2      28.694  41.561  -1.484  1.00  0.00           N  
+ATOM      3 HH11 ARG A   2      28.089  41.809  -2.480  1.00  0.00           H  
+ATOM      3 HH12 ARG A   2      29.766  41.066  -1.634  1.00  0.00           H  
+ATOM      3  NH2 ARG A   2      28.285  43.099   0.095  1.00  0.00           N  
+ATOM      3 HH21 ARG A   2      27.536  43.967  -0.232  1.00  0.00           H  
+ATOM      3 HH22 ARG A   2      28.955  43.437   1.019  1.00  0.00           H  
+ATOM      3  C   ARG A   2      24.061  36.421  -2.189  1.00  0.00           C  
+ATOM      3  O   ARG A   2      24.411  36.106  -3.325  1.00  0.00           O  
+ATOM      3  N   GLU A   3      23.456  35.570  -1.408  1.00  0.00           N  
+ATOM      3  H   GLU A   3      23.028  35.844  -0.334  1.00  0.00           H  
+ATOM      3  CA  GLU A   3      23.064  34.219  -1.780  1.00  0.00           C  
+ATOM      3  HA  GLU A   3      23.679  33.794  -2.710  1.00  0.00           H  
+ATOM      3  CB  GLU A   3      23.067  33.293  -0.568  1.00  0.00           C  
+ATOM      3  HB2 GLU A   3      22.647  32.197  -0.811  1.00  0.00           H  
+ATOM      3  HB3 GLU A   3      22.272  33.605   0.271  1.00  0.00           H  
+ATOM      3  CG  GLU A   3      24.431  33.215   0.088  1.00  0.00           C  
+ATOM      3  HG2 GLU A   3      24.298  32.589   1.101  1.00  0.00           H  
+ATOM      3  HG3 GLU A   3      25.122  34.127   0.432  1.00  0.00           H  
+ATOM      3  CD  GLU A   3      25.340  32.327  -0.714  1.00  0.00           C  
+ATOM      3  OE1 GLU A   3      24.891  31.745  -1.724  1.00  0.00           O  
+ATOM      3  OE2 GLU A   3      26.527  32.135  -0.455  1.00  0.00           O  
+ATOM      3  C   GLU A   3      21.682  34.241  -2.380  1.00  0.00           C  
+ATOM      3  O   GLU A   3      21.239  33.190  -2.786  1.00  0.00           O  
+TER       3      GLU A   3                                                      
+ATOM      3  N   ARG C   5      36.898  42.175  -2.688  1.00  0.00           N
+ATOM      3  H   ARG C   5      37.673  41.570  -2.916  1.00  0.00           H
+ATOM      3  H2  ARG C   5      35.929  41.470  -2.758  1.00  0.00           H
+ATOM      3  H3  ARG C   5      37.099  42.392  -1.524  1.00  0.00           H
+ATOM      3  CA  ARG C   5      37.080  43.455  -3.421  1.00  0.00           C
+ATOM      3  HA  ARG C   5      38.102  43.960  -3.065  1.00  0.00           H
+ATOM      3  CB  ARG C   5      37.064  43.172  -4.926  1.00  0.00           C
+ATOM      3  HB2 ARG C   5      36.937  44.238  -5.450  1.00  0.00           H
+ATOM      3  HB3 ARG C   5      36.146  42.550  -5.381  1.00  0.00           H
+ATOM      3  CG  ARG C   5      38.366  42.367  -5.167  1.00  0.00           C
+ATOM      3  HG2 ARG C   5      38.044  41.263  -5.501  1.00  0.00           H
+ATOM      3  HG3 ARG C   5      39.214  42.156  -4.350  1.00  0.00           H
+ATOM      3  CD  ARG C   5      39.191  43.008  -6.234  1.00  0.00           C
+ATOM      3  HD2 ARG C   5      39.652  44.053  -5.873  1.00  0.00           H
+ATOM      3  HD3 ARG C   5      40.211  42.425  -6.479  1.00  0.00           H
+ATOM      3  NE  ARG C   5      38.557  43.081  -7.486  1.00  0.00           N
+ATOM      3  HE  ARG C   5      38.421  41.980  -7.920  1.00  0.00           H
+ATOM      3  CZ  ARG C   5      38.266  43.951  -8.427  1.00  0.00           C
+ATOM      3  NH1 ARG C   5      38.554  45.234  -8.396  1.00  0.00           N
+ATOM      3 HH11 ARG C   5      39.085  45.950  -7.607  1.00  0.00           H
+ATOM      3 HH12 ARG C   5      38.392  45.917  -9.359  1.00  0.00           H
+ATOM      3  NH2 ARG C   5      37.609  43.458  -9.493  1.00  0.00           N
+ATOM      3 HH21 ARG C   5      36.480  43.750  -9.739  1.00  0.00           H
+ATOM      3 HH22 ARG C   5      38.086  42.813 -10.373  1.00  0.00           H
+ATOM      3  C   ARG C   5      36.102  44.524  -2.998  1.00  0.00           C
+ATOM      3  O   ARG C   5      36.577  45.677  -2.879  1.00  0.00           O
+ATOM      3  N   GLU C   2      34.849  44.167  -2.710  1.00  0.00           N
+ATOM      3  H   GLU C   2      34.444  43.155  -3.175  1.00  0.00           H
+ATOM      3  CA  GLU C   2      33.861  45.127  -2.233  1.00  0.00           C
+ATOM      3  HA  GLU C   2      33.871  46.090  -2.939  1.00  0.00           H
+ATOM      3  CB  GLU C   2      32.480  44.538  -2.041  1.00  0.00           C
+ATOM      3  HB2 GLU C   2      32.305  43.781  -1.133  1.00  0.00           H
+ATOM      3  HB3 GLU C   2      31.793  45.504  -1.851  1.00  0.00           H
+ATOM      3  CG  GLU C   2      31.968  43.831  -3.261  1.00  0.00           C
+ATOM      3  HG2 GLU C   2      32.228  42.682  -3.461  1.00  0.00           H
+ATOM      3  HG3 GLU C   2      32.059  44.448  -4.281  1.00  0.00           H
+ATOM      3  CD  GLU C   2      30.440  43.676  -3.190  1.00  0.00           C
+ATOM      3  OE1 GLU C   2      29.816  44.208  -2.210  1.00  0.00           O
+ATOM      3  OE2 GLU C   2      30.005  43.060  -4.204  1.00  0.00           O
+ATOM      3  C   GLU C   2      34.180  45.629  -0.820  1.00  0.00           C
+ATOM      3  O   GLU C   2      33.914  46.775  -0.464  1.00  0.00           O
+ATOM      3  N   MET C  -1      43.010 -16.998  71.911  1.00 54.34              
+ATOM      3  CA  MET C  -1      42.850 -16.494  70.506  1.00 52.98              
+ATOM      3  C   MET C  -1      41.752 -17.205  69.684  1.00 52.05              
+ATOM      3  O   MET C  -1      41.560 -18.418  69.777  1.00 54.00              
+ATOM      3  CB  MET C  -1      44.170 -16.675  69.746  1.00 54.15              
+ATOM      3  CG  MET C  -1      44.178 -16.031  68.376  0.70 53.45              
+ATOM      3  SD  MET C  -1      45.459 -16.671  67.274  0.70 54.81             
+ATOM      3  CE  MET C  -1      46.644 -15.335  67.447  0.50 56.04      ABCD    
+TER       3      MET C  -1                                                      
+ATOM      3  P    DT D   2      36.556  19.296  31.761  1.00247.39      Z    
+ATOM      3  OP1  DT D   2      37.512  20.431  31.873  1.00246.92      Z
+ATOM      3  OP2  DT D   2      36.121  18.841  30.413  1.00249.27      Z
+ATOM      3  O5'  DT D   2      37.156  18.071  32.587  1.00240.73      Z
+ATOM      3  C5'  DT D   2      37.291  18.167  34.022  1.00234.60      Z
+ATOM      3  C4'  DT D   2      36.894  16.884  34.720  1.00230.04      Z
+ATOM      3  O4'  DT D   2      35.483  16.586  34.583  1.00223.51      Z
+ATOM      3  C3'  DT D   2      37.637  15.617  34.271  1.00231.80      Z
+ATOM      3  O3'  DT D   2      38.514  15.208  35.326  1.00243.58      Z
+ATOM      3  C2'  DT D   2      36.528  14.599  34.046  1.00225.69      Z
+ATOM      3  C1'  DT D   2      35.377  15.199  34.824  1.00221.02      Z
+ATOM      3  N1   DT D   2      34.026  14.737  34.425  1.00216.83      Z
+ATOM      3  C2   DT D   2      33.171  14.323  35.424  1.00212.97      Z
+ATOM      3  O2   DT D   2      33.456  14.374  36.611  1.00208.83      Z
+ATOM      3  N3   DT D   2      31.953  13.865  34.982  1.00211.37      Z
+ATOM      3  C4   DT D   2      31.522  13.771  33.670  1.00212.96      Z
+ATOM      3  O4   DT D   2      30.395  13.347  33.427  1.00214.43      Z
+ATOM      3  C5   DT D   2      32.479  14.201  32.672  1.00213.13      Z
+ATOM      3  C7   DT D   2      32.100  14.139  31.225  1.00210.53      Z
+ATOM      3  C6   DT D   2      33.671  14.646  33.094  1.00215.41      Z       
+HETATM    4 CA    CA A 301      44.698  -0.753  65.490  1.00 57.81              
+HETATM    5  O   HOH A 302      61.179  -8.803  36.085  1.00 51.61              
+HETATM    6  O   HOH A 303      64.052  21.644  20.397  1.00 65.18              
+HETATM    7  O   HOH B 301      11.052 -12.419  29.700  1.00 73.70              
+HETATM    8  O   HOH C 301      -8.172 -22.003  57.197  1.00 70.53              
+HETATM    9  O   HOH C 302      36.020 -23.583  73.186  1.00 24.82              
+HETATM   10  O   HOH C 303      41.203 -28.852  57.698  1.00 53.16              
+HETATM   11  O   HOH C 304      -4.491  -9.687  56.752  1.00 55.08              
+HETATM   12  O   HOH C 305      24.561   0.532  70.565  1.00 44.77              
+CONECT   10   11                                                                
+CONECT    1    2   4   5  
+

--- a/tests/test_pdb_delinsertion.py
+++ b/tests/test_pdb_delinsertion.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 João Pedro Rodrigues
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit Tests for `pdb_delinsertion`.
+"""
+
+import os
+import sys
+import unittest
+
+from config import data_dir
+from utils import OutputCapture
+
+
+class TestTool(unittest.TestCase):
+    """
+    Generic class for testing tools.
+    """
+
+    def setUp(self):
+        # Dynamically import the module
+        name = 'pdbtools.pdb_delinsertion'
+        self.module = __import__(name, fromlist=[''])
+
+    def exec_module(self):
+        """
+        Execs module.
+        """
+
+        with OutputCapture() as output:
+            try:
+                self.module.main()
+            except SystemExit as e:
+                self.retcode = e.code
+
+        self.stdout = output.stdout
+        self.stderr = output.stderr
+
+        return
+
+    def test_default(self):
+        """$ pdb_delinsertion data/dummy_insertions.pdb"""
+
+        # Simulate input
+        # pdb_delinsertion dummy_insertions.pdb
+        sys.argv = ['', os.path.join(data_dir, 'dummy_insertions.pdb')]
+
+        # Execute the script
+        self.exec_module()
+
+        # Validate results
+        self.assertEqual(self.retcode, 0)  # ensure the program exited OK.
+        self.assertEqual(len(self.stdout), 214)  # no lines deleted
+        self.assertEqual(len(self.stderr), 0)  # no errors
+
+        # Check if we do not have any insertions
+        records = (('ATOM', 'HETATM'))
+        icodes = set(l[26] for l in self.stdout if l.startswith(records))
+        self.assertEqual(icodes, set(' '))
+
+        # Check numbering was corrected
+        resid = [int(l[22:26]) for l in self.stdout if l.startswith(records)]
+        expected = [4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                    4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+                    7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
+                    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5,
+                    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+                    5, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, -1, -1, -1,
+                    -1, -1, -1, -1, -1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                    2, 2, 2, 2, 2, 2, 2, 301, 302, 303, 301, 301, 302, 303, 304,
+                    305]
+        self.assertEqual(resid, expected)
+
+    def test_select_insertion(self):
+        """$ pdb_delinsertion -A1 data/dummy_insertions.pdb"""
+
+        sys.argv = ['', '-A1', os.path.join(data_dir, 'dummy_insertions.pdb')]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 0)
+        self.assertEqual(len(self.stdout), 214)
+        self.assertEqual(len(self.stderr), 0)
+
+        records = (('ATOM', 'HETATM'))
+
+        # Check the insertions were deleted specifically
+        for line in self.stdout:
+            if line.startswith(records):
+                icode = line[26]
+                resid = int(line[22:26])
+                if line[17:26] == 'ARG B   4':
+                    self.assertEqual(icode, 'A')
+                    self.assertEqual(resid, 4)
+                elif line[17:26] == 'GLY B   4':
+                    self.assertEqual(icode, ' ')
+                    self.assertEqual(resid, 4)
+                elif line[17:26] == 'ASN A   1':
+                    self.assertEqual(icode, ' ')
+                    self.assertEqual(resid, 1)
+                elif line[17:26] == 'GLY A   1':
+                    self.assertEqual(icode, ' ')
+                    self.assertEqual(resid, 2)  # should have renumbered
+
+        # Check numbering was corrected overall
+        resid = [int(l[22:26]) for l in self.stdout if l.startswith(records)]
+        expected = [4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+                    6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
+                    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5,
+                    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+                    5, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, -1, -1, -1,
+                    -1, -1, -1, -1, -1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                    2, 2, 2, 2, 2, 2, 2, 301, 302, 303, 301, 301, 302, 303, 304,
+                    305]
+
+        self.assertEqual(resid, expected)
+
+    def test_file_not_found(self):
+        """$ pdb_delinsertion not_existing.pdb"""
+
+        afile = os.path.join(data_dir, 'not_existing.pdb')
+        sys.argv = ['', afile]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)  # exit code is 1 (error)
+        self.assertEqual(len(self.stdout), 0)  # nothing written to stdout
+        self.assertEqual(self.stderr[0][:22],
+                         "ERROR!! File not found")  # proper error message
+
+    def test_file_missing(self):
+        """$ pdb_delinsertion -A89"""
+
+        sys.argv = ['', '-A89']
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)  # no output
+        self.assertEqual(self.stderr[0],
+                         "ERROR!! No data to process!")
+
+    def test_helptext(self):
+        """$ pdb_delinsertion"""
+
+        sys.argv = ['']
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)  # ensure the program exited gracefully.
+        self.assertEqual(len(self.stdout), 0)  # no output
+        self.assertEqual(self.stderr, self.module.__doc__.split("\n")[:-1])
+
+    def test_invalid_option(self):
+        """$ pdb_delinsertion -A data/dummy_insertions.pdb"""
+
+        sys.argv = ['', '-A', os.path.join(data_dir, 'dummy_insertions.pdb')]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)
+        self.assertEqual(self.stderr[0][:27],
+                         "ERROR!! Option invalid: 'A'")
+
+    def test_invalid_option_2(self):
+        """$ pdb_delinsertion -12A data/dummy_insertions.pdb"""
+
+        sys.argv = ['', '-12A', os.path.join(data_dir, 'dummy_insertions.pdb')]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)
+        self.assertEqual(self.stderr[0][:39],
+                         "ERROR!! Option invalid: '12A'")
+
+    def test_not_an_option(self):
+        """$ pdb_delinsertion 20 data/dummy_insertions.pdb"""
+
+        sys.argv = ['', '20', os.path.join(data_dir, 'dummy_insertions.pdb')]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)
+        self.assertEqual(self.stderr[0],
+                         "ERROR! First argument is not an option: '20'")
+
+
+if __name__ == '__main__':
+    from config import test_dir
+
+    mpath = os.path.abspath(os.path.join(test_dir, '..'))
+    sys.path.insert(0, mpath)  # so we load dev files before  any installation
+
+    unittest.main()


### PR DESCRIPTION
Following issue #13, here is a pull request to try and address that need. `pdb_delinsertion` removes, by default, _all_ insertions and pads the numbering accordingly. It also allows the user to specify insertions that should be removed, ignoring all others (e.g. `pdb_delinsertion -A99,B24` removes only insertions at residues 99 of chain A and 24 of chain B).

Comments? @mtrellet @joaomcteixeira @amjjbonvin 