### PR TITLE
treatment of MASTER lines

### DIFF
--- a/pdbtools/pdb_keepcoord.py
+++ b/pdbtools/pdb_keepcoord.py
@@ -18,7 +18,7 @@
 """
 Removes all non-coordinate records from the file.
 
-Keeps only MODEL, ENDMDL, END, ATOM, HETATM, CONECT, and MASTER.
+Keeps only MODEL, ENDMDL, END, ATOM, HETATM, CONECT.
 
 Usage:
     python pdb_keepcoord.py <pdb file>
@@ -77,7 +77,7 @@ def keep_coordinates(fhandle):
 
     records = ('MODEL ', 'ATOM  ', 'HETATM',
                'ENDMDL', 'END   ',
-               'TER   ', 'CONECT', 'MASTER')
+               'TER   ', 'CONECT')
     for line in fhandle:
         if line.startswith(records):
             yield line

--- a/pdbtools/pdb_keepcoord.py
+++ b/pdbtools/pdb_keepcoord.py
@@ -18,7 +18,7 @@
 """
 Removes all non-coordinate records from the file.
 
-Keeps only MODEL, ENDMDL, END, ATOM, HETATM, and CONECT.
+Keeps only MODEL, ENDMDL, END, ATOM, HETATM, CONECT, and MASTER.
 
 Usage:
     python pdb_keepcoord.py <pdb file>

--- a/pdbtools/pdb_tidy.py
+++ b/pdbtools/pdb_tidy.py
@@ -131,7 +131,7 @@ def tidy_pdbfile(fhandle, strict=False):
     fmt_TER = "TER   {:>5d}      {:3s} {:1s}{:>4s}{:1s}" + " " * 53 + "\n"
 
     records = ('ATOM', 'HETATM')
-    ignored = ('TER', 'END ', 'END\n', 'CONECT')
+    ignored = ('TER', 'END ', 'END\n', 'CONECT', 'MASTER')
     # Iterate up to the first ATOM/HETATM line
     prev_line = None
     for line in fhandle:

--- a/tests/test_pdb_tidy.py
+++ b/tests/test_pdb_tidy.py
@@ -89,6 +89,18 @@ class TestTool(unittest.TestCase):
         # Check if we added END statements correctly
         self.assertTrue(self.stdout[-1].startswith('END'))
 
+    def test_tidy_removes_master(self):
+        """Test pdb_tidy removes MASTER lines as well."""
+        sys.argv = ['']
+        self.exec_module(
+            'MASTER      378    0    9    5    3    '
+            '0   29    6  847    1   76    7'
+            )
+
+        # Check no MASTER in output
+        m_master = sum(1 for i in self.stdout if i.startswith('MASTER'))
+        self.assertEqual(m_master, 0)
+
     def test_default_stdin(self):
         """$ cat data/dummy.pdb | pdb_tidy"""
 


### PR DESCRIPTION
Hi,

Sorry for not raising an issue for this, I thought going straight to a PR, in case you agree, it can be merged directly without further discussion.

I wanted to get the backbone of a specific PDB file.

```
pdb_fetch 5d8v | pdb_keepcoord | pdb_selatom -CA,C,N,O | pdb_delresname -HOH | pdb_selaltloc -A | pdb_reatom -1 | pdb_tidy > 5d8vBB.pdb
```

This gives a very clean file except for the `MASTER` line at the end:

```
ATOM    331  C   GLY A  83       5.965  20.737   8.504  0.55  4.29           C  
ATOM    332  O   GLY A  83       7.215  20.811   8.519  0.55  4.32           O  
TER     333      GLY A  83                                                      
MASTER      378    0    9    5    3    0   29    6  847    1   76    7          
END   
```                      

Yet, I believe after so many modifications, the `MASTER` line is a bit meaningless there. I thought the same way `pdb_tidy` is removing `CONECT` lines, as discussed in #72, it maybe should remove `MASTER` as well.

What do you think? If you agree, this PR already provides the modifications and some tests.

Also, I added the `MASTER` to the docstring of `pdb_keepcoords`, because it was keeping the `MASTER` without telling that to the user. 