### PR TITLE
pdb_reres was ignoring MODEL lines

### DIFF
--- a/pdbtools/pdb_reres.py
+++ b/pdbtools/pdb_reres.py
@@ -124,6 +124,7 @@ def renumber_residues(fhandle, starting_resid):
         line = _pad_line(line)
         if line.startswith('MODEL'):
             resid = starting_resid - 1  # account for first residue
+            yield line
         elif line.startswith(records):
             line_resuid = line[17:27]
             if line_resuid != prev_resid:

--- a/pdbtools/pdb_reres.py
+++ b/pdbtools/pdb_reres.py
@@ -124,7 +124,9 @@ def renumber_residues(fhandle, starting_resid):
         line = _pad_line(line)
         if line.startswith('MODEL'):
             resid = starting_resid - 1  # account for first residue
+            prev_resid = None  # tracks chain and resid
             yield line
+
         elif line.startswith(records):
             line_resuid = line[17:27]
             if line_resuid != prev_resid:

--- a/tests/data/ensemble_more_OK.pdb
+++ b/tests/data/ensemble_more_OK.pdb
@@ -1,0 +1,13 @@
+HEADER    THIS A DUMMY PDB FOR PDB-TOOLS TESTING                                
+TITLE     A RANDOM PDB                                                          
+MODEL        1                                                                  
+ATOM      1  N   ASN A   1      22.066  40.557   0.420  1.00  0.00           N  
+ATOM      2  H   ASN A   1      21.629  41.305  -0.098  1.00  0.00           H  
+ATOM      3  N   ASN A   2      22.066  40.557   0.420  1.00  0.00           N  
+ATOM      4  H   ASN A   2      21.629  41.305  -0.098  1.00  0.00           H  
+ENDMDL                                                                          
+MODEL        2                                                                  
+ATOM      1  N   ASN A   1      22.066  40.557   0.420  1.00  0.00           N  
+ATOM      2  H   ASN A   1      21.629  41.305  -0.098  1.00  0.00           H  
+ENDMDL                                                                          
+END                                                                             

--- a/tests/test_pdb_reres.py
+++ b/tests/test_pdb_reres.py
@@ -151,6 +151,50 @@ class TestTool(unittest.TestCase):
 
         self.assertEqual(resid_list, expected)
 
+    def test_three_with_single_res_models(self):
+        """$ pdb_reres -4 data/ensemble.OK.pdb"""
+        sys.argv = ['', '-4', os.path.join(data_dir, 'ensemble_OK.pdb')]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 0)
+        self.assertEqual(len(self.stdout), 11)
+        self.assertEqual(len(self.stderr), 0)
+
+        records = ('ATOM', 'HETATM')
+        resid_list = [int(l[22:26]) for l in self.stdout
+                      if l.startswith(records)]
+
+        expected = [4, 4, 4, 4]
+        self.assertEqual(resid_list, expected)
+
+        models = ('MODEL',)
+        models_int = [int(l[5:]) for l in self.stdout if l.startswith(models)]
+        models_expected = [1, 2]
+        self.assertEqual(models_int, models_expected)
+
+    def test_three_with_models(self):
+        """$ pdb_reres -4 data/ensemble.OK.pdb"""
+        sys.argv = ['', '-4', os.path.join(data_dir, 'ensemble_more_OK.pdb')]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 0)
+        self.assertEqual(len(self.stdout), 13)
+        self.assertEqual(len(self.stderr), 0)
+
+        records = ('ATOM', 'HETATM')
+        resid_list = [int(l[22:26]) for l in self.stdout
+                      if l.startswith(records)]
+
+        expected = [4, 4, 5, 5, 4, 4]
+        self.assertEqual(resid_list, expected)
+
+        models = ('MODEL',)
+        models_int = [int(l[5:]) for l in self.stdout if l.startswith(models)]
+        models_expected = [1, 2]
+        self.assertEqual(models_int, models_expected)
+
     def test_too_many_residues(self):
         """$ pdb_reres -9998 data/dummy.pdb"""
 


### PR DESCRIPTION
* `pdb_reres` was ignoring `MODEL` lines, and these were omitted in the output
* `MODEL` lines are now piped to the output.
* Solves issue #68