### PR TITLE
Adding option for subcommands

### DIFF
--- a/pdbtools/cli.py
+++ b/pdbtools/cli.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 João Pedro Rodrigues
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Main client to organize pdb-tools as subcommands.
+
+Usage:
+    pdbtools <TOOL> <OPTION>
+
+Example:
+    pdbtools fetch 12as
+    pdbtools fetch 12as | pdbtools selchain -B > 12AS_B.pdb
+"""
+import importlib
+import os
+import sys
+from pathlib import Path
+
+
+def exit_with_error(options):
+    """Exit run with error."""
+    list_scripts = "* " + "\n* ".join(options) + "\n"
+    fmt = (
+        "# Welcome to pdb-tools\n"
+        "# List of available scripts: \n {}"
+        "List of avaiable tools above."
+        )
+    print(fmt.format(list_scripts))
+    sys.exit()
+
+
+def main():
+    """Client for subcommands."""
+    pdbtools_folder = Path(__file__).parent
+    pdbtools_scripts = sorted(pdbtools_folder.glob('pdb_*.py'))
+    options = [f.stem.split('_')[1] for f in pdbtools_scripts]
+
+    if len(sys.argv) == 1:
+        exit_with_error(options)
+
+    execs = {
+        name: importlib.import_module('pdbtools.' + os.fspath(module.stem)).main
+        for name, module in zip(options, pdbtools_scripts)
+        }
+
+    sys.argv.pop(0)
+    subcommand = sys.argv[0]
+    try:
+        execs[subcommand]()
+    except KeyError:
+        exit_with_error(options)
+    return
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ See:
 https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
-
+import sys
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
 from os import listdir, path
@@ -36,12 +36,16 @@ cli_choices = {
     's': subcommands,
     }
 
-cli_choice = None
-while cli_choice not in ('i', 's'):
-    _ = input('Install [I]ndependent scripts or [S]ubcommands? ')
-    cli_choice = _.lower()
+if 'test' in sys.argv:
+    exec_cli = bin_py
 
-exec_cli = cli_choices[cli_choice]
+else:
+    cli_choice = None
+    while cli_choice not in ('i', 's'):
+        _ = input('Install [I]ndependent scripts or [S]ubcommands? ')
+        cli_choice = _.lower()
+
+    exec_cli = cli_choices[cli_choice]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,26 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 # Collect names of bin/*py scripts
 # e.g. 'pdb_intersect=bin.pdb_intersect:main',
 binfiles = listdir(path.join(here, 'pdbtools'))
-bin_py = [f[:-3] + '=pdbtools.' + f[:-3] + ':main' for f in binfiles
-          if f.endswith('.py')]
+bin_py = [
+    f[:-3] + '=pdbtools.' + f[:-3] + ':main'
+    for f in binfiles
+    if f.endswith('.py')
+    ]
+
+subcommands = 'pdbtools = pdbtools.cli:main'
+
+cli_choices = {
+    'i': bin_py,
+    's': subcommands,
+    }
+
+cli_choice = None
+while cli_choice not in ('i', 's'):
+    _ = input('Install [I]ndependent scripts or [S]ubcommands? ')
+    cli_choice = _.lower()
+
+exec_cli = cli_choices[cli_choice]
+
 
 setup(
     name='pdb-tools',  # Required
@@ -84,7 +102,7 @@ setup(
     # For example, the following would provide a command called `sample` which
     # executes the function `main` from this package when invoked:
     entry_points={  # Optional
-        'console_scripts': bin_py,
+        'console_scripts': exec_cli,
     },
 
     # scripts=[path.join('bin', f) for f in listdir(path.join(here, 'bin'))],


### PR DESCRIPTION
Following the discussion on #102 ,

I implemented an option to allow the user to decide whether to install `pdb-tools` using subcommands as `CLI`s or the traditional one-tool one command option.

When installing the user is prompt with this question:

```
Install [I]ndependent scripts or [S]ubcommands?
```

`Independent` gives the usual behaviour.
`Subcommands` gives the behaviour suggested in #102.

```
pdbtools fetch 12as | pdbtools selchain -B
```

Writing only `pdbtools` gives a kind-off help message. (this can be improved)

**Note** the proposed implementation uses only `sys`, `os`, and `pathlib`. I think we are okay with `pathlib` because we don't need to grant compatibility with py27 for this.

The current implementation already works. But let us discuss a bit more before merging this.

Cheers.