### PR TITLE
Updated README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,14 @@ recommended way as it makes updating/uninstalling rather simple:
 pip install pdb-tools
 ```
 
-If you want to install the latest development version, which might give you new
-features but also some bugs, see [here](#Installing-from-Source).
-
+Because we use semantic versioning in the development of `pdb-tools`, every bugfix
+or new feature results in a new version of the software that is automatically published
+on PyPI. As such, there is no difference between the code on github and the latest version
+you can install with `pip`. To update your installation to the latest version of the code
+run:
+```bash
+pip install --upgrade pdb-tools
+```
 
 ## What can I do with them?
 The names of the tools should be self-explanatory. Their command-line interface

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,14 @@ recommended way as it makes updating/uninstalling rather simple:
 pip install pdb-tools
 ```
 
-If you want to install the latest development version, which might give you new
-features but also some bugs, see [here](#Installing-from-Source).
+Because we use semantic versioning in the development of `pdb-tools`, every bugfix
+or new feature results in a new version of the software that is automatically published
+on PyPI. As such, there is no difference between the code on github and the latest version
+you can install with `pip`. To update your installation to the latest version of the code
+run:
+```bash
+pip install --upgrade pdb-tools
+```
 
 
 ## What can I do with them?


### PR DESCRIPTION
The current instructions refer to 'installing from source' as a way to get the latest version of the code. Our recent changes to the way we do versions and automatically publishing packages sort of make this obsolete.