### PR TITLE
Deleted unreachable/duplicated return statements

### DIFF
--- a/pdbtools/pdb_delresname.py
+++ b/pdbtools/pdb_delresname.py
@@ -111,8 +111,6 @@ def check_input(args):
 
     return (option_set, fh)
 
-    return (option, fh)
-
 
 def delete_residue_by_name(fhandle, resname_set):
     """Removes specific residue that match a given name.

--- a/pdbtools/pdb_selatom.py
+++ b/pdbtools/pdb_selatom.py
@@ -112,8 +112,6 @@ def check_input(args):
 
     return (option_set, fh)
 
-    return (option, fh)
-
 
 def filter_atoms(fhandle, atomname_set):
     """Removes specific atoms that do not match a given atom name.

--- a/pdbtools/pdb_selresname.py
+++ b/pdbtools/pdb_selresname.py
@@ -111,8 +111,6 @@ def check_input(args):
 
     return (option_set, fh)
 
-    return (option, fh)
-
 
 def filter_residue_by_name(fhandle, resname_set):
     """Removes specific residue that do not match a given name.


### PR DESCRIPTION
There were a few scripts with double `return` statements in the input parsing function - typo/leftover from copy-paste.