### PR TITLE
Remove support to py3.6

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [2.7, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Actions break because `py36` is dead already—no need to keep supporting it.

* remove support to py3.6
* Use `[SKIP]`