### PR TITLE
avoid IndexError: string index out of range

### DIFF
--- a/pdbtools/pdb_selchain.py
+++ b/pdbtools/pdb_selchain.py
@@ -118,7 +118,7 @@ def select_chain(fhandle, chain_set):
     records = ('ATOM', 'HETATM', 'TER', 'ANISOU')
     for line in fhandle:
         if line.startswith(records):
-            if len(line)>20 and line[21] not in chain_set:
+            if len(line) > 20 and line[21] not in chain_set:
                 continue
         yield line
 

--- a/pdbtools/pdb_selchain.py
+++ b/pdbtools/pdb_selchain.py
@@ -118,7 +118,7 @@ def select_chain(fhandle, chain_set):
     records = ('ATOM', 'HETATM', 'TER', 'ANISOU')
     for line in fhandle:
         if line.startswith(records):
-            if line[21] not in chain_set:
+            if len(line)>20 and line[21] not in chain_set:
                 continue
         yield line
 


### PR DESCRIPTION
In certain not-so-clean PDB files, this change avoids index out of range error