### PR TITLE
Ignores CONECT lines in pdb_tidy

### DIFF
--- a/pdbtools/pdb_tidy.py
+++ b/pdbtools/pdb_tidy.py
@@ -120,7 +120,6 @@ def tidy_pdbfile(fhandle):
             break
 
     # Now go through all the remaining lines
-    serial_equiv = {}  # store for conect statements
     atom_section = False
     serial_offset = 0  # To offset after adding TER records
     for line in fhandle:

--- a/pdbtools/pdb_tidy.py
+++ b/pdbtools/pdb_tidy.py
@@ -100,7 +100,7 @@ def tidy_pdbfile(fhandle):
     fmt_TER = "TER   {:>5d}      {:3s} {:1s}{:>4s}{:1s}" + " " * 53 + "\n"
 
     records = ('ATOM', 'HETATM')
-    ignored = ('TER', 'END ', 'END\n')
+    ignored = ('TER', 'END ', 'END\n', 'CONECT')
     # Iterate up to the first ATOM/HETATM line
     prev_line = None
     for line in fhandle:
@@ -158,9 +158,6 @@ def tidy_pdbfile(fhandle):
             # Avoids doing the offset again
             serial = int(prev_line[6:11])
             line = line[:6] + str(serial).rjust(5) + line[11:]
-
-        elif line.startswith('CONECT'):
-            continue
 
         else:
             if atom_section:

--- a/pdbtools/pdb_tidy.py
+++ b/pdbtools/pdb_tidy.py
@@ -98,10 +98,6 @@ def tidy_pdbfile(fhandle):
 
     # TER     606      LEU A  75
     fmt_TER = "TER   {:>5d}      {:3s} {:1s}{:>4s}{:1s}" + " " * 53 + "\n"
-    # CONECT 1179  746 1184 1195 1203
-    fmt_CONECT = "CONECT{:>5s}{:>5s}{:>5s}{:>5s}{:>5s}" + " " * 49 + "\n"
-    char_ranges = (slice(6, 11), slice(11, 16),
-                   slice(16, 21), slice(21, 26), slice(26, 31))
 
     records = ('ATOM', 'HETATM')
     ignored = ('TER', 'END ', 'END\n')
@@ -165,16 +161,6 @@ def tidy_pdbfile(fhandle):
             line = line[:6] + str(serial).rjust(5) + line[11:]
 
         elif line.startswith('CONECT'):
-            if atom_section:
-                atom_section = False
-                yield make_TER(prev_line)
-
-            # 6:11, 11:16, 16:21, 21:26, 26:31
-            serials = [line[cr] for cr in char_ranges]
-            # If not found, return default
-            new_serials = [str(serial_equiv.get(s, s)) for s in serials]
-            conect_line = fmt_CONECT.format(*new_serials)
-            yield conect_line
             continue
 
         else:

--- a/tests/test_pdb_tidy.py
+++ b/tests/test_pdb_tidy.py
@@ -64,12 +64,17 @@ class TestTool(unittest.TestCase):
 
         # Validate results
         self.assertEqual(self.retcode, 0)  # ensure the program exited OK.
-        self.assertEqual(len(self.stdout), 207)
+        # CONECTs are ignored by issue #72, expected only 205 lines
+        self.assertEqual(len(self.stdout), 205)
         self.assertEqual(len(self.stderr), 0)  # no errors
 
         # Check if we added TER statements correctly
         n_ter = len([r for r in self.stdout if r.startswith('TER')])
         self.assertEqual(n_ter, 5)
+
+        # Check no CONECT in output
+        c_conect = sum(1 for i in self.stdout if i.startswith('CONECT'))
+        self.assertEqual(c_conect, 0)
 
         # Check if we added END statements correctly
         self.assertTrue(self.stdout[-1].startswith('END'))


### PR DESCRIPTION
After the discussion in #72, `pdb_tidy` now ignores `CONECT` lines, removing them from the output.

Closes #72 