### PR TITLE
Update build_and_test.yml to remove Py2 images.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Python 2.7 images are no longer supported on GHA, so unfortunately we have to drop them. We should consider drop support for Python 2 completely. I highly doubt many clusters/servers still support it actively.