### PR TITLE
`pdb_renameatom` - Renames atoms.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -490,7 +490,7 @@ Usage:
     python pdb_renameatom.py -&lt;AT1&gt;:&lt;AT2&gt; &lt;pdb-file&gt;
 
 Example:
-    python pdb_renameatom.py -HB2,2HB 1CTF.pdb  # Renames HB2 to 2HB
+    python pdb_renameatom.py -HB3,2HB 2M9Y.pdb  # Renames HB3 to 2HB
 </span>
 </details>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -484,6 +484,18 @@ Example:
 </div>
 <div style="margin-bottom: 1em;">
 <details>
+<summary><b>pdb_renameatom</b><p>Renames atom.</p></summary>
+<span style="font-family: monospace; white-space: pre;">
+Usage:
+    python pdb_renameatom.py -&lt;AT1&gt;:&lt;AT2&gt; &lt;pdb-file&gt;
+
+Example:
+    python pdb_renameatom.py -HB2,2HB 1CTF.pdb  # Renames HB2 to 2HB
+</span>
+</details>
+</div>
+<div style="margin-bottom: 1em;">
+<details>
 <summary><b>pdb_reres</b><p>Renumbers the residues of the PDB file starting from a given number (default 1).</p></summary>
 <span style="font-family: monospace; white-space: pre;">
 Usage:

--- a/pdbtools/pdb_renameatom.py
+++ b/pdbtools/pdb_renameatom.py
@@ -25,7 +25,7 @@ Usage:
     python pdb_selatom.py -<option> <pdb file>
 
 Example:
-    python pdb_renameatom.py -1HB,HB2 1CTF.pdb  # renames '1HB' to 'HB2'
+    python pdb_renameatom.py -HB3,2HB 2M9Y.pdb  # renames 'HB3' to '2HB'
 
 This program is part of the `pdb-tools` suite of utilities and should not be
 distributed isolatedly. The `pdb-tools` were created to quickly manipulate PDB

--- a/pdbtools/pdb_renameatom.py
+++ b/pdbtools/pdb_renameatom.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 João MC Teixeira
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Renames all atoms matching the given name in the PDB file by a new name.
+
+Atom names are matched *without* taking into consideration spaces, so ' CA '
+(alpha carbon) and 'CA  ' (calcium) will both be renamed if -CA is passed.
+
+Usage:
+    python pdb_selatom.py -<option> <pdb file>
+
+Example:
+    python pdb_renameatom.py -1HB,HB2 1CTF.pdb  # renames '1HB' to 'HB2'
+
+This program is part of the `pdb-tools` suite of utilities and should not be
+distributed isolatedly. The `pdb-tools` were created to quickly manipulate PDB
+files using the terminal, and can be used sequentially, with one tool streaming
+data to another. They are based on old FORTRAN77 code that was taking too much
+effort to maintain and compile. RIP.
+"""
+import os
+import sys
+
+__author__ = ["Joao M.C. Teixeira"]
+__email__ = ["joaomcteixeira@gmail.com"]
+
+
+def check_input(args):
+    """Checks whether to read from stdin/file and validates user input/options.
+    """
+    if not args:
+        emsg = 'ERROR! No option nor input provided{}'
+        sys.stderr.write(emsg.format(os.linesep))
+        sys.stderr.write(__doc__)
+        sys.exit(1)
+
+    # The first argument is mandatory, you always need to select an atom
+    if not args[0].startswith('-'):
+        emsg = 'ERROR! First argument is not an option: \'{}\'{}'
+        sys.stderr.write(emsg.format(args[0], os.linesep))
+        sys.stderr.write(__doc__)
+        sys.exit(1)
+
+    # atom names have at most 4 characters
+    option = args[0][1:].split(',')
+    if len(option) != 2:
+        emsg = 'ERROR! You need to provide two atom names: source and target.{}'
+        sys.stderr.write(emsg.format(os.linesep))
+        sys.stderr.write(__doc__)
+        sys.exit(1)
+
+    if any(len(atom_name) > 4 for atom_name in option):
+        emsg = 'ERROR!! Atom names have maximum 4 characters: \'{}\'{}'
+        sys.stderr.write(emsg.format(args[0], os.linesep))
+        sys.stderr.write(__doc__)
+        sys.exit(1)
+
+    # Pipe or file
+    if sys.stdin.isatty():  # ensure the PDB data is streamed in
+        if not os.path.isfile(args[0]):
+            emsg = 'ERROR!! File not found or not readable: \'{}\'{}'
+            sys.stderr.write(emsg.format(args[0], os.linesep))
+            sys.stderr.write(__doc__)
+            sys.exit(1)
+
+    fh = open(args[1], 'r')
+    return fh, option
+
+
+def run(fhandler, source, target):
+    """
+    Rename selected atoms
+
+    This function is a generator.
+
+    Atom names are matched *without* taking into consideration spaces,
+    so ' CA ' (alpha carbon) and 'CA  ' (calcium) will both be renamed
+    if -CA is passed.
+
+    Parameters
+    ----------
+    fhandle : a line-by-line iterator of the original PDB file.
+
+    source : the atom name to change.
+
+    target : the new atom name.
+
+    Yields
+    ------
+    str (line-by-line)
+        All non-RECORD lines and RECORD lines within the selected atom
+        names.
+    """
+    records = ('ATOM', 'HETATM', 'ANISOU')
+    # try/catch block is added here to avoid creating it every line
+    try:
+        for line in fhandle:
+            if line.startswith(records):
+                atom_source = line[12:16].strip()
+                element = line[76:78].strip()
+                if atom_source == source:
+                    new_name = format_atom(atom_source, element)
+                    line = line[:13] + new_name + line[16:]
+                yield _line
+            yield line
+
+    except KeyError as err:
+        _ = f'Could not format this atom:type -> {atom_source}:{element}'
+        raise KeyError(_) from err
+
+
+# string formats for atom name depending on element
+_3 = ' {:<3s}'
+_4 = '{:<4s}'
+_atom_format_dict = {
+    1: { 1: _3, 2: _3, 3: _3, 4: _4},
+    2: { 1: _4, 2: _4, 3: _4, 4: _4},
+    }
+
+
+def format_atom_name(atom, element, AFD=_atom_format_dict):
+    """
+    Format PDB Record line Atom name.
+
+    Further Reading:
+
+    * https://www.cgl.ucsf.edu/chimera/docs/UsersGuide/tutorials/pdbintro.html
+
+    Parameters
+    ----------
+    atom : str
+        The atom name.
+
+    element : str
+        The atom element code.
+
+    Returns
+    -------
+    str
+        Formatted atom name.
+    """
+    len_atm = len(atm)
+    len_ele = len(element)
+    return AFD[len_ele][len_atm].format(atom)
+
+
+renameatom = run
+
+
+def main():
+    # Check Input
+    pdbfh, option = check_input(sys.argv[1:])
+
+    # Do the job
+    new_pdb = run(pdbfh, *option)
+
+    try:
+        _buffer = []
+        _buffer_size = 5000  # write N lines at a time
+        for lineno, line in enumerate(new_pdb):
+            if not (lineno % _buffer_size):
+                sys.stdout.write(''.join(_buffer))
+                _buffer = []
+            _buffer.append(line)
+
+        sys.stdout.write(''.join(_buffer))
+        sys.stdout.flush()
+    except IOError:
+        # This is here to catch Broken Pipes
+        # for example to use 'head' or 'tail' without
+        # the error message showing up
+        pass
+
+    # last line of the script
+    # We can close it even if it is sys.stdin
+    pdbfh.close()
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/pdbtools/pdb_renameatom.py
+++ b/pdbtools/pdb_renameatom.py
@@ -91,7 +91,11 @@ def check_input(args):
             sys.stderr.write(__doc__)
             sys.exit(1)
 
-    fh = open(args[1], 'r')
+        fh = open(args[1], 'r')
+
+    else:  # input comes from pipe
+        fh = sys.stdin
+
     return fh, option
 
 

--- a/tests/test_pdb_renameatom.py
+++ b/tests/test_pdb_renameatom.py
@@ -69,6 +69,15 @@ class TestTool(unittest.TestCase):
         xxx_count = sum(1 for l in self.stdout if l[12:16].strip() == 'XXX')
         self.assertEqual(xxx_count, 6)
 
+        with open(os.path.join(data_dir, 'dummy.pdb'), 'r') as fin:
+            lines = fin.readlines()
+            diff_lines = sum(
+                1
+                for i, j in zip(lines, self.stdout)
+                if i.strip() != j.strip())
+
+        self.assertEqual(diff_lines, 6)
+
     def test_DNA_example(self):
         """$ pdb_renameatom -O5',O6' data/dummy.pdb"""
 
@@ -87,6 +96,15 @@ class TestTool(unittest.TestCase):
         self.assertEqual(hg2_count, 0)
         xxx_count = sum(1 for l in self.stdout if l[12:16].strip() == "O6'")
         self.assertEqual(xxx_count, 1)
+
+        with open(os.path.join(data_dir, 'dummy.pdb'), 'r') as fin:
+            lines = fin.readlines()
+            diff_lines = sum(
+                1
+                for i, j in zip(lines, self.stdout)
+                if i.strip() != j.strip())
+
+        self.assertEqual(diff_lines, 1)
 
     def test_no_input_provided(self):
         """$ pdb_renameatom """

--- a/tests/test_pdb_renameatom.py
+++ b/tests/test_pdb_renameatom.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 João MC Teixeira
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit Tests for `pdb_renameatom`.
+"""
+import os
+import sys
+import unittest
+
+from config import data_dir
+from utils import OutputCapture
+
+
+class TestTool(unittest.TestCase):
+    """
+    Generic class for testing tools.
+    """
+    def setUp(self):
+        # Dynamically import the module
+        name = 'pdbtools.pdb_renameatom'
+        self.module = __import__(name, fromlist=[''])
+
+    def exec_module(self):
+        """
+        Execs module.
+        """
+        with OutputCapture() as output:
+            try:
+                self.module.main()
+            except SystemExit as e:
+                self.retcode = e.code
+
+        self.stdout = output.stdout
+        self.stderr = output.stderr
+
+        return
+
+    def test_one_option(self):
+        """$ pdb_renameatom -HG2,XXX data/dummy.pdb"""
+
+        # Simulate input
+        sys.argv = ['', '-HG2,XXX', os.path.join(data_dir, 'dummy.pdb')]
+
+        # Execute the script
+        self.exec_module()
+
+        # Validate results
+        self.assertEqual(self.retcode, 0)  # ensure the program exited OK.
+        self.assertEqual(len(self.stdout), 204)  # all file lines
+        self.assertEqual(len(self.stderr), 0)  # no errors
+
+        hg2_count = sum(1 for l in self.stdout if l[12:16].strip() == 'HG2')
+        self.assertEqual(hg2_count, 0)
+        xxx_count = sum(1 for l in self.stdout if l[12:16].strip() == 'XXX')
+        self.assertEqual(xxx_count, 6)
+
+    def test_DNA_example(self):
+        """$ pdb_renameatom -O5',O6' data/dummy.pdb"""
+
+        # Simulate input
+        sys.argv = ['', "-O5',O6'", os.path.join(data_dir, 'dummy.pdb')]
+
+        # Execute the script
+        self.exec_module()
+
+        # Validate results
+        self.assertEqual(self.retcode, 0)  # ensure the program exited OK.
+        self.assertEqual(len(self.stdout), 204)  # all file lines
+        self.assertEqual(len(self.stderr), 0)  # no errors
+
+        hg2_count = sum(1 for l in self.stdout if l[12:16].strip() == "O5'")
+        self.assertEqual(hg2_count, 0)
+        xxx_count = sum(1 for l in self.stdout if l[12:16].strip() == "O6'")
+        self.assertEqual(xxx_count, 1)
+
+    def test_no_input_provided(self):
+        """$ pdb_renameatom """
+        sys.argv = ['']
+        self.exec_module()
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)  # nothing written to stdout
+        emsg = 'ERROR! No input provided'
+        self.assertEqual(self.stderr[0].split(os.linesep)[0], emsg)
+        return
+
+    def test_too_much_input_provided(self):
+        """$ pdb_renameatom -HB2,HB3 dummy.pdb yet_another_file.pdb"""
+        sys.argv = ['', '-HB2,HB3', 'dummy.pdb', 'yet_another_file.pdb']
+        self.exec_module()
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)  # nothing written to stdout
+        emsg = 'ERROR! Too many arguments.'
+        self.assertEqual(self.stderr[0].split(os.linesep)[0], emsg)
+        return
+
+    def test_invalid_option(self):
+        """$ pdb_renameatom data/dummy.pdb"""
+
+        _file = os.path.join(data_dir, 'dummy.pdb')
+        sys.argv = ['', _file]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)
+        emsg = 'ERROR! First argument is not an option: \'{}\''
+        emsg = emsg.format(_file)
+        self.assertEqual(self.stderr[0].split(os.linesep)[0], emsg)
+
+    def test_atom2_missing(self):
+        """$ pdb_renameatom -AT1 data/dummy.pdb"""
+
+        sys.argv = ['', '-AT1', os.path.join(data_dir, 'dummy.pdb')]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)
+        emsg = 'ERROR! You need to provide two atom names: source and target.'
+        self.assertEqual(self.stderr[0].split(os.linesep)[0], emsg)
+
+    def test_atoms_at_most_4_chars(self):
+        """$ pdb_renameatom -AT1,AT223 data/dummy.pdb"""
+
+        sys.argv = ['', '-AT1,AT223', os.path.join(data_dir, 'dummy.pdb')]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)
+        emsg = 'ERROR!! Atom names have maximum 4 characters: \'{}\''
+        emsg = emsg.format('-AT1,AT223')
+        self.assertEqual(self.stderr[0].split(os.linesep)[0], emsg)
+
+    def test_atoms_at_most_4_chars_2(self):
+        """$ pdb_renameatom -AT111,AT2 data/dummy.pdb"""
+
+        sys.argv = ['', '-AT111,AT2', os.path.join(data_dir, 'dummy.pdb')]
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)
+        emsg = 'ERROR!! Atom names have maximum 4 characters: \'{}\''
+        emsg = emsg.format('-AT111,AT2')
+        self.assertEqual(self.stderr[0].split(os.linesep)[0], emsg)
+
+    def test_file_not_provided(self):
+        """$ pdb_renameatom -HB2,HB4"""
+
+        sys.argv = ['', '-HB2,HB4']
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)  # no output
+        # proper error message
+        emsg = 'ERROR!! No file provided.'
+        self.assertEqual(self.stderr[0].split(os.linesep)[0], emsg)
+
+    def test_file_not_provided(self):
+        """$ pdb_renameatom -HB2,HB4 not_existing.pdb"""
+
+        sys.argv = ['', '-HB2,HB4', 'not_existing.pdb']
+
+        self.exec_module()
+
+        self.assertEqual(self.retcode, 1)
+        self.assertEqual(len(self.stdout), 0)  # no output
+        # proper error message
+        emsg = 'ERROR!! File not found or not readable: \'{}\''
+        emsg = emsg.format('not_existing.pdb')
+        self.assertEqual(self.stderr[0].split(os.linesep)[0], emsg)
+
+
+if __name__ == '__main__':
+    from config import test_dir
+
+    mpath = os.path.abspath(os.path.join(test_dir, '..'))
+    sys.path.insert(0, mpath)  # so we load dev files before  any installation
+
+    unittest.main()


### PR DESCRIPTION
Adds a tool to rename atom names.

Sometimes when exchanging PDBs between programs we find atom names are not compatible. For example, [here](https://bmrb.io/ref_info/atom_nom.tbl) is a table with the different atom name nomenclatures for some of the most relevant software and databases in the field.

This tool comes also as a request from my colleagues at @formankay lab, yet I trust it will be very helpful for the whole community.

**What it does:**

Atom names are renamed and [formatted according to the element type](https://www.cgl.ucsf.edu/chimera/docs/UsersGuide/tutorials/pdbintro.html). In case of missing elements, the atom name will be left-justified to four characters.

@JoaoRodrigues I added only my name in the `authors` and copyright just because of what we commented in #112. But just add also yours if you feel so, or we can use instead `CSB Group`, @amjjbonvin 

**NOTE:** add `[FEATURE]` in the commit message when merging.