### PR TITLE
fix bug pdb_selaltloc.py

### DIFF
--- a/pdbtools/pdb_selaltloc.py
+++ b/pdbtools/pdb_selaltloc.py
@@ -150,7 +150,7 @@ def select_altloc(fhandle, selloc=None, byocc=False):
 
     prev_altloc = ''
     prev_resname = ''
-    prev_resnum = ''
+    prev_resnum = -float('inf')
 
     # uses the same function names in the loop below. However, depending
     # on the input options, the functions used are different. One is
@@ -170,7 +170,7 @@ def select_altloc(fhandle, selloc=None, byocc=False):
             # captures the relevant parameters
             altloc = line[16]
             resname = line[17:20]
-            resnum = line[22:26].strip()
+            resnum = int(line[22:26].strip())
 
             if is_another_altloc_group(
                     altloc, prev_altloc, resnum, prev_resnum,
@@ -219,14 +219,14 @@ def select_altloc(fhandle, selloc=None, byocc=False):
 
             prev_altloc = ''
             prev_resname = ''
-            prev_resnum = ''
+            prev_resnum = -float('inf')
 
             yield line  # the terminator line
 
         else:
             prev_altloc = ''
             prev_resname = ''
-            prev_resnum = ''
+            prev_resnum = -float('inf')
             yield line
 
     # end of for loop


### PR DESCRIPTION
In function select_altloc(), residue numbers were compared as string. This was causing unexpected behavior in occasion. For example, in this test case, residue 9 was removed in output.
```
ATOM     31  CA  PRO A   5     330.251  77.884  99.983  1.00  9.79           C
ATOM     39  CA ASER A   6     329.416  79.995 103.003  0.11 12.15           C
ATOM     40  CA BSER A   6     329.428  80.056 102.954  0.89 12.06           C
ATOM     50  CA  SER A   7     333.035  80.324 104.142  1.00 12.28           C
ATOM     56  CA  VAL A   8     336.686  79.643 103.388  1.00 12.51           C
ATOM     64  CA ASER A   9     339.751  80.077 105.586  0.25 14.04           C
ATOM     65  CA BSER A   9     339.751  80.141 105.546  0.75 13.93           C
ATOM     75  CA  ALA A  10     343.449  80.372 104.774  1.00 14.02           C
```
The "resnum" and "prev_resnum" got casted to numeric in this pull request.