### PR TITLE
Fixed MODEL line bug when model number > 10

### DIFF
--- a/pdbtools/pdb_mkensemble.py
+++ b/pdbtools/pdb_mkensemble.py
@@ -81,7 +81,7 @@ def make_ensemble(f_name_list):
     fmt_REMARK = "REMARK     {:<67s}\n"
 
     # MODEL        1
-    fmt_MODEL = "MODEL {:>5d}\n"
+    fmt_MODEL = "MODEL    {:>5d}\n"
 
     for fileno, file_name in enumerate(f_name_list, start=1):
         fpath = os.path.basename(file_name)

--- a/tests/test_pdb_mkensemble.py
+++ b/tests/test_pdb_mkensemble.py
@@ -68,6 +68,32 @@ class TestTool(unittest.TestCase):
         self.assertEqual(len(self.stdout), 385)
         self.assertEqual(len(self.stderr), 0)
 
+    def test_default_multiple(self):
+        """$ pdb_mkensemble data/dummy.pdb x20"""
+
+        # Simulate input
+        args = [os.path.join(data_dir, 'dummy.pdb') for _ in range(20)]
+        sys.argv = [''] + args
+
+        # Execute the script
+        self.exec_module()
+
+        # Validate results
+        self.assertEqual(self.retcode, 0)
+        self.assertEqual(len(self.stdout), 3823)
+        self.assertEqual(len(self.stderr), 0)
+
+        # Validate MODEL lines
+        model_no = [
+            int(line[10:14])
+            for line in self.stdout
+            if line.startswith('MODEL')
+        ]
+        model_no = sorted(set(model_no))
+        n_models = len(model_no)
+        self.assertEqual(n_models, 20)
+        self.assertEqual(model_no, list(range(1, 21)))
+
     def test_file_not_found(self):
         """$ pdb_mkensemble not_existing.pdb"""
 


### PR DESCRIPTION
Small bug in `pdb_mkensemble` that placed the model number at the wrong column. Splitting with `pdb_splitmodel` in an ensemble of more than 10 models would yield always 10 models (only reading the last digit).