### PR TITLE
Adds tool pdb_chainbows to sequentially assign chain identifiers

### DIFF
--- a/pdbtools/pdb_chainbows.py
+++ b/pdbtools/pdb_chainbows.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 João Pedro Rodrigues
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Renames chain identifiers sequentially, based on TER records.
+
+Since HETATM records are not separated by TER records and usually come together
+at the end of the PDB file, this script will erroneously reassign their chain
+identifiers. It is a format limitation. You have been warned!
+
+Usage:
+    python pdb_chainbows.py <pdb file>
+
+Example:
+    python pdb_chainbows.py 1CTF.pdb
+
+This program is part of the `pdb-tools` suite of utilities and should not be
+distributed isolatedly. The `pdb-tools` were created to quickly manipulate PDB
+files using the terminal, and can be used sequentially, with one tool streaming
+data to another. They are based on old FORTRAN77 code that was taking too much
+effort to maintain and compile. RIP.
+"""
+
+import os
+import string
+import sys
+
+__author__ = "Joao Rodrigues"
+__email__ = "j.p.g.l.m.rodrigues@gmail.com"
+
+
+def check_input(args):
+    """Checks whether to read from stdin/file and validates user input/options.
+    """
+
+    # Defaults
+    fh = sys.stdin  # file handle
+
+    if not len(args):
+        # Reading from pipe with default option
+        if sys.stdin.isatty():
+            sys.stderr.write(__doc__)
+            sys.exit(1)
+
+    elif len(args) == 1:
+        if not os.path.isfile(args[0]):
+            emsg = 'ERROR!! File not found or not readable: \'{}\'\n'
+            sys.stderr.write(emsg.format(args[0]))
+            sys.stderr.write(__doc__)
+            sys.exit(1)
+
+        fh = open(args[0], 'r')
+
+    else:  # Whatever ...
+        emsg = 'ERROR!! Script takes 1 argument, not \'{}\'\n'
+        sys.stderr.write(emsg.format(len(args)))
+        sys.stderr.write(__doc__)
+        sys.exit(1)
+
+    return fh
+
+
+def set_chain_sequence(fhandle):
+    """Sets chains sequentially based on existing TER records."""
+
+    chainlist = list(string.ascii_uppercase) + list(string.ascii_lowercase) + \
+        list(range(0, 10))
+    max_chains = len(chainlist)
+
+    issued_warning = False
+
+    curchain = chainlist.pop(0)
+    records = ('ATOM', 'TER', 'ANISOU')
+    for line in fhandle:
+        if line.startswith(records):
+            line = line[:21] + curchain + line[22:]
+
+            if line.startswith('TER'):
+                try:
+                    curchain = chainlist.pop(0)
+                except IndexError:
+                    emsg = 'ERROR!! Structure contains more than {} TER records.\n'
+                    sys.stderr.write(emsg.format(max_chains))
+                    sys.stderr.write(__doc__)
+                    sys.exit(1)
+
+        elif line.startswith('HETATM') and not issued_warning:
+            emsg = 'WARNING!! HETATM will not be reassigned. See documentation.\n'
+            sys.stderr.write(emsg)
+            issued_warning = True
+
+        yield line
+
+
+def main():
+    # Check Input
+    pdbfh = check_input(sys.argv[1:])
+
+    # Do the job
+    new_pdb = set_chain_sequence(pdbfh)
+
+    try:
+        _buffer = []
+        _buffer_size = 5000  # write N lines at a time
+        for lineno, line in enumerate(new_pdb):
+            if not (lineno % _buffer_size):
+                sys.stdout.write(''.join(_buffer))
+                _buffer = []
+            _buffer.append(line)
+
+        sys.stdout.write(''.join(_buffer))
+        sys.stdout.flush()
+    except IOError:
+        # This is here to catch Broken Pipes
+        # for example to use 'head' or 'tail' without
+        # the error message showing up
+        pass
+
+    # last line of the script
+    # We can close it even if it is sys.stdin
+    pdbfh.close()
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_pdb_chainbows.py
+++ b/tests/test_pdb_chainbows.py
@@ -66,6 +66,7 @@ class TestTool(unittest.TestCase):
         self.assertEqual(self.retcode, 0)  # ensure the program exited OK.
         # CONECTs are ignored by issue #72, expected only 204 lines
         self.assertEqual(len(self.stdout), 204)
+        self.assertEqual(len(self.stderr), 0)  # no warnings/errors
 
         # Check chains were reassigned properly
         expected = ['A'] * 51 + ['B'] * 56 + ['C'] * 49 + ['D'] * 20
@@ -81,10 +82,8 @@ class TestTool(unittest.TestCase):
         ]
         self.assertEqual(chains, expected)
 
-        # Check HETATM were ignored and warning was issued
-        self.assertEqual(len(self.stderr), 1)  # one warning message
-        self.assertEqual(self.stderr[0][:40], 'WARNING!! HETATM will not be reassigned.')
-        expected = ['A', 'A', 'A', 'B', 'C', 'C', 'C', 'C', 'C']
+        # Check HETATM were reassigned properly
+        expected = ['B', 'B', 'B', 'A', 'C', 'C', 'C', 'C', 'C']
         chains = [
             l[21] for l in self.stdout if l.startswith('HETATM')
         ]

--- a/tests/test_pdb_chainbows.py
+++ b/tests/test_pdb_chainbows.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 João Pedro Rodrigues
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit Tests for `pdb_chainbows`.
+"""
+
+import os
+import sys
+import unittest
+
+from config import data_dir
+from utils import OutputCapture
+
+
+class TestTool(unittest.TestCase):
+    """
+    Generic class for testing tools.
+    """
+
+    def setUp(self):
+        # Dynamically import the module
+        name = 'pdbtools.pdb_chainbows'
+        self.module = __import__(name, fromlist=[''])
+
+    def exec_module(self):
+        """
+        Execs module.
+        """
+
+        with OutputCapture() as output:
+            try:
+                self.module.main()
+            except SystemExit as e:
+                self.retcode = e.code
+
+        self.stdout = output.stdout
+        self.stderr = output.stderr
+
+        return
+
+    def test_default(self):
+        """$ pdb_chainbows data/dummy.pdb"""
+
+        fpath = os.path.join(data_dir, 'dummy.pdb')
+        sys.argv = ['', fpath]
+
+        # Execute the script
+        self.exec_module()
+
+        # Validate results
+        self.assertEqual(self.retcode, 0)  # ensure the program exited OK.
+        # CONECTs are ignored by issue #72, expected only 204 lines
+        self.assertEqual(len(self.stdout), 204)
+
+        # Check chains were reassigned properly
+        expected = ['A'] * 51 + ['B'] * 56 + ['C'] * 49 + ['D'] * 20
+        chains = [
+            l[21] for l in self.stdout if l.startswith('ATOM')
+        ]
+        self.assertEqual(chains, expected)
+
+        # Check TERs
+        expected = ['A', 'B', 'C']
+        chains = [
+            l[21] for l in self.stdout if l.startswith('TER')
+        ]
+        self.assertEqual(chains, expected)
+
+        # Check HETATM were ignored and warning was issued
+        self.assertEqual(len(self.stderr), 1)  # one warning message
+        self.assertEqual(self.stderr[0][:40], 'WARNING!! HETATM will not be reassigned.')
+        expected = ['A', 'A', 'A', 'B', 'C', 'C', 'C', 'C', 'C']
+        chains = [
+            l[21] for l in self.stdout if l.startswith('HETATM')
+        ]
+        self.assertEqual(chains, expected)
+
+    def test_file_not_found(self):
+        """$ pdb_chainbows not_existing.pdb"""
+
+        # Error (file not found)
+        afile = os.path.join(data_dir, 'not_existing.pdb')
+        sys.argv = ['', afile]
+
+        # Execute the script
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)
+        self.assertEqual(self.stderr[0][:22],
+                         "ERROR!! File not found")
+
+    def test_helptext(self):
+        """$ pdb_chainbows"""
+
+        sys.argv = ['']
+
+        # Execute the script
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)
+        self.assertEqual(self.stderr, self.module.__doc__.split("\n")[:-1])
+
+    def test_invalid_option(self):
+        """$ pdb_chainbows -A data/dummy.pdb"""
+
+        sys.argv = ['', '-A', os.path.join(data_dir, 'dummy.pdb')]
+
+        # Execute the script
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)
+        self.assertEqual(self.stderr[0][:36],
+                         "ERROR!! Script takes 1 argument, not")
+
+
+if __name__ == '__main__':
+    from config import test_dir
+
+    mpath = os.path.abspath(os.path.join(test_dir, '..'))
+    sys.path.insert(0, mpath)  # so we load dev files before  any installation
+
+    unittest.main()


### PR DESCRIPTION
Tool adds chain identifiers sequentially (ABC..abc...012..) based on existing TER records in the file. Addresses the second part of #70.