### PR TITLE
Improved `pdb_selaltloc`

### DIFF
--- a/pdbtools/pdb_selaltloc.py
+++ b/pdbtools/pdb_selaltloc.py
@@ -178,7 +178,7 @@ def select_altloc(fhandle, selloc=None, byocc=False):
                 else:
                     flush_func = flush_func_multi_residues
 
-                for __line in flush_func(selloc, altloc_lines, res_per_loc):
+                for __line in flush_func(selloc=selloc, altloc_lines=altloc_lines, res_per_loc=res_per_loc):
                     yield __line
 
             # saves the line per altloc identifier
@@ -201,7 +201,7 @@ def select_altloc(fhandle, selloc=None, byocc=False):
                     flush_func = flush_func_single_residues
                 else:
                     flush_func = flush_func_multi_residues
-                for __line in flush_func(selloc, altloc_lines, res_per_loc):
+                for __line in flush_func(selloc=selloc, altloc_lines=altloc_lines, res_per_loc=res_per_loc):
                     yield __line
 
             prev_altloc = ''
@@ -225,7 +225,7 @@ def select_altloc(fhandle, selloc=None, byocc=False):
         else:
             flush_func = flush_func_multi_residues
 
-        for __line in flush_func(selloc, altloc_lines, res_per_loc):
+        for __line in flush_func(selloc=selloc, altloc_lines=altloc_lines, res_per_loc=res_per_loc):
             yield __line
 
 
@@ -286,7 +286,7 @@ def flush_resloc(selloc, altloc_lines, res_per_loc):
     res_per_loc.clear()
 
 
-def flush_resloc_occ(selloc, altloc_lines, res_per_loc):
+def flush_resloc_occ(altloc_lines, res_per_loc, **kw):
     """Flush the captured altloc lines by highest occupancy."""
     # only the selected altloc is yieled
     highest = 0.00
@@ -343,7 +343,7 @@ def flush_resloc_id_same_residue(selloc, altloc_lines, res_per_loc):
     res_per_loc.clear()
 
 
-def flush_resloc_occ_same_residue(selloc, altloc_lines, res_per_loc):
+def flush_resloc_occ_same_residue(altloc_lines, res_per_loc, **kw):
     """Flush altloc if altloc are atoms in the same residue - by occ."""
     # places all lines in a single list
     all_lines = []
@@ -389,7 +389,7 @@ def all_same_residue(altloc_lines):
 
 
 def partial_altloc(altloc_lines):
-    """."""
+    """Detect if the altloc positions are atoms in a single residue."""
     return ' ' in altloc_lines and all_same_residue(altloc_lines)
 
 

--- a/pdbtools/pdb_selaltloc.py
+++ b/pdbtools/pdb_selaltloc.py
@@ -39,7 +39,6 @@ files using the terminal, and can be used sequentially, with one tool streaming
 data to another. They are based on old FORTRAN77 code that was taking too much
 effort to maintain and compile. RIP.
 """
-from pprint import pprint
 import operator
 import os
 import sys

--- a/tests/test_pdb_selaltloc.py
+++ b/tests/test_pdb_selaltloc.py
@@ -60,7 +60,7 @@ class TestTool(unittest.TestCase):
         Exemple of a starting line with empty strings.
         """
         result = self.module.is_another_altloc_group(
-            ' ', '', '1', '', 'ALA', '', {' ': ['line']})
+            ' ', '', '1', '', 'ALA', '', {}, {})
 
         self.assertFalse(result)
 
@@ -71,7 +71,7 @@ class TestTool(unittest.TestCase):
         Example of a starting line with Nones.
         """
         result = self.module.is_another_altloc_group(
-            ' ', None, None, None, None, None, {})
+            ' ', None, None, None, None, None, {}, {})
 
         self.assertFalse(result)
 
@@ -82,7 +82,8 @@ class TestTool(unittest.TestCase):
         Example of all parameters are the same as previous line.
         """
         result = self.module.is_another_altloc_group(
-            'B', 'B', '12', '12', 'ALA', 'ALA', {'B': None}
+            'B', 'B', '12', '12', 'ALA', 'ALA', {'B': None},
+            {'B': {('ALA', '12')}}
             )
         self.assertFalse(result)
 
@@ -97,9 +98,10 @@ class TestTool(unittest.TestCase):
         dummy_altloc2.pdb.
         """
         result = self.module.is_another_altloc_group(
-            'A', 'A', '26', '25', 'LEU', 'GLU', {'A': None}
+            'A', 'A', '26', '25', 'LEU', 'GLU', {'A': ['lines']},
+            {'A': {('GLU', '25')}}
             )
-        self.assertTrue(result)
+        self.assertFalse(result)
 
     def test_is_same_group_5(self):
         """
@@ -111,9 +113,10 @@ class TestTool(unittest.TestCase):
         dummy_altloc2.pdb.
         """
         result = self.module.is_another_altloc_group(
-            'A', ' ', '26', '25', 'GLU', 'GLU', {' ': ['lines']}
+            'A', ' ', '26', '25', 'GLU', 'GLU', {' ': ['lines']},
+            {' ': {('GLU', '25')}}
             )
-        self.assertTrue(result)
+        self.assertFalse(result)
 
     def test_is_same_group_6(self):
         """
@@ -125,85 +128,38 @@ class TestTool(unittest.TestCase):
         dummy_altloc2.pdb.
         """
         result = self.module.is_another_altloc_group(
-            'A', ' ', '25', '25', 'ALA', 'GLU', {' ': ['lines']}
+            'A', ' ', '25', '25', 'ALA', 'GLU', {' ': ['lines']},
+            {' ': {('GLU', '25')}}
             )
-        self.assertTrue(result)
+        self.assertFalse(result)
 
     def test_is_another_group_1(self):
         result = self.module.is_another_altloc_group(
-            ' ', 'B', '2', '1', 'ALA', 'PRO', {'B': ['lines']}
+            ' ', 'B', '2', '1', 'ALA', 'PRO', {'B': ['lines']},
+            {'B': {('PRO', '1')}}
             )
         self.assertTrue(result)
 
-    #def test_is_same_group_7(self):
-    #    """Test if is_another_altloc_group."""
-    #    result = self.module.is_another_altloc_group(
-    #        'A', ' ', '25', '25', 'LEU', 'GLY', {' ': ['lines']}
-    #        )
-    #    self.assertTrue(result)
+    def test_is_another_group_2(self):
+        result = self.module.is_another_altloc_group(
+            ' ', ' ', '2', '1', 'ALA', 'ALA', {' ': ['lines']},
+            {' ': {('ALA', '1')}}
+            )
+        self.assertTrue(result)
 
-    #def test_is_another_group_1(self):
-    #    """
-    #    Test if line is from another altloc group.
+    def test_is_another_group_3(self):
+        result = self.module.is_another_altloc_group(
+            ' ', ' ', '1', '1', 'ALA', 'GLU', {' ': ['lines']},
+            {' ': {('GLU', '1')}}
+            )
+        self.assertTrue(result)
 
-    #    Same all params but resnum different.
-    #    """
-    #    result = self.module.is_another_altloc_group(
-    #        'A', 'A', '12', '11', 'ALA', 'ALA', {'A': ['lines']})
-    #    self.assertTrue(result)
-
-    #def test_is_another_group_2(self):
-    #    """
-    #    Test if line is from another altloc group.
-
-    #    All same parameters except resname.
-    #    """
-    #    result = self.module.is_another_altloc_group(
-    #        'A', 'A', '12', '12', 'PRO', 'ALA', {'A': ['lines']})
-    #    self.assertTrue(result)
-
-    #def test_is_another_group_3(self):
-    #    """
-    #    Test if line is from another altloc group.
-
-    #    Altloc changes but it was already in the altloc dictionary.
-    #    """
-    #    result = self.module.is_another_altloc_group(
-    #        'B', 'A', '12', '12', 'ALA', 'ALA', {'B': ['lines'], 'A': ['lines']})
-    #    self.assertTrue(result)
-
-
-    #def test_is_another_group_5(self):
-    #    """Test if is_another_altloc_group."""
-    #    result = self.module.is_another_altloc_group(
-    #        ' ', ' ', '2', '1', 'LEU', 'GLY', {' ': ['lines']}
-    #        )
-    #    self.assertTrue(result)
-
-    #def test_is_another_group_6(self):
-    #    """Test if is_another_altloc_group."""
-    #    result = self.module.is_another_altloc_group(
-    #        'A', ' ', '26', '25', 'LEU', 'GLU', {}
-    #        )
-    #    self.assertTrue(result)
-
-    #def test_is_another_group_7(self):
-    #    """
-    #    Test if from the same group.
-    #    """
-    #    result = self.module.is_another_altloc_group(
-    #        'B', 'A', '12', '13', 'ALA', 'PRO', {'A': None}
-    #        )
-    #    self.assertTrue(result)
-
-    #def test_is_another_group_8(self):
-    #    """
-    #    Test if from the same group.
-    #    """
-    #    result = self.module.is_another_altloc_group(
-    #        'A', ' ', '12', '13', 'ALA', 'PRO', {' ': None}
-    #        )
-    #    self.assertTrue(result)
+    def test_is_another_group_4(self):
+        result = self.module.is_another_altloc_group(
+            'A', 'A', '26', '25', 'LEU', 'GLU', {' ': ['lines'], 'A': ['lines']},
+            {' ': {('LEU', '25')}, 'A': {('GLU', '26')}}
+            )
+        self.assertTrue(result)
 
     def test_default(self):
         """$ pdb_selaltloc data/dummy_altloc.pdb"""

--- a/tests/test_pdb_selaltloc.py
+++ b/tests/test_pdb_selaltloc.py
@@ -53,58 +53,157 @@ class TestTool(unittest.TestCase):
 
         return
 
-    def test_is_another_group_1(self):
-        """Test if is_another_altloc_group altloc is ' '."""
+    def test_is_same_group_1(self):
+        """
+        Test if from the same group.
+
+        Exemple of a starting line with empty strings.
+        """
+        result = self.module.is_another_altloc_group(
+            ' ', '', '1', '', 'ALA', '', {' ': ['line']})
+
+        self.assertFalse(result)
+
+    def test_is_same_group_2(self):
+        """
+        Test if from the same group.
+
+        Example of a starting line with Nones.
+        """
         result = self.module.is_another_altloc_group(
             ' ', None, None, None, None, None, {})
 
-        self.assertTrue(result)
+        self.assertFalse(result)
 
-    def test_is_another_group_2(self):
-        """Test if is_another_altloc_group second with residue number."""
-        result = self.module.is_another_altloc_group(
-            'A', 'A', '12', '11', 'ALA', 'ALA', {})
-        self.assertTrue(result)
+    def test_is_same_group_3(self):
+        """
+        Test if from the same group.
 
-    def test_is_another_group_3(self):
-        """Test if is_another_altloc_group second with residue name."""
-        result = self.module.is_another_altloc_group(
-            'A', 'A', '12', '12', 'PRO', 'ALA', {})
-        self.assertTrue(result)
-
-    def test_is_another_group_4(self):
-        """Test if is_another_altloc_group third with residueloc."""
-        result = self.module.is_another_altloc_group(
-            'B', 'A', None, None, None, None, {'B': None, 'A': None})
-        self.assertTrue(result)
-
-    def test_is_another_group_5(self):
-        """Test if is_another_altloc_group."""
+        Example of all parameters are the same as previous line.
+        """
         result = self.module.is_another_altloc_group(
             'B', 'B', '12', '12', 'ALA', 'ALA', {'B': None}
             )
         self.assertFalse(result)
 
-    def test_is_another_group_6(self):
-        """Test if is_another_altloc_group."""
-        result = self.module.is_another_altloc_group(
-            'B', 'A', '12', '13', 'ALA', 'PRO', {'A': None}
-            )
-        self.assertFalse(result)
 
-    def test_is_another_group_7(self):
-        """Test if is_another_altloc_group."""
-        result = self.module.is_another_altloc_group(
-            'A', ' ', '26', '25', 'LEU', 'GLU', {}
-            )
-        self.assertFalse(result)
+    def test_is_same_group_4(self):
+        """
+        Test if line is from another group.
 
-    def test_is_another_group_8(self):
-        """Test if is_another_altloc_group."""
+        Multiple residue altloc.
+
+        This considers altloc spanning several residues. See example
+        dummy_altloc2.pdb.
+        """
         result = self.module.is_another_altloc_group(
             'A', 'A', '26', '25', 'LEU', 'GLU', {'A': None}
             )
         self.assertTrue(result)
+
+    def test_is_same_group_5(self):
+        """
+        Test if line is from another group.
+
+        Multiple residue altloc.
+
+        This considers altloc spanning several residues. See example
+        dummy_altloc2.pdb.
+        """
+        result = self.module.is_another_altloc_group(
+            'A', ' ', '26', '25', 'GLU', 'GLU', {' ': ['lines']}
+            )
+        self.assertTrue(result)
+
+    def test_is_same_group_6(self):
+        """
+        Test if line is from another group.
+
+        Multiple residue altloc.
+
+        This considers altloc spanning several residues. See example
+        dummy_altloc2.pdb.
+        """
+        result = self.module.is_another_altloc_group(
+            'A', ' ', '25', '25', 'ALA', 'GLU', {' ': ['lines']}
+            )
+        self.assertTrue(result)
+
+    def test_is_another_group_1(self):
+        result = self.module.is_another_altloc_group(
+            ' ', 'B', '2', '1', 'ALA', 'PRO', {'B': ['lines']}
+            )
+        self.assertTrue(result)
+
+    #def test_is_same_group_7(self):
+    #    """Test if is_another_altloc_group."""
+    #    result = self.module.is_another_altloc_group(
+    #        'A', ' ', '25', '25', 'LEU', 'GLY', {' ': ['lines']}
+    #        )
+    #    self.assertTrue(result)
+
+    #def test_is_another_group_1(self):
+    #    """
+    #    Test if line is from another altloc group.
+
+    #    Same all params but resnum different.
+    #    """
+    #    result = self.module.is_another_altloc_group(
+    #        'A', 'A', '12', '11', 'ALA', 'ALA', {'A': ['lines']})
+    #    self.assertTrue(result)
+
+    #def test_is_another_group_2(self):
+    #    """
+    #    Test if line is from another altloc group.
+
+    #    All same parameters except resname.
+    #    """
+    #    result = self.module.is_another_altloc_group(
+    #        'A', 'A', '12', '12', 'PRO', 'ALA', {'A': ['lines']})
+    #    self.assertTrue(result)
+
+    #def test_is_another_group_3(self):
+    #    """
+    #    Test if line is from another altloc group.
+
+    #    Altloc changes but it was already in the altloc dictionary.
+    #    """
+    #    result = self.module.is_another_altloc_group(
+    #        'B', 'A', '12', '12', 'ALA', 'ALA', {'B': ['lines'], 'A': ['lines']})
+    #    self.assertTrue(result)
+
+
+    #def test_is_another_group_5(self):
+    #    """Test if is_another_altloc_group."""
+    #    result = self.module.is_another_altloc_group(
+    #        ' ', ' ', '2', '1', 'LEU', 'GLY', {' ': ['lines']}
+    #        )
+    #    self.assertTrue(result)
+
+    #def test_is_another_group_6(self):
+    #    """Test if is_another_altloc_group."""
+    #    result = self.module.is_another_altloc_group(
+    #        'A', ' ', '26', '25', 'LEU', 'GLU', {}
+    #        )
+    #    self.assertTrue(result)
+
+    #def test_is_another_group_7(self):
+    #    """
+    #    Test if from the same group.
+    #    """
+    #    result = self.module.is_another_altloc_group(
+    #        'B', 'A', '12', '13', 'ALA', 'PRO', {'A': None}
+    #        )
+    #    self.assertTrue(result)
+
+    #def test_is_another_group_8(self):
+    #    """
+    #    Test if from the same group.
+    #    """
+    #    result = self.module.is_another_altloc_group(
+    #        'A', ' ', '12', '13', 'ALA', 'PRO', {' ': None}
+    #        )
+    #    self.assertTrue(result)
 
     def test_default(self):
         """$ pdb_selaltloc data/dummy_altloc.pdb"""

--- a/tests/test_pdb_selaltloc.py
+++ b/tests/test_pdb_selaltloc.py
@@ -53,6 +53,59 @@ class TestTool(unittest.TestCase):
 
         return
 
+    def test_is_another_group_1(self):
+        """Test if is_another_altloc_group altloc is ' '."""
+        result = self.module.is_another_altloc_group(
+            ' ', None, None, None, None, None, {})
+
+        self.assertTrue(result)
+
+    def test_is_another_group_2(self):
+        """Test if is_another_altloc_group second with residue number."""
+        result = self.module.is_another_altloc_group(
+            'A', 'A', '12', '11', 'ALA', 'ALA', {})
+        self.assertTrue(result)
+
+    def test_is_another_group_3(self):
+        """Test if is_another_altloc_group second with residue name."""
+        result = self.module.is_another_altloc_group(
+            'A', 'A', '12', '12', 'PRO', 'ALA', {})
+        self.assertTrue(result)
+
+    def test_is_another_group_4(self):
+        """Test if is_another_altloc_group third with residueloc."""
+        result = self.module.is_another_altloc_group(
+            'B', 'A', None, None, None, None, {'B': None, 'A': None})
+        self.assertTrue(result)
+
+    def test_is_another_group_5(self):
+        """Test if is_another_altloc_group."""
+        result = self.module.is_another_altloc_group(
+            'B', 'B', '12', '12', 'ALA', 'ALA', {'B': None}
+            )
+        self.assertFalse(result)
+
+    def test_is_another_group_6(self):
+        """Test if is_another_altloc_group."""
+        result = self.module.is_another_altloc_group(
+            'B', 'A', '12', '13', 'ALA', 'PRO', {'A': None}
+            )
+        self.assertFalse(result)
+
+    def test_is_another_group_7(self):
+        """Test if is_another_altloc_group."""
+        result = self.module.is_another_altloc_group(
+            'A', ' ', '26', '25', 'LEU', 'GLU', {}
+            )
+        self.assertFalse(result)
+
+    def test_is_another_group_8(self):
+        """Test if is_another_altloc_group."""
+        result = self.module.is_another_altloc_group(
+            'A', 'A', '26', '25', 'LEU', 'GLU', {'A': None}
+            )
+        self.assertTrue(result)
+
     def test_default(self):
         """$ pdb_selaltloc data/dummy_altloc.pdb"""
 

--- a/tests/test_pdb_selaltloc.py
+++ b/tests/test_pdb_selaltloc.py
@@ -18,7 +18,6 @@
 """
 Unit Tests for `pdb_selaltloc`.
 """
-
 import os
 import sys
 import unittest
@@ -160,6 +159,45 @@ class TestTool(unittest.TestCase):
             {' ': {('LEU', '25')}, 'A': {('GLU', '26')}}
             )
         self.assertTrue(result)
+
+    def test_all_same_residue(self):
+        """Test all same residue."""
+        inp = {
+            ' ': [
+                    "ATOM      3  N   ASN A   1      22.066  40.557   0.420  1.00  0.00           N  ",
+                    "ATOM      3  H   ASN A   1      21.629  41.305  -0.098  1.00  0.00           H  ",
+                    "ATOM      3  H2  ASN A   1      23.236  40.798   0.369  1.00  0.00           H  ",
+                    "ATOM      3  H3  ASN A   1      21.866  40.736   1.590  1.00  0.00           H  ",
+                    ],
+            'B': ["ATOM      3  CA BASN A   1      20.000  30.000   0.005  0.60  0.00           C  "],
+            'A': ["ATOM      3  CA AASN A   1      21.411  39.311   0.054  0.40  0.00           C  "],
+            }
+
+        result = self.module.all_same_residue(inp)
+        self.assertTrue(result)
+
+    def test_all_same_residue_false(self):
+        """Test all same residue."""
+        inp = {
+            'B': ["ATOM      3  CA BSER A   2      20.000  30.000   0.005  0.60  0.00           C  "], 'A': ["ATOM      3  CA AASN A   1      21.411  39.311   0.054  0.40  0.00           C  "], } 
+        result = self.module.all_same_residue(inp)
+        self.assertFalse(result)
+
+    def test_partial_altloc(self):
+        inp = {
+            'A': [
+                    "ATOM    333  CA AGLU A  26     -10.000  -3.000 -12.000  0.50  4.89           C  ",
+                    "ANISOU  333  CA AGLU A  26      576    620    663     31     42     45       C  ",
+                 ],
+            'B':[
+                "ATOM    333  CA CGLU A  26     -10.679  -3.437 -12.387  1.00  4.89           C  ",
+                "ANISOU  333  CA CGLU A  26      576    620    663     31     42     45       C  ",
+                ],
+            }
+
+        result = self.module.partial_altloc(inp)
+        self.assertFalse(result)
+
 
     def test_default(self):
         """$ pdb_selaltloc data/dummy_altloc.pdb"""
@@ -387,6 +425,41 @@ class TestTool(unittest.TestCase):
         ]
 
         self.assertEqual(observed, expected)
+
+    def test_gives_same_dummy_A(self):
+        """Test dummy.pdb is not altered because there are not altlocs."""
+        sys.argv = ['', '-A', os.path.join(data_dir, 'dummy.pdb')]
+        self.exec_module()
+        self.assertEqual(self.retcode, 0)
+        self.assertEqual(len(self.stdout), 203)
+        self.assertEqual(len(self.stderr), 0)
+        self.assertEqual(
+            self.stdout[80],
+            "ATOM      3  CA  ASN A   1      21.411  39.311   0.054  0.40  0.00           C  ")
+
+    def test_gives_same_dummy_B(self):
+        """Test dummy.pdb is not altered because there are not altlocs."""
+        sys.argv = ['', '-B', os.path.join(data_dir, 'dummy.pdb')]
+        self.exec_module()
+        self.assertEqual(self.retcode, 0)
+        self.assertEqual(len(self.stdout), 203)
+        self.assertEqual(len(self.stderr), 0)
+        self.assertEqual(
+            self.stdout[80],
+            "ATOM      3  CA  ASN A   1      20.000  30.000   0.005  0.60  0.00           C  "
+            )
+
+    def test_gives_same_dummy_maxocc(self):
+        """Test dummy.pdb is not altered because there are not altlocs."""
+        sys.argv = ['', os.path.join(data_dir, 'dummy.pdb')]
+        self.exec_module()
+        self.assertEqual(self.retcode, 0)
+        self.assertEqual(len(self.stdout), 203)
+        self.assertEqual(len(self.stderr), 0)
+        self.assertEqual(
+            self.stdout[80],
+            "ATOM      3  CA  ASN A   1      20.000  30.000   0.005  0.60  0.00           C  "
+            )
 
     def test_file_not_found(self):
         """$ pdb_selaltloc not_existing.pdb"""


### PR DESCRIPTION
Closes #115 

This one was tough.

**Done:**
* the previous `pdb_selaltloc` API is maintained
* the previous positive behaviour is maintained (all previous tests pass without change)
* issues reported in #115 are solved. You can run the example and see.
* Added additional tests for `dummy.pdb`. Now `altloc` inside residues, that is `altloc` atoms within residues also work.
* Complete rewrote the internals. Before there were two functions to select `altloc` by identifier or by occupancy. Now there is a single function to collect data from the PDB and two different functions to flush by id or by `occ`. There are two additional functions in case the altloc group to flush belongs to a single residue (technicalities).
* This was possible because determining when we move to the next `altloc` group is done by a boolean expression, hence it is more general and can be used even outside `pdb_selaltloc`.

The script might look more complex at first, but if you flow it is not, simply there are so many cases. We start at one function and we branch down to the `yield` statements. Some yield statements are tricky because of the `ANISOU` extra lines.

@JoaoRodrigues I really can't think about additional cases. You had already many different cases in `dummy_altloc.pdb` and `dummy_altloc2.pdb` and all those are covered.