### PR TITLE
Correct `pdb_tidy` when used with lists in lib

### DIFF
--- a/pdbtools/pdb_tidy.py
+++ b/pdbtools/pdb_tidy.py
@@ -125,6 +125,7 @@ def run(fhandle, strict=False):
         The modified (or not) PDB line.
     """
     not_strict = not strict
+    fhandle = iter(fhandle)
 
     def make_TER(prev_line):
         """Creates a TER statement based on the last ATOM/HETATM line.
@@ -148,6 +149,7 @@ def run(fhandle, strict=False):
     prev_line = None
     num_models = 1
     in_model = False
+    #serial = 0
     for line in fhandle:
 
         line = line.strip()  # We will pad/add \n later to make uniform

--- a/pdbtools/pdb_tidy.py
+++ b/pdbtools/pdb_tidy.py
@@ -149,7 +149,6 @@ def run(fhandle, strict=False):
     prev_line = None
     num_models = 1
     in_model = False
-    #serial = 0
     for line in fhandle:
 
         line = line.strip()  # We will pad/add \n later to make uniform

--- a/tests/test_pdb_tidy.py
+++ b/tests/test_pdb_tidy.py
@@ -89,6 +89,43 @@ class TestTool(unittest.TestCase):
         # Check if we added END statements correctly
         self.assertTrue(self.stdout[-1].startswith('END'))
 
+    def test_default_in_lib(self):
+        """
+        Test command-line versus lib.
+
+        $ pdb_tidy data/dummy.pdb
+
+        >>> original_lines = open('dummy.pdb').readlines()
+        >>> lines = list(pdb_tidy.run(original_lines))
+
+        `lines` and the result from the command-line must be the same.
+        """
+
+        fpath = os.path.join(data_dir, 'dummy.pdb')
+        sys.argv = ['', fpath]
+
+        # Execute the script
+        self.exec_module()
+
+        fin = open(os.path.join(data_dir, 'dummy.pdb'))
+        original_lines = fin.readlines()
+        fin.close()
+        lines = list(self.module.run(original_lines))
+
+        self.assertEqual(len(lines), 205)
+        # Check if we added TER statements correctly
+        n_ter = len([r for r in lines if r.startswith('TER')])
+        self.assertEqual(n_ter, 5)
+
+        # Check no CONECT in output
+        c_conect = sum(1 for i in lines if i.startswith('CONECT'))
+        self.assertEqual(c_conect, 0)
+
+        # Check if we added END statements correctly
+        self.assertTrue(lines[-1].startswith('END'))
+
+        self.assertTrue(lines, self.stdout)
+
     def test_tidy_removes_master(self):
         """Test pdb_tidy removes MASTER lines as well."""
         sys.argv = ['']


### PR DESCRIPTION
`pdb_tidy` partially exhausts the `fhandle` iterator to obtain initial information about the PDB. However, when running `pdb_tidy.run` with lists, this "exhaustion" does not work because the list starts from scratch in the second `for`-loop. This PR corrects for this by making the input always an iterator regardless of its type. 