### PR TITLE
Corrects `selaltloc` for python 2.7 using OrderedDict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         platform: [macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/pdbtools/pdb_selaltloc.py
+++ b/pdbtools/pdb_selaltloc.py
@@ -42,6 +42,11 @@ effort to maintain and compile. RIP.
 import os
 import sys
 
+if sys.version[0] == '2':
+    from collections import OrderedDict
+    dict = OrderedDict
+
+
 __author__ = "Joao Rodrigues"
 __email__ = "j.p.g.l.m.rodrigues@gmail.com"
 
@@ -141,8 +146,8 @@ def select_altloc(fhandle, selloc=None, byocc=False):
     if selloc is None and not byocc:
         raise ValueError('Provide either `selloc` or `byocc`.')
 
-    altloc_lines = {}  # dict to capture the lines from a altloc group
-    res_per_loc = {}  # dict to capture the residues per altloc group
+    altloc_lines = dict()  # dict to capture the lines from a altloc group
+    res_per_loc = dict()  # dict to capture the residues per altloc group
 
     prev_altloc = ''
     prev_resname = ''
@@ -184,8 +189,8 @@ def select_altloc(fhandle, selloc=None, byocc=False):
                 for __line in flush_func(selloc=selloc, altloc_lines=altloc_lines):
                     yield __line
 
-                altloc_lines = {}
-                res_per_loc = {}
+                altloc_lines = dict()
+                res_per_loc = dict()
 
             # saves the line per altloc identifier
             current_loc = altloc_lines.setdefault(altloc, [])
@@ -210,8 +215,8 @@ def select_altloc(fhandle, selloc=None, byocc=False):
                 for __line in flush_func(selloc=selloc, altloc_lines=altloc_lines):
                     yield __line
 
-                altloc_lines = {}
-                res_per_loc = {}
+                altloc_lines = dict()
+                res_per_loc = dict()
 
             prev_altloc = ''
             prev_resname = ''
@@ -238,7 +243,7 @@ def select_altloc(fhandle, selloc=None, byocc=False):
             yield __line
 
         altloc_lines = []
-        res_per_loc = {}
+        res_per_loc = dict()
 
 
 def is_another_altloc_group(
@@ -385,7 +390,7 @@ def _get_sort_atoms(altloc_lines):
         all_lines.extend(lines)
 
     # organize by atoms
-    atoms = {}
+    atoms = dict()
     # key in the dictionary are unique identifiers of the same residue
     for line in all_lines:
         res_number = int(line[22:26])


### PR DESCRIPTION
* Corrects `selaltloc` for python 2.7 using OrderedDict
* add `2.7` in github actions

In the end I thought this was the simplest and cleanest way despite the additional import.