### PR TITLE
Fixes issue with *.pyc files in Python 2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 dist/
 *egg-info/
 *__pycache__
+*.pyc

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 # Collect names of bin/*py scripts
 # e.g. 'pdb_intersect=bin.pdb_intersect:main',
 binfiles = listdir(path.join(here, 'pdbtools'))
-bin_py = [f[:-3] + '=pdbtools.' + f[:-3] + ':main' for f in binfiles]
+bin_py = [f[:-3] + '=pdbtools.' + f[:-3] + ':main' for f in binfiles
+          if f.endswith('.py')]
 
 setup(
     name='pdb-tools',  # Required


### PR DESCRIPTION
Addresses issue #31 , caused by Python2.7 creating *.pyc files on testing because of imports.