### PR TITLE
Added -strict option to pdb_tidy to avoid adding intra-chain TERs

### DIFF
--- a/pdbtools/pdb_tidy.py
+++ b/pdbtools/pdb_tidy.py
@@ -112,6 +112,8 @@ def tidy_pdbfile(fhandle, strict=False):
     If strict is True, does not add TER statements at intra-chain breaks.
     """
 
+    not_strict = not strict
+
     def make_TER(prev_line):
         """Creates a TER statement based on the last ATOM/HETATM line.
         """
@@ -163,7 +165,7 @@ def tidy_pdbfile(fhandle, strict=False):
         if line.startswith('ATOM'):
 
             is_gap = (int(line[22:26]) - int(prev_line[22:26])) > 1
-            if atom_section and (line[21] != prev_line[21] or (not strict and is_gap)):
+            if atom_section and (line[21] != prev_line[21] or (not_strict and is_gap)):
                 serial_offset += 1  # account for TER statement
                 yield make_TER(prev_line)
 

--- a/tests/test_pdb_tidy.py
+++ b/tests/test_pdb_tidy.py
@@ -79,6 +79,32 @@ class TestTool(unittest.TestCase):
         # Check if we added END statements correctly
         self.assertTrue(self.stdout[-1].startswith('END'))
 
+    def test_default_strict(self):
+        """$ pdb_tidy -strict data/dummy.pdb"""
+
+        fpath = os.path.join(data_dir, 'dummy.pdb')
+        sys.argv = ['', '-strict', fpath]
+
+        # Execute the script
+        self.exec_module()
+
+        # Validate results
+        self.assertEqual(self.retcode, 0)  # ensure the program exited OK.
+        # CONECTs are ignored by issue #72, expected only 204 lines
+        self.assertEqual(len(self.stdout), 204)
+        self.assertEqual(len(self.stderr), 0)  # no errors
+
+        # Check if we added TER statements correctly
+        n_ter = len([r for r in self.stdout if r.startswith('TER')])
+        self.assertEqual(n_ter, 4)
+
+        # Check no CONECT in output
+        c_conect = sum(1 for i in self.stdout if i.startswith('CONECT'))
+        self.assertEqual(c_conect, 0)
+
+        # Check if we added END statements correctly
+        self.assertTrue(self.stdout[-1].startswith('END'))
+
     def test_file_not_found(self):
         """$ pdb_tidy not_existing.pdb"""
 
@@ -117,7 +143,7 @@ class TestTool(unittest.TestCase):
         self.assertEqual(self.retcode, 1)
         self.assertEqual(len(self.stdout), 0)
         self.assertEqual(self.stderr[0][:36],
-                         "ERROR!! Script takes 1 argument, not")
+                         "ERROR! First argument is not a valid")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Partially addresses the points raised in #70 by adding a `-strict` option to `pdb_tidy` that prevents the tool from adding TER records on chain breaks. The default behavior is to add TERs on chain breaks, is this OK @amjjbonvin ?