### PR TITLE
Adjust fhandle names to files and iterables.

### DIFF
--- a/pdbtools/__init__.py
+++ b/pdbtools/__init__.py
@@ -71,7 +71,6 @@ All MODULEs and `run` functions provide comprehensive documentation.
 >>> help(MODULE)
 >>> help(MODULE.run)
 """
-import os
 
 
 __all__ = [

--- a/pdbtools/__init__.py
+++ b/pdbtools/__init__.py
@@ -123,19 +123,3 @@ __all__ = [
     'pdb_validate',
     'pdb_wc',
     ]
-
-
-def get_fname(fhandle, output=None):
-
-    if output:
-        return os.path.basename(output)
-
-    else:
-        try:
-            fn = fhandle.name
-            fname_root = fn[:-4] if fn != '<stdin>' else 'output'
-        except AttributeError:
-            print('got attribute error')
-            fname_root = 'output'
-
-        return os.path.basename(fname_root)

--- a/pdbtools/__init__.py
+++ b/pdbtools/__init__.py
@@ -71,6 +71,8 @@ All MODULEs and `run` functions provide comprehensive documentation.
 >>> help(MODULE)
 >>> help(MODULE.run)
 """
+import os
+
 
 __all__ = [
     'pdb_b',
@@ -121,3 +123,19 @@ __all__ = [
     'pdb_validate',
     'pdb_wc',
     ]
+
+
+def get_fname(fhandle, output=None):
+
+    if output:
+        return os.path.basename(output)
+
+    else:
+        try:
+            fn = fhandle.name
+            fname_root = fn[:-4] if fn != '<stdin>' else 'output'
+        except AttributeError:
+            print('got attribute error')
+            fname_root = 'output'
+
+        return os.path.basename(fname_root)

--- a/pdbtools/pdb_splitchain.py
+++ b/pdbtools/pdb_splitchain.py
@@ -84,7 +84,9 @@ def run(fhandle, outname=None):
     fhandle : an iterable giving the PDB file line-by-line
 
     outname : str
-        The base name of the output files.
+        The base name of the output files. If None is given, tries to
+        extract a name from the `.name` attribute of `fhandler`. If
+        `fhandler` has no attribute name, assigns `splitchains`.
     """
     _defname = 'splitchains'
     if outname is None:

--- a/pdbtools/pdb_splitchain.py
+++ b/pdbtools/pdb_splitchain.py
@@ -34,8 +34,6 @@ effort to maintain and compile. RIP.
 import os
 import sys
 
-from pdbtools import get_fname
-
 
 __author__ = "Joao Rodrigues"
 __email__ = "j.p.g.l.m.rodrigues@gmail.com"
@@ -88,7 +86,15 @@ def run(fhandle, outname=None):
     outname : str
         The base name of the output files.
     """
-    basename = get_fname(fhandle, outname)
+    _defname = 'splitchains'
+    if outname is None:
+        try:
+            fn = fhandle.name
+            outname = fn[:-4] if fn != '<stdin>' else _defname
+        except AttributeError:
+            outname = _defname
+
+    basename = os.path.basename(outname)
 
     chain_data = {}  # {chain_id: lines}
 

--- a/pdbtools/pdb_splitchain.py
+++ b/pdbtools/pdb_splitchain.py
@@ -34,6 +34,9 @@ effort to maintain and compile. RIP.
 import os
 import sys
 
+from pdbtools import get_fname
+
+
 __author__ = "Joao Rodrigues"
 __email__ = "j.p.g.l.m.rodrigues@gmail.com"
 
@@ -71,7 +74,7 @@ def check_input(args):
     return fh
 
 
-def run(fhandle):
+def run(fhandle, outname=None):
     """
     Split the PDB into its different chains.
 
@@ -81,9 +84,11 @@ def run(fhandle):
     Parameters
     ----------
     fhandle : an iterable giving the PDB file line-by-line
+
+    outname : str
+        The base name of the output files.
     """
-    fname_root = fhandle.name[:-4] if fhandle.name != '<stdin>' else 'output'
-    basename = os.path.basename(fname_root)
+    basename = get_fname(fhandle, outname)
 
     chain_data = {}  # {chain_id: lines}
 

--- a/pdbtools/pdb_splitmodel.py
+++ b/pdbtools/pdb_splitmodel.py
@@ -34,8 +34,6 @@ effort to maintain and compile. RIP.
 import os
 import sys
 
-from pdbtools import get_fname
-
 
 __author__ = "Joao Rodrigues"
 __email__ = "j.p.g.l.m.rodrigues@gmail.com"
@@ -88,7 +86,15 @@ def run(fhandle, outname=None):
     outname : str
         The base name of the output files.
     """
-    basename = get_fname(fhandle, outname)
+    _defname = 'splitmodels'
+    if outname is None:
+        try:
+            fn = fhandle.name
+            outname = fn[:-4] if fn != '<stdin>' else _defname
+        except AttributeError:
+            outname = _defname
+
+    basename = os.path.basename(outname)
 
     model_lines = []
     records = ('ATOM', 'HETATM', 'ANISOU', 'TER')

--- a/pdbtools/pdb_splitmodel.py
+++ b/pdbtools/pdb_splitmodel.py
@@ -84,7 +84,9 @@ def run(fhandle, outname=None):
     fhandle : a line-by-line iterator of the original PDB file.
 
     outname : str
-        The base name of the output files.
+        The base name of the output files. If None is given, tries to
+        extract a name from the `.name` attribute of `fhandler`. If
+        `fhandler` has no attribute name, assigns `splitmodels`.
     """
     _defname = 'splitmodels'
     if outname is None:

--- a/pdbtools/pdb_splitmodel.py
+++ b/pdbtools/pdb_splitmodel.py
@@ -34,6 +34,9 @@ effort to maintain and compile. RIP.
 import os
 import sys
 
+from pdbtools import get_fname
+
+
 __author__ = "Joao Rodrigues"
 __email__ = "j.p.g.l.m.rodrigues@gmail.com"
 
@@ -71,7 +74,7 @@ def check_input(args):
     return fh
 
 
-def run(fhandle):
+def run(fhandle, outname=None):
     """
     Split PDB into MODELS.
 
@@ -81,9 +84,11 @@ def run(fhandle):
     Parameters
     ----------
     fhandle : a line-by-line iterator of the original PDB file.
+
+    outname : str
+        The base name of the output files.
     """
-    fname_root = fhandle.name[:-4] if fhandle.name != '<stdin>' else 'pdbfile'
-    basename = os.path.basename(fname_root)
+    basename = get_fname(fhandle, outname)
 
     model_lines = []
     records = ('ATOM', 'HETATM', 'ANISOU', 'TER')

--- a/pdbtools/pdb_splitseg.py
+++ b/pdbtools/pdb_splitseg.py
@@ -34,8 +34,6 @@ effort to maintain and compile. RIP.
 import os
 import sys
 
-from pdbtools import get_fname
-
 
 __author__ = "Joao Rodrigues"
 __email__ = "j.p.g.l.m.rodrigues@gmail.com"
@@ -88,7 +86,15 @@ def run(fhandle, outname=None):
     outname : str
         The base name of the output files.
     """
-    basename = get_fname(fhandle, outname)
+    _defname = 'splitsegs'
+    if outname is None:
+        try:
+            fn = fhandle.name
+            outname = fn[:-4] if fn != '<stdin>' else _defname
+        except AttributeError:
+            outname = _defname
+
+    basename = os.path.basename(outname)
 
     segment_data = {}  # {segment_id: lines}
 

--- a/pdbtools/pdb_splitseg.py
+++ b/pdbtools/pdb_splitseg.py
@@ -84,7 +84,9 @@ def run(fhandle, outname=None):
     fhandle : a line-by-line iterator of the original PDB file.
 
     outname : str
-        The base name of the output files.
+        The base name of the output files. If None is given, tries to
+        extract a name from the `.name` attribute of `fhandler`. If
+        `fhandler` has no attribute name, assigns `splitsegs`.
     """
     _defname = 'splitsegs'
     if outname is None:

--- a/pdbtools/pdb_splitseg.py
+++ b/pdbtools/pdb_splitseg.py
@@ -34,6 +34,9 @@ effort to maintain and compile. RIP.
 import os
 import sys
 
+from pdbtools import get_fname
+
+
 __author__ = "Joao Rodrigues"
 __email__ = "j.p.g.l.m.rodrigues@gmail.com"
 
@@ -71,7 +74,7 @@ def check_input(args):
     return fh
 
 
-def run(fhandle):
+def run(fhandle, outname=None):
     """
     Split PDB into segments.
 
@@ -81,9 +84,11 @@ def run(fhandle):
     Parameters
     ----------
     fhandle : a line-by-line iterator of the original PDB file.
+
+    outname : str
+        The base name of the output files.
     """
-    fname_root = fhandle.name[:-4] if fhandle.name != '<stdin>' else 'output'
-    basename = os.path.basename(fname_root)
+    basename = get_fname(fhandle, outname)
 
     segment_data = {}  # {segment_id: lines}
 

--- a/pdbtools/pdb_tocif.py
+++ b/pdbtools/pdb_tocif.py
@@ -83,7 +83,7 @@ def pad_line(line):
     return line[:81]  # 80 + newline character
 
 
-def run(fhandle):
+def run(fhandle, outname=None):
     """
     Convert a structure in PDB format to mmCIF format.
 
@@ -109,8 +109,8 @@ def run(fhandle):
     yield '#\n'
 
     # Headers
-    fhandle_name = get_fname(fhandle)
-    fname, _ = os.path.splitext(get_fname(fhandle))
+    fhandle_name = get_fname(fhandle, outname)
+    fname, _ = os.path.splitext(fhandle_name)
     if fname == '<stdin>':
         fname = 'cell'
     yield 'data_{}\n'.format(fname)

--- a/pdbtools/pdb_tocif.py
+++ b/pdbtools/pdb_tocif.py
@@ -36,8 +36,6 @@ effort to maintain and compile. RIP.
 import os
 import sys
 
-from pdbtools import get_fname
-
 
 __author__ = "Joao Rodrigues"
 __email__ = "j.p.g.l.m.rodrigues@gmail.com"
@@ -109,11 +107,17 @@ def run(fhandle, outname=None):
     yield '#\n'
 
     # Headers
-    fhandle_name = get_fname(fhandle, outname)
-    fname, _ = os.path.splitext(fhandle_name)
-    if fname == '<stdin>':
-        fname = 'cell'
-    yield 'data_{}\n'.format(fname)
+    _defname = 'cell'
+    if outname is None:
+        try:
+            fn = fhandle.name
+            outname = fn[:-4] if fn != '<stdin>' else _defname
+        except AttributeError:
+            outname = _defname
+
+    fname_root = os.path.basename(outname)
+
+    yield 'data_{}\n'.format(fname_root)
 
     yield '#\n'
     yield 'loop_\n'

--- a/pdbtools/pdb_tocif.py
+++ b/pdbtools/pdb_tocif.py
@@ -36,6 +36,9 @@ effort to maintain and compile. RIP.
 import os
 import sys
 
+from pdbtools import get_fname
+
+
 __author__ = "Joao Rodrigues"
 __email__ = "j.p.g.l.m.rodrigues@gmail.com"
 
@@ -106,7 +109,8 @@ def run(fhandle):
     yield '#\n'
 
     # Headers
-    fname, _ = os.path.splitext(os.path.basename(fhandle.name))
+    fhandle_name = get_fname(fhandle)
+    fname, _ = os.path.splitext(get_fname(fhandle))
     if fname == '<stdin>':
         fname = 'cell'
     yield 'data_{}\n'.format(fname)

--- a/pdbtools/pdb_tocif.py
+++ b/pdbtools/pdb_tocif.py
@@ -91,6 +91,11 @@ def run(fhandle, outname=None):
     ----------
     fhandle : an iterable giving the PDB file line-by-line.
 
+    outname : str
+        The base name of the output files. If None is given, tries to
+        extract a name from the `.name` attribute of `fhandler`. If
+        `fhandler` has no attribute name, assigns `cell`.
+
     Yields
     ------
     str (line-by-line)

--- a/tests/test_pdb_splitchain.py
+++ b/tests/test_pdb_splitchain.py
@@ -138,7 +138,11 @@ class TestTool(unittest.TestCase):
         pdb_splitchain.run(lines)
 
         # Read files created by script and then delete
-        ofiles = [f for f in os.listdir(self.tempdir) if f.startswith('output')]
+        ofiles = [
+            f
+            for f in os.listdir(self.tempdir)
+            if f.startswith('splitchains')
+            ]
         self.assertEqual(len(ofiles), 4)  # 4 chains
 
         # Make sure each file has the chain it should have

--- a/tests/test_pdb_splitchain.py
+++ b/tests/test_pdb_splitchain.py
@@ -61,6 +61,7 @@ class TestTool(unittest.TestCase):
 
         return
 
+
     def test_default(self):
         """$ pdb_splitchain data/dummy.pdb"""
 
@@ -89,6 +90,87 @@ class TestTool(unittest.TestCase):
         for fpath in ofiles:
             if fpath == 'dummy.pdb':
                 continue
+
+            with open(os.path.join(self.tempdir, fpath), 'r') as handle:
+                fname_chain = fpath.split('_')[1][:-4]  # xxx_(X).pdb
+                pdb_chains = [l[21] for l in handle if l.startswith(records)]
+
+                self.assertEqual(fname_chain, list(set(pdb_chains))[0])
+
+    def test_run_fhandler(self):
+        """pdb_splitchain.run(fhandler)"""
+        from pdbtools import pdb_splitchain
+
+        src = os.path.join(data_dir, 'dummy.pdb')
+        dst = os.path.join(self.tempdir, 'dummy.pdb')
+        shutil.copy(src, dst)
+
+        with open(dst, 'r') as fin:
+            pdb_splitchain.run(fin)
+
+        # Read files created by script and then delete
+        ofiles = [f for f in os.listdir(self.tempdir) if f.startswith('dummy')]
+        self.assertEqual(len(ofiles), 4 + 1)  # ori + 4 chains
+
+        # Make sure each file has the chain it should have
+        records = (('ATOM', 'HETATM', 'TER', 'ANISOU'))
+        for fpath in ofiles:
+            if fpath == 'dummy.pdb':
+                continue
+
+            with open(os.path.join(self.tempdir, fpath), 'r') as handle:
+                fname_chain = fpath.split('_')[1][:-4]  # xxx_(X).pdb
+                pdb_chains = [l[21] for l in handle if l.startswith(records)]
+
+                self.assertEqual(fname_chain, list(set(pdb_chains))[0])
+
+    def test_run_iterable(self):
+        """pdb_splitchain.run(iterable)"""
+        from pdbtools import pdb_splitchain
+
+        src = os.path.join(data_dir, 'dummy.pdb')
+        dst = os.path.join(self.tempdir, 'dummy.pdb')
+        shutil.copy(src, dst)
+
+        with open(dst, 'r') as fin:
+            lines = fin.readlines()
+
+        pdb_splitchain.run(lines)
+
+        # Read files created by script and then delete
+        ofiles = [f for f in os.listdir(self.tempdir) if f.startswith('output')]
+        self.assertEqual(len(ofiles), 4)  # 4 chains
+
+        # Make sure each file has the chain it should have
+        records = (('ATOM', 'HETATM', 'TER', 'ANISOU'))
+        for fpath in ofiles:
+
+            with open(os.path.join(self.tempdir, fpath), 'r') as handle:
+                fname_chain = fpath.split('_')[1][:-4]  # xxx_(X).pdb
+                pdb_chains = [l[21] for l in handle if l.startswith(records)]
+
+                self.assertEqual(fname_chain, list(set(pdb_chains))[0])
+
+    def test_run_iterable_with_name(self):
+        """pdb_splitchain.run(iterable)"""
+        from pdbtools import pdb_splitchain
+
+        src = os.path.join(data_dir, 'dummy.pdb')
+        dst = os.path.join(self.tempdir, 'dummy.pdb')
+        shutil.copy(src, dst)
+
+        with open(dst, 'r') as fin:
+            lines = fin.readlines()
+
+        pdb_splitchain.run(lines, outname='newname')
+
+        # Read files created by script and then delete
+        ofiles = [f for f in os.listdir(self.tempdir) if f.startswith('newname')]
+        self.assertEqual(len(ofiles), 4)  # 4 chains
+
+        # Make sure each file has the chain it should have
+        records = (('ATOM', 'HETATM', 'TER', 'ANISOU'))
+        for fpath in ofiles:
 
             with open(os.path.join(self.tempdir, fpath), 'r') as handle:
                 fname_chain = fpath.split('_')[1][:-4]  # xxx_(X).pdb

--- a/tests/test_pdb_splitmodel.py
+++ b/tests/test_pdb_splitmodel.py
@@ -93,6 +93,88 @@ class TestTool(unittest.TestCase):
                 n_lines = len(handle.readlines())
                 self.assertEqual(n_lines, 2)
 
+    def test_run_iterable(self):
+        """pdb_splitmodel.run(iterable)"""
+        from pdbtools import pdb_splitmodel
+
+        # Copy input file to tempdir
+
+        # Simulate input
+        src = os.path.join(data_dir, 'ensemble_OK.pdb')
+        dst = os.path.join(self.tempdir, 'ensemble_OK.pdb')
+        shutil.copy(src, dst)
+
+        with open(dst, 'r') as fin:
+            lines = fin.readlines()
+
+        pdb_splitmodel.run(lines)
+
+        # Read files created by script
+        ofiles = [f for f in os.listdir(self.tempdir)
+                  if f.startswith('output')]
+        self.assertEqual(len(ofiles), 2)
+
+        for fpath in ofiles:
+            if fpath == 'ensemble_OK.pdb':
+                continue
+
+            with open(os.path.join(self.tempdir, fpath), 'r') as handle:
+                n_lines = len(handle.readlines())
+                self.assertEqual(n_lines, 2)
+
+    def test_run_iterable_with_name(self):
+        """pdb_splitmodel.run(iterable)"""
+        from pdbtools import pdb_splitmodel
+
+        # Copy input file to tempdir
+
+        # Simulate input
+        src = os.path.join(data_dir, 'ensemble_OK.pdb')
+        dst = os.path.join(self.tempdir, 'ensemble_OK.pdb')
+        shutil.copy(src, dst)
+
+        with open(dst, 'r') as fin:
+            lines = fin.readlines()
+
+        pdb_splitmodel.run(lines, outname='newname')
+
+        # Read files created by script
+        ofiles = [f for f in os.listdir(self.tempdir)
+                  if f.startswith('newname')]
+        self.assertEqual(len(ofiles), 2)
+
+        for fpath in ofiles:
+            with open(os.path.join(self.tempdir, fpath), 'r') as handle:
+                n_lines = len(handle.readlines())
+                self.assertEqual(n_lines, 2)
+
+    def test_run_fhandler(self):
+        """pdb_splitmodel.run(fhandler)"""
+        from pdbtools import pdb_splitmodel
+
+        # Copy input file to tempdir
+
+        # Simulate input
+        src = os.path.join(data_dir, 'ensemble_OK.pdb')
+        dst = os.path.join(self.tempdir, 'ensemble_OK.pdb')
+        shutil.copy(src, dst)
+
+        with open(dst, 'r') as fin:
+            pdb_splitmodel.run(fin)
+
+        # Read files created by script
+        ofiles = [f for f in os.listdir(self.tempdir)
+                  if f.startswith('ensemble_OK')]
+        self.assertEqual(len(ofiles), 2 + 1)  # ori + 2 models
+
+        for fpath in ofiles:
+            if fpath == 'ensemble_OK.pdb':
+                continue
+
+            with open(os.path.join(self.tempdir, fpath), 'r') as handle:
+                n_lines = len(handle.readlines())
+                self.assertEqual(n_lines, 2)
+
     def test_file_not_found(self):
         """$ pdb_splitmodel not_existing.pdb"""
 

--- a/tests/test_pdb_splitmodel.py
+++ b/tests/test_pdb_splitmodel.py
@@ -111,7 +111,7 @@ class TestTool(unittest.TestCase):
 
         # Read files created by script
         ofiles = [f for f in os.listdir(self.tempdir)
-                  if f.startswith('output')]
+                  if f.startswith('splitmodels')]
         self.assertEqual(len(ofiles), 2)
 
         for fpath in ofiles:

--- a/tests/test_pdb_splitseg.py
+++ b/tests/test_pdb_splitseg.py
@@ -139,7 +139,10 @@ class TestTool(unittest.TestCase):
         pdb_splitseg.run(lines)
 
         # Read files created by script and then delete
-        ofiles = [f for f in os.listdir(self.tempdir) if f.startswith('output')]
+        ofiles = [
+            f
+            for f in os.listdir(self.tempdir)
+            if f.startswith('splitsegs')]
         self.assertEqual(len(ofiles), 2)
 
         # Make sure each file has the chain it should have

--- a/tests/test_pdb_splitseg.py
+++ b/tests/test_pdb_splitseg.py
@@ -61,6 +61,97 @@ class TestTool(unittest.TestCase):
 
         return
 
+    def test_run_fhandler(self):
+        """pdb_splitseg.run(iterable)"""
+        from pdbtools import pdb_splitseg
+
+        # Copy input file to tempdir
+
+        # Simulate input
+        src = os.path.join(data_dir, 'dummy.pdb')
+        dst = os.path.join(self.tempdir, 'dummy.pdb')
+        shutil.copy(src, dst)
+
+        with open(dst, 'r') as fin:
+            pdb_splitseg.run(fin)
+
+        # Read files created by script and then delete
+        ofiles = [f for f in os.listdir(self.tempdir) if f.startswith('dummy')]
+        self.assertEqual(len(ofiles), 2 + 1)  # ori + 2 segments
+
+        # Make sure each file has the chain it should have
+        records = (('ATOM', 'HETATM', 'TER', 'ANISOU'))
+        for fpath in ofiles:
+            if fpath == 'dummy.pdb':
+                continue
+
+            with open(os.path.join(self.tempdir, fpath), 'r') as handle:
+                fname_seg = fpath.split('_')[1][:-4]  # xxx_(X).pdb
+                pdb_segids = [l[72:76].strip() for l in handle
+                              if l.startswith(records)]
+
+                self.assertEqual(fname_seg, list(set(pdb_segids))[0])
+
+    def test_run_iterable_with_name(self):
+        """pdb_splitseg.run(iterable, outname='newname')"""
+        from pdbtools import pdb_splitseg
+
+        # Copy input file to tempdir
+
+        # Simulate input
+        src = os.path.join(data_dir, 'dummy.pdb')
+        dst = os.path.join(self.tempdir, 'dummy.pdb')
+        shutil.copy(src, dst)
+
+        with open(dst, 'r') as fin:
+            lines = fin.readlines()
+
+        pdb_splitseg.run(lines, outname='newname')
+
+        # Read files created by script and then delete
+        ofiles = [f for f in os.listdir(self.tempdir) if f.startswith('newname')]
+        self.assertEqual(len(ofiles), 2)
+
+        # Make sure each file has the chain it should have
+        records = (('ATOM', 'HETATM', 'TER', 'ANISOU'))
+        for fpath in ofiles:
+            with open(os.path.join(self.tempdir, fpath), 'r') as handle:
+                fname_seg = fpath.split('_')[1][:-4]  # xxx_(X).pdb
+                pdb_segids = [l[72:76].strip() for l in handle
+                              if l.startswith(records)]
+
+                self.assertEqual(fname_seg, list(set(pdb_segids))[0])
+
+    def test_run_iterable(self):
+        """pdb_splitseg.run(fhandler)"""
+        from pdbtools import pdb_splitseg
+
+        # Copy input file to tempdir
+
+        # Simulate input
+        src = os.path.join(data_dir, 'dummy.pdb')
+        dst = os.path.join(self.tempdir, 'dummy.pdb')
+        shutil.copy(src, dst)
+
+        with open(dst, 'r') as fin:
+            lines = fin.readlines()
+
+        pdb_splitseg.run(lines)
+
+        # Read files created by script and then delete
+        ofiles = [f for f in os.listdir(self.tempdir) if f.startswith('output')]
+        self.assertEqual(len(ofiles), 2)
+
+        # Make sure each file has the chain it should have
+        records = (('ATOM', 'HETATM', 'TER', 'ANISOU'))
+        for fpath in ofiles:
+            with open(os.path.join(self.tempdir, fpath), 'r') as handle:
+                fname_seg = fpath.split('_')[1][:-4]  # xxx_(X).pdb
+                pdb_segids = [l[72:76].strip() for l in handle
+                              if l.startswith(records)]
+
+                self.assertEqual(fname_seg, list(set(pdb_segids))[0])
+
     def test_default(self):
         """$ pdb_splitseg data/dummy.pdb"""
 

--- a/tests/test_pdb_tocif.py
+++ b/tests/test_pdb_tocif.py
@@ -72,7 +72,7 @@ class TestTool(unittest.TestCase):
         self.assertEqual(n_coord, 185)
 
         # check name
-        self.assertEqual(newlines[2], 'data_output\n')
+        self.assertEqual(newlines[2], 'data_cell\n')
 
     def test_single_model_run_iterable_with_name(self):
         """$ pdb_tocif.run(iterable)"""

--- a/tests/test_pdb_tocif.py
+++ b/tests/test_pdb_tocif.py
@@ -53,6 +53,86 @@ class TestTool(unittest.TestCase):
 
         return
 
+    def test_single_model_run_iterable(self):
+        """$ pdb_tocif.run(iterable)"""
+        from pdbtools import pdb_tocif
+
+        fpath = os.path.join(data_dir, 'dummy.pdb')
+        with open(fpath, 'r') as fin:
+            lines = fin.readlines()
+
+        newlines = list(pdb_tocif.run(lines))
+
+        # Check no of records
+        n_ATOM = sum(1 for l in newlines if l.startswith('ATOM'))
+        n_HETATM = sum(1 for l in newlines if l.startswith('HETATM'))
+        n_coord = n_ATOM + n_HETATM
+        self.assertEqual(n_ATOM, 176)
+        self.assertEqual(n_HETATM, 9)
+        self.assertEqual(n_coord, 185)
+
+        # check name
+        self.assertEqual(newlines[2], 'data_output\n')
+
+    def test_single_model_run_iterable_with_name(self):
+        """$ pdb_tocif.run(iterable)"""
+        from pdbtools import pdb_tocif
+
+        fpath = os.path.join(data_dir, 'dummy.pdb')
+        with open(fpath, 'r') as fin:
+            lines = fin.readlines()
+
+        newlines = list(pdb_tocif.run(lines, outname='newcif'))
+
+        # Check no of records
+        n_ATOM = sum(1 for l in newlines if l.startswith('ATOM'))
+        n_HETATM = sum(1 for l in newlines if l.startswith('HETATM'))
+        n_coord = n_ATOM + n_HETATM
+        self.assertEqual(n_ATOM, 176)
+        self.assertEqual(n_HETATM, 9)
+        self.assertEqual(n_coord, 185)
+
+        # check name
+        self.assertEqual(newlines[2], 'data_newcif\n')
+
+    def test_single_model_run_fhandler(self):
+        """$ pdb_tocif.run(fhandler)"""
+        from pdbtools import pdb_tocif
+
+        fpath = os.path.join(data_dir, 'dummy.pdb')
+        with open(fpath, 'r') as fin:
+            newlines = list(pdb_tocif.run(fin))
+
+        # Check no of records
+        n_ATOM = sum(1 for l in newlines if l.startswith('ATOM'))
+        n_HETATM = sum(1 for l in newlines if l.startswith('HETATM'))
+        n_coord = n_ATOM + n_HETATM
+        self.assertEqual(n_ATOM, 176)
+        self.assertEqual(n_HETATM, 9)
+        self.assertEqual(n_coord, 185)
+
+        # check name
+        self.assertEqual(newlines[2], 'data_dummy\n')
+
+    def test_single_model_run_fhandler_name(self):
+        """$ pdb_tocif.run(fhandler)"""
+        from pdbtools import pdb_tocif
+
+        fpath = os.path.join(data_dir, 'dummy.pdb')
+        with open(fpath, 'r') as fin:
+            newlines = list(pdb_tocif.run(fin, outname='newname'))
+
+        # Check no of records
+        n_ATOM = sum(1 for l in newlines if l.startswith('ATOM'))
+        n_HETATM = sum(1 for l in newlines if l.startswith('HETATM'))
+        n_coord = n_ATOM + n_HETATM
+        self.assertEqual(n_ATOM, 176)
+        self.assertEqual(n_HETATM, 9)
+        self.assertEqual(n_coord, 185)
+
+        # check name
+        self.assertEqual(newlines[2], 'data_newname\n')
+
     def test_single_model(self):
         """$ pdb_tocif data/dummy.pdb"""
 


### PR DESCRIPTION
In #107 the `run` function was documented to be used either providing a `file handler` or an `iterator` scrolling over the `PDB` lines. However in `pdb_split*` and `pdb_tocif` the `run` function defines the output files basenames given the `.name` attribute of the `file handler`. `iterables` won't have this attribute. This PR corrects that by providing a default name, `output`, when the attribute `.name` is not present in `fhandler`. Also, if `run` is used directly, the user can define `outname` specifically, instead of relying on the default values.

You will see a new function  `get_fname` in the `__init__.py`. This function is imported where it is needed. I don't think this adds any overhead to the execution, and keeps things clean.

I am keeping this PR as draft while I write the tests, so that you can comment on it already. But we should merge asap.