### PR TITLE
Fix pdb_selres on piped input files

### DIFF
--- a/pdbtools/pdb_selres.py
+++ b/pdbtools/pdb_selres.py
@@ -41,6 +41,7 @@ data to another. They are based on old FORTRAN77 code that was taking too much
 effort to maintain and compile. RIP.
 """
 
+from itertools import chain as iter_chain
 import os
 import sys
 
@@ -122,7 +123,7 @@ def check_input(args):
 
     # Defaults
     option = '::'
-    fh = sys.stdin  # file handle
+    fh = sys.stdin.buffer  # file handle
 
     if not len(args):
         # Reading from pipe with default option
@@ -171,17 +172,28 @@ def check_input(args):
         sys.exit(1)
 
     # Read file handle to extract residue numbers
+    # Because sys.stdin is not seekable we store the
+    # lines again in an iterator.
+    buffer = iter([])
     resid_list = []
+        
     records = ('ATOM', 'HETATM', 'TER', 'ANISOU')
     prev_res = None
     for line in fh:
+        line = line.decode('utf-8')
         if line.startswith(records):
             res_id = line[21:26]  # include chain ID
             if res_id != prev_res:
                 prev_res = res_id
                 resid_list.append(int(line[22:26]))
+        buffer = iter_chain(buffer, [line])
 
-    fh.seek(0)  # rewind
+    try:
+        fh.close()  # in case we opened a file. Just to be clean.
+    except AttributeError:
+        pass
+
+    fh = buffer
 
     residue_range = set()  # stores all the residues to write.
     for entry in option.split(','):
@@ -239,8 +251,8 @@ def main():
         pass
 
     # last line of the script
-    # We can close it even if it is sys.stdin
-    pdbfh.close()
+    # No need to close the file handle since we
+    # build an iterator in the check_input functions
     sys.exit(0)
 
 

--- a/pdbtools/pdb_selres.py
+++ b/pdbtools/pdb_selres.py
@@ -148,7 +148,7 @@ def check_input(args):
                 sys.stderr.write(__doc__)
                 sys.exit(1)
 
-            fh = open(args[0], 'r')
+            fh = open(args[0], 'rb')
 
     elif len(args) == 2:
         # Two options: option & File
@@ -165,7 +165,7 @@ def check_input(args):
             sys.exit(1)
 
         option = args[0][1:]
-        fh = open(args[1], 'r')
+        fh = open(args[1], 'rb')
 
     else:  # Whatever ...
         sys.stderr.write(__doc__)

--- a/pdbtools/pdb_selres.py
+++ b/pdbtools/pdb_selres.py
@@ -176,7 +176,7 @@ def check_input(args):
     # lines again in an iterator.
     buffer = iter([])
     resid_list = []
-        
+
     records = ('ATOM', 'HETATM', 'TER', 'ANISOU')
     prev_res = None
     for line in fh:

--- a/pdbtools/pdb_selres.py
+++ b/pdbtools/pdb_selres.py
@@ -123,7 +123,7 @@ def check_input(args):
 
     # Defaults
     option = '::'
-    fh = sys.stdin.buffer  # file handle
+    fh = sys.stdin  # file handle
 
     if not len(args):
         # Reading from pipe with default option
@@ -180,7 +180,7 @@ def check_input(args):
     records = ('ATOM', 'HETATM', 'TER', 'ANISOU')
     prev_res = None
     for line in fh:
-        line = line.decode('utf-8')
+        line = line
         if line.startswith(records):
             res_id = line[21:26]  # include chain ID
             if res_id != prev_res:

--- a/pdbtools/pdb_selres.py
+++ b/pdbtools/pdb_selres.py
@@ -180,7 +180,6 @@ def check_input(args):
     records = ('ATOM', 'HETATM', 'TER', 'ANISOU')
     prev_res = None
     for line in fh:
-        line = line
         if line.startswith(records):
             res_id = line[21:26]  # include chain ID
             if res_id != prev_res:

--- a/pdbtools/pdb_selres.py
+++ b/pdbtools/pdb_selres.py
@@ -148,7 +148,7 @@ def check_input(args):
                 sys.stderr.write(__doc__)
                 sys.exit(1)
 
-            fh = open(args[0], 'rb')
+            fh = open(args[0], 'r')
 
     elif len(args) == 2:
         # Two options: option & File
@@ -165,7 +165,7 @@ def check_input(args):
             sys.exit(1)
 
         option = args[0][1:]
-        fh = open(args[1], 'rb')
+        fh = open(args[1], 'r')
 
     else:  # Whatever ...
         sys.stderr.write(__doc__)


### PR DESCRIPTION
Python's `sys.stdin` is not seekable apparently, so we cannot rewind the contents of the data after reading once. Running the script now one something like `pdb_fetch 1ctf | pdb_selres -80:` will not return anything because the file is exhausted and the seek doesn't throw and error (at least on Windows). This PR fixes this by populating an iterator as we read the file the first time. Same low-memory behavior, slightly slower.