### PR TITLE
Reset residue numbering for each model

### DIFF
--- a/pdbtools/pdb_reres.py
+++ b/pdbtools/pdb_reres.py
@@ -122,7 +122,7 @@ def renumber_residues(fhandle, starting_resid):
     records = ('ATOM', 'HETATM', 'TER', 'ANISOU')
     for line in fhandle:
         line = _pad_line(line)
-        if line.startswith('ENDMDL'):
+        if line.startswith('MODEL'):
             resid = starting_resid - 1 # account for first residue
         elif line.startswith(records):
             line_resuid = line[17:27]

--- a/pdbtools/pdb_reres.py
+++ b/pdbtools/pdb_reres.py
@@ -123,7 +123,7 @@ def renumber_residues(fhandle, starting_resid):
     for line in fhandle:
         line = _pad_line(line)
         if line.startswith('MODEL'):
-            resid = starting_resid - 1 # account for first residue
+            resid = starting_resid - 1  # account for first residue
         elif line.startswith(records):
             line_resuid = line[17:27]
             if line_resuid != prev_resid:


### PR DESCRIPTION
Since large ensembles tend to surpass 9999 overall residues, I tweaked `pdb_reres` so that the numbering scheme will reset between models. Since `pdb_reatom` already does this for each model, this would also help improve consistency between scripts. 