### PR TITLE
[PATCH] Fixes issue #168 - charge assignment logic

### DIFF
--- a/pdbtools/pdb_fromcif.py
+++ b/pdbtools/pdb_fromcif.py
@@ -176,9 +176,8 @@ def run(fhandle):
             occ = float(fields[labels.get('_atom_site.occupancy')])
             bfactor = float(fields[labels.get('_atom_site.B_iso_or_equiv')])
 
-            charge = fields[labels.get('_atom_site.pdbx_formal_charge')]
             try:
-                charge = charge
+                charge = fields[labels.get('_atom_site.pdbx_formal_charge')]
             except ValueError:
                 charge = '  '
 

--- a/pdbtools/pdb_fromcif.py
+++ b/pdbtools/pdb_fromcif.py
@@ -178,7 +178,7 @@ def run(fhandle):
 
             try:
                 charge = fields[labels.get('_atom_site.pdbx_formal_charge')]
-            except ValueError:
+            except TypeError:
                 charge = '  '
 
             segid = chainid

--- a/tests/data/af3_output.cif
+++ b/tests/data/af3_output.cif
@@ -1,0 +1,5608 @@
+# By using this file you agree to the legally binding terms of use found at
+# https://github.com/google-deepmind/alphafold3/blob/main/OUTPUT_TERMS_OF_USE.md.
+# To request access to the AlphaFold 3 model parameters, follow the process set
+# out at https://github.com/google-deepmind/alphafold3. You may only use these if
+# received directly from Google. Use is subject to terms of use available at
+# https://github.com/google-deepmind/alphafold3/blob/main/WEIGHTS_TERMS_OF_USE.md.
+data_imgvr_pc_000001435
+#
+_entry.id imgvr_pc_000001435
+#
+loop_
+_atom_type.symbol
+C 
+N 
+O 
+S 
+#
+loop_
+_audit_author.name
+_audit_author.pdbx_ordinal
+"Google DeepMind" 1 
+"Isomorphic Labs" 2 
+#
+_audit_conform.dict_location https://raw.githubusercontent.com/ihmwg/ModelCIF/master/dist/mmcif_ma.dic
+_audit_conform.dict_name     mmcif_ma.dic
+_audit_conform.dict_version  1.4.5
+#
+loop_
+_chem_comp.formula
+_chem_comp.formula_weight
+_chem_comp.id
+_chem_comp.mon_nstd_flag
+_chem_comp.name
+_chem_comp.pdbx_smiles
+_chem_comp.pdbx_synonyms
+_chem_comp.type
+"C3 H7 N O2"    89.093  ALA y ALANINE         C[C@@H](C(=O)O)N                     ? "L-PEPTIDE LINKING" 
+"C6 H15 N4 O2"  175.209 ARG y ARGININE        C(C[C@@H](C(=O)O)N)CNC(=[NH2+])N     ? "L-PEPTIDE LINKING" 
+"C4 H8 N2 O3"   132.118 ASN y ASPARAGINE      C([C@@H](C(=O)O)N)C(=O)N             ? "L-PEPTIDE LINKING" 
+"C4 H7 N O4"    133.103 ASP y "ASPARTIC ACID" C([C@@H](C(=O)O)N)C(=O)O             ? "L-PEPTIDE LINKING" 
+"C3 H7 N O2 S"  121.158 CYS y CYSTEINE        C([C@@H](C(=O)O)N)S                  ? "L-PEPTIDE LINKING" 
+"C5 H10 N2 O3"  146.144 GLN y GLUTAMINE       C(CC(=O)N)[C@@H](C(=O)O)N            ? "L-PEPTIDE LINKING" 
+"C5 H9 N O4"    147.129 GLU y "GLUTAMIC ACID" C(CC(=O)O)[C@@H](C(=O)O)N            ? "L-PEPTIDE LINKING" 
+"C2 H5 N O2"    75.067  GLY y GLYCINE         C(C(=O)O)N                           ? "PEPTIDE LINKING"   
+"C6 H10 N3 O2"  156.162 HIS y HISTIDINE       c1c([nH+]c[nH]1)C[C@@H](C(=O)O)N     ? "L-PEPTIDE LINKING" 
+"C6 H13 N O2"   131.173 ILE y ISOLEUCINE      CC[C@H](C)[C@@H](C(=O)O)N            ? "L-PEPTIDE LINKING" 
+"C6 H13 N O2"   131.173 LEU y LEUCINE         CC(C)C[C@@H](C(=O)O)N                ? "L-PEPTIDE LINKING" 
+"C6 H15 N2 O2"  147.195 LYS y LYSINE          C(CC[NH3+])C[C@@H](C(=O)O)N          ? "L-PEPTIDE LINKING" 
+"C5 H11 N O2 S" 149.211 MET y METHIONINE      CSCC[C@@H](C(=O)O)N                  ? "L-PEPTIDE LINKING" 
+"C9 H11 N O2"   165.189 PHE y PHENYLALANINE   c1ccc(cc1)C[C@@H](C(=O)O)N           ? "L-PEPTIDE LINKING" 
+"C5 H9 N O2"    115.130 PRO y PROLINE         C1C[C@H](NC1)C(=O)O                  ? "L-PEPTIDE LINKING" 
+"C3 H7 N O3"    105.093 SER y SERINE          C([C@@H](C(=O)O)N)O                  ? "L-PEPTIDE LINKING" 
+"C4 H9 N O3"    119.119 THR y THREONINE       C[C@H]([C@@H](C(=O)O)N)O             ? "L-PEPTIDE LINKING" 
+"C11 H12 N2 O2" 204.225 TRP y TRYPTOPHAN      c1ccc2c(c1)c(c[nH]2)C[C@@H](C(=O)O)N ? "L-PEPTIDE LINKING" 
+"C9 H11 N O3"   181.189 TYR y TYROSINE        c1cc(ccc1C[C@@H](C(=O)O)N)O          ? "L-PEPTIDE LINKING" 
+"C5 H11 N O2"   117.146 VAL y VALINE          CC(C)[C@@H](C(=O)O)N                 ? "L-PEPTIDE LINKING" 
+#
+_citation.book_publisher          ?
+_citation.country                 UK
+_citation.id                      primary
+_citation.journal_full            Nature
+_citation.journal_id_ASTM         NATUAS
+_citation.journal_id_CSD          0006
+_citation.journal_id_ISSN         0028-0836
+_citation.journal_volume          630
+_citation.page_first              493
+_citation.page_last               500
+_citation.pdbx_database_id_DOI    10.1038/s41586-024-07487-w
+_citation.pdbx_database_id_PubMed 38718835
+_citation.title                   "Accurate structure prediction of biomolecular interactions with AlphaFold 3"
+_citation.year                    2024
+#
+loop_
+_citation_author.citation_id
+_citation_author.name
+_citation_author.ordinal
+primary "Google DeepMind" 1 
+primary "Isomorphic Labs" 2 
+#
+_entity.id               1
+_entity.pdbx_description .
+_entity.type             polymer
+#
+_entity_poly.entity_id      1
+_entity_poly.pdbx_strand_id A
+_entity_poly.type           polypeptide(L)
+#
+loop_
+_entity_poly_seq.entity_id
+_entity_poly_seq.hetero
+_entity_poly_seq.mon_id
+_entity_poly_seq.num
+1 n VAL 1   
+1 n LEU 2   
+1 n THR 3   
+1 n LYS 4   
+1 n GLY 5   
+1 n ARG 6   
+1 n LYS 7   
+1 n ILE 8   
+1 n ILE 9   
+1 n LYS 10  
+1 n VAL 11  
+1 n ASP 12  
+1 n VAL 13  
+1 n SER 14  
+1 n ARG 15  
+1 n ASN 16  
+1 n GLU 17  
+1 n LEU 18  
+1 n GLU 19  
+1 n ASN 20  
+1 n VAL 21  
+1 n ASN 22  
+1 n THR 23  
+1 n VAL 24  
+1 n CYS 25  
+1 n ASN 26  
+1 n VAL 27  
+1 n ILE 28  
+1 n ASN 29  
+1 n SER 30  
+1 n ALA 31  
+1 n PHE 32  
+1 n PRO 33  
+1 n VAL 34  
+1 n HIS 35  
+1 n LEU 36  
+1 n LYS 37  
+1 n ASN 38  
+1 n LYS 39  
+1 n ILE 40  
+1 n GLU 41  
+1 n ILE 42  
+1 n ASP 43  
+1 n TYR 44  
+1 n LEU 45  
+1 n MET 46  
+1 n ASP 47  
+1 n TYR 48  
+1 n TYR 49  
+1 n LYS 50  
+1 n GLY 51  
+1 n ASN 52  
+1 n GLN 53  
+1 n PRO 54  
+1 n ILE 55  
+1 n LEU 56  
+1 n ASN 57  
+1 n LYS 58  
+1 n VAL 59  
+1 n LYS 60  
+1 n GLU 61  
+1 n ILE 62  
+1 n ARG 63  
+1 n SER 64  
+1 n GLU 65  
+1 n ILE 66  
+1 n ASN 67  
+1 n ASN 68  
+1 n LYS 69  
+1 n LEU 70  
+1 n VAL 71  
+1 n LEU 72  
+1 n ASN 73  
+1 n HIS 74  
+1 n ALA 75  
+1 n GLN 76  
+1 n MET 77  
+1 n ILE 78  
+1 n THR 79  
+1 n ARG 80  
+1 n LYS 81  
+1 n ILE 82  
+1 n VAL 83  
+1 n GLY 84  
+1 n TYR 85  
+1 n PHE 86  
+1 n LEU 87  
+1 n GLY 88  
+1 n ASN 89  
+1 n PRO 90  
+1 n ILE 91  
+1 n GLN 92  
+1 n TYR 93  
+1 n ILE 94  
+1 n PRO 95  
+1 n SER 96  
+1 n GLY 97  
+1 n ILE 98  
+1 n SER 99  
+1 n LYS 100 
+1 n LYS 101 
+1 n LYS 102 
+1 n GLU 103 
+1 n LEU 104 
+1 n ILE 105 
+1 n ASP 106 
+1 n GLU 107 
+1 n LEU 108 
+1 n ASN 109 
+1 n ILE 110 
+1 n TYR 111 
+1 n THR 112 
+1 n GLN 113 
+1 n TYR 114 
+1 n GLU 115 
+1 n ASN 116 
+1 n LYS 117 
+1 n ALA 118 
+1 n SER 119 
+1 n VAL 120 
+1 n ASP 121 
+1 n LYS 122 
+1 n GLU 123 
+1 n LEU 124 
+1 n GLY 125 
+1 n GLU 126 
+1 n TYR 127 
+1 n GLN 128 
+1 n SER 129 
+1 n ILE 130 
+1 n CYS 131 
+1 n GLY 132 
+1 n THR 133 
+1 n ALA 134 
+1 n TYR 135 
+1 n ARG 136 
+1 n ILE 137 
+1 n ILE 138 
+1 n TYR 139 
+1 n ARG 140 
+1 n ASP 141 
+1 n GLY 142 
+1 n ASP 143 
+1 n PHE 144 
+1 n THR 145 
+1 n GLY 146 
+1 n ARG 147 
+1 n LYS 148 
+1 n ASN 149 
+1 n ASP 150 
+1 n THR 151 
+1 n VAL 152 
+1 n PRO 153 
+1 n PHE 154 
+1 n GLU 155 
+1 n ASP 156 
+1 n ARG 157 
+1 n ALA 158 
+1 n LEU 159 
+1 n ASP 160 
+1 n PRO 161 
+1 n SER 162 
+1 n THR 163 
+1 n THR 164 
+1 n PHE 165 
+1 n MET 166 
+1 n VAL 167 
+1 n TYR 168 
+1 n GLU 169 
+1 n SER 170 
+1 n ASN 171 
+1 n ILE 172 
+1 n SER 173 
+1 n GLY 174 
+1 n TYR 175 
+1 n PRO 176 
+1 n LEU 177 
+1 n LEU 178 
+1 n GLY 179 
+1 n VAL 180 
+1 n THR 181 
+1 n TYR 182 
+1 n TYR 183 
+1 n ASP 184 
+1 n VAL 185 
+1 n TYR 186 
+1 n ASP 187 
+1 n ALA 188 
+1 n ASP 189 
+1 n GLY 190 
+1 n LYS 191 
+1 n PHE 192 
+1 n LYS 193 
+1 n GLY 194 
+1 n ILE 195 
+1 n ARG 196 
+1 n LEU 197 
+1 n TYR 198 
+1 n ALA 199 
+1 n TYR 200 
+1 n SER 201 
+1 n ASP 202 
+1 n PHE 203 
+1 n GLY 204 
+1 n ARG 205 
+1 n TYR 206 
+1 n GLU 207 
+1 n PHE 208 
+1 n ILE 209 
+1 n SER 210 
+1 n ASP 211 
+1 n GLY 212 
+1 n LEU 213 
+1 n GLU 214 
+1 n PRO 215 
+1 n LEU 216 
+1 n SER 217 
+1 n GLU 218 
+1 n ASP 219 
+1 n ASN 220 
+1 n LEU 221 
+1 n VAL 222 
+1 n GLU 223 
+1 n PHE 224 
+1 n ILE 225 
+1 n PRO 226 
+1 n TYR 227 
+1 n ASN 228 
+1 n VAL 229 
+1 n GLY 230 
+1 n GLY 231 
+1 n ILE 232 
+1 n PRO 233 
+1 n ILE 234 
+1 n ILE 235 
+1 n GLU 236 
+1 n TYR 237 
+1 n PRO 238 
+1 n ASN 239 
+1 n ASN 240 
+1 n SER 241 
+1 n TRP 242 
+1 n ARG 243 
+1 n ILE 244 
+1 n GLY 245 
+1 n ASP 246 
+1 n TRP 247 
+1 n GLU 248 
+1 n LEU 249 
+1 n VAL 250 
+1 n ILE 251 
+1 n GLY 252 
+1 n LEU 253 
+1 n MET 254 
+1 n ASP 255 
+1 n ALA 256 
+1 n ILE 257 
+1 n ASN 258 
+1 n GLU 259 
+1 n LEU 260 
+1 n ASN 261 
+1 n SER 262 
+1 n GLY 263 
+1 n ARG 264 
+1 n LEU 265 
+1 n ASP 266 
+1 n ASP 267 
+1 n ILE 268 
+1 n GLU 269 
+1 n GLN 270 
+1 n VAL 271 
+1 n ILE 272 
+1 n GLN 273 
+1 n SER 274 
+1 n LEU 275 
+1 n ILE 276 
+1 n VAL 277 
+1 n PHE 278 
+1 n LEU 279 
+1 n ASN 280 
+1 n ALA 281 
+1 n GLU 282 
+1 n ILE 283 
+1 n ASP 284 
+1 n SER 285 
+1 n GLU 286 
+1 n THR 287 
+1 n TYR 288 
+1 n ASP 289 
+1 n GLU 290 
+1 n MET 291 
+1 n ARG 292 
+1 n ARG 293 
+1 n GLN 294 
+1 n GLY 295 
+1 n VAL 296 
+1 n VAL 297 
+1 n MET 298 
+1 n LEU 299 
+1 n ASN 300 
+1 n SER 301 
+1 n SER 302 
+1 n GLU 303 
+1 n ASN 304 
+1 n LEU 305 
+1 n LYS 306 
+1 n SER 307 
+1 n ASP 308 
+1 n VAL 309 
+1 n LYS 310 
+1 n THR 311 
+1 n ILE 312 
+1 n VAL 313 
+1 n ASN 314 
+1 n GLN 315 
+1 n LEU 316 
+1 n ASP 317 
+1 n GLN 318 
+1 n ASN 319 
+1 n GLY 320 
+1 n MET 321 
+1 n ASN 322 
+1 n LEU 323 
+1 n PHE 324 
+1 n ALA 325 
+1 n GLN 326 
+1 n GLU 327 
+1 n LEU 328 
+1 n GLU 329 
+1 n GLU 330 
+1 n LEU 331 
+1 n LEU 332 
+1 n TYR 333 
+1 n SER 334 
+1 n LEU 335 
+1 n VAL 336 
+1 n GLY 337 
+1 n VAL 338 
+1 n PRO 339 
+1 n SER 340 
+1 n ARG 341 
+1 n HIS 342 
+1 n ASP 343 
+1 n GLY 344 
+1 n ALA 345 
+1 n SER 346 
+1 n GLY 347 
+1 n GLY 348 
+1 n ASP 349 
+1 n THR 350 
+1 n GLY 351 
+1 n LEU 352 
+1 n ALA 353 
+1 n ILE 354 
+1 n GLU 355 
+1 n LEU 356 
+1 n ARG 357 
+1 n ASP 358 
+1 n GLY 359 
+1 n TRP 360 
+1 n ALA 361 
+1 n ASP 362 
+1 n LEU 363 
+1 n GLU 364 
+1 n ILE 365 
+1 n ILE 366 
+1 n CYS 367 
+1 n LYS 368 
+1 n ASN 369 
+1 n LYS 370 
+1 n GLU 371 
+1 n LEU 372 
+1 n ILE 373 
+1 n PHE 374 
+1 n LYS 375 
+1 n GLU 376 
+1 n SER 377 
+1 n GLU 378 
+1 n LYS 379 
+1 n LYS 380 
+1 n THR 381 
+1 n LEU 382 
+1 n ASN 383 
+1 n ILE 384 
+1 n LEU 385 
+1 n LEU 386 
+1 n HIS 387 
+1 n ILE 388 
+1 n PHE 389 
+1 n ASN 390 
+1 n ILE 391 
+1 n GLY 392 
+1 n ARG 393 
+1 n SER 394 
+1 n GLU 395 
+1 n LYS 396 
+1 n LEU 397 
+1 n ASP 398 
+1 n LYS 399 
+1 n LEU 400 
+1 n ASP 401 
+1 n LEU 402 
+1 n ASP 403 
+1 n ILE 404 
+1 n LYS 405 
+1 n PHE 406 
+1 n SER 407 
+1 n ARG 408 
+1 n ASN 409 
+1 n LYS 410 
+1 n ASN 411 
+1 n ASN 412 
+1 n ASN 413 
+1 n LEU 414 
+1 n LEU 415 
+1 n VAL 416 
+1 n LYS 417 
+1 n THR 418 
+1 n GLN 419 
+1 n SER 420 
+1 n TYR 421 
+1 n GLN 422 
+1 n SER 423 
+1 n LEU 424 
+1 n LEU 425 
+1 n SER 426 
+1 n THR 427 
+1 n ARG 428 
+1 n THR 429 
+1 n LEU 430 
+1 n SER 431 
+1 n PRO 432 
+1 n GLU 433 
+1 n ASP 434 
+1 n CYS 435 
+1 n LEU 436 
+1 n SER 437 
+1 n ILE 438 
+1 n VAL 439 
+1 n ASP 440 
+1 n LEU 441 
+1 n VAL 442 
+1 n SER 443 
+1 n ASP 444 
+1 n PRO 445 
+1 n ASN 446 
+1 n ASP 447 
+1 n TYR 448 
+1 n ILE 449 
+1 n GLU 450 
+1 n ARG 451 
+1 n GLY 452 
+1 n LEU 453 
+1 n ALA 454 
+1 n PHE 455 
+1 n TRP 456 
+1 n GLU 457 
+1 n LYS 458 
+1 n ARG 459 
+1 n GLU 460 
+1 n THR 461 
+1 n GLU 462 
+1 n GLU 463 
+1 n VAL 464 
+1 n SER 465 
+1 n GLU 466 
+1 n ASN 467 
+1 n GLY 468 
+1 n LEU 469 
+1 n LEU 470 
+1 n ASP 471 
+1 n ASP 472 
+1 n VAL 473 
+1 n GLU 474 
+1 n LYS 475 
+1 n GLY 476 
+1 n ASP 477 
+1 n GLU 478 
+1 n GLY 479 
+1 n ASN 480 
+1 n ASN 481 
+1 n ASP 482 
+1 n SER 483 
+1 n VAL 484 
+1 n ASP 485 
+1 n SER 486 
+1 n PRO 487 
+1 n ILE 488 
+1 n ILE 489 
+1 n ASN 490 
+#
+_ma_data.content_type "model coordinates"
+_ma_data.id           1
+_ma_data.name         Model
+#
+_ma_model_list.data_id          1
+_ma_model_list.model_group_id   1
+_ma_model_list.model_group_name "AlphaFold-beta-20231127 (3.0.0 @ 2025-05-20 20:08:58)"
+_ma_model_list.model_id         1
+_ma_model_list.model_name       "Top ranked model"
+_ma_model_list.model_type       "Ab initio model"
+_ma_model_list.ordinal_id       1
+#
+loop_
+_ma_protocol_step.method_type
+_ma_protocol_step.ordinal_id
+_ma_protocol_step.protocol_id
+_ma_protocol_step.step_id
+"coevolution MSA" 1 1 1 
+"template search" 2 1 2 
+modeling          3 1 3 
+#
+loop_
+_ma_qa_metric.id
+_ma_qa_metric.mode
+_ma_qa_metric.name
+_ma_qa_metric.software_group_id
+_ma_qa_metric.type
+1 global pLDDT 1 pLDDT 
+2 local  pLDDT 1 pLDDT 
+#
+_ma_qa_metric_global.metric_id    1
+_ma_qa_metric_global.metric_value 83.24
+_ma_qa_metric_global.model_id     1
+_ma_qa_metric_global.ordinal_id   1
+#
+loop_
+_ma_qa_metric_local.label_asym_id
+_ma_qa_metric_local.label_comp_id
+_ma_qa_metric_local.label_seq_id
+_ma_qa_metric_local.metric_id
+_ma_qa_metric_local.metric_value
+_ma_qa_metric_local.model_id
+_ma_qa_metric_local.ordinal_id
+A VAL 1   2 68.17 1 1   
+A LEU 2   2 71.41 1 2   
+A THR 3   2 81.23 1 3   
+A LYS 4   2 80.33 1 4   
+A GLY 5   2 95.21 1 5   
+A ARG 6   2 94.98 1 6   
+A LYS 7   2 86.30 1 7   
+A ILE 8   2 96.24 1 8   
+A ILE 9   2 97.67 1 9   
+A LYS 10  2 93.52 1 10  
+A VAL 11  2 94.53 1 11  
+A ASP 12  2 91.27 1 12  
+A VAL 13  2 92.21 1 13  
+A SER 14  2 89.88 1 14  
+A ARG 15  2 76.36 1 15  
+A ASN 16  2 86.40 1 16  
+A GLU 17  2 88.05 1 17  
+A LEU 18  2 89.95 1 18  
+A GLU 19  2 82.05 1 19  
+A ASN 20  2 88.85 1 20  
+A VAL 21  2 92.23 1 21  
+A ASN 22  2 88.15 1 22  
+A THR 23  2 94.18 1 23  
+A VAL 24  2 95.29 1 24  
+A CYS 25  2 95.62 1 25  
+A ASN 26  2 91.86 1 26  
+A VAL 27  2 96.35 1 27  
+A ILE 28  2 95.80 1 28  
+A ASN 29  2 94.34 1 29  
+A SER 30  2 93.51 1 30  
+A ALA 31  2 96.54 1 31  
+A PHE 32  2 92.07 1 32  
+A PRO 33  2 95.52 1 33  
+A VAL 34  2 96.69 1 34  
+A HIS 35  2 95.51 1 35  
+A LEU 36  2 93.28 1 36  
+A LYS 37  2 86.54 1 37  
+A ASN 38  2 96.77 1 38  
+A LYS 39  2 94.59 1 39  
+A ILE 40  2 94.90 1 40  
+A GLU 41  2 95.51 1 41  
+A ILE 42  2 97.69 1 42  
+A ASP 43  2 96.30 1 43  
+A TYR 44  2 96.97 1 44  
+A LEU 45  2 97.74 1 45  
+A MET 46  2 93.44 1 46  
+A ASP 47  2 95.88 1 47  
+A TYR 48  2 97.95 1 48  
+A TYR 49  2 98.05 1 49  
+A LYS 50  2 95.32 1 50  
+A GLY 51  2 97.78 1 51  
+A ASN 52  2 95.25 1 52  
+A GLN 53  2 96.86 1 53  
+A PRO 54  2 97.62 1 54  
+A ILE 55  2 97.37 1 55  
+A LEU 56  2 97.20 1 56  
+A ASN 57  2 94.30 1 57  
+A LYS 58  2 94.20 1 58  
+A VAL 59  2 94.18 1 59  
+A LYS 60  2 85.08 1 60  
+A GLU 61  2 79.81 1 61  
+A ILE 62  2 77.70 1 62  
+A ARG 63  2 72.48 1 63  
+A SER 64  2 85.44 1 64  
+A GLU 65  2 81.91 1 65  
+A ILE 66  2 86.77 1 66  
+A ASN 67  2 93.17 1 67  
+A ASN 68  2 93.32 1 68  
+A LYS 69  2 95.05 1 69  
+A LEU 70  2 92.50 1 70  
+A VAL 71  2 96.96 1 71  
+A LEU 72  2 95.39 1 72  
+A ASN 73  2 96.42 1 73  
+A HIS 74  2 93.89 1 74  
+A ALA 75  2 98.01 1 75  
+A GLN 76  2 88.83 1 76  
+A MET 77  2 91.98 1 77  
+A ILE 78  2 97.46 1 78  
+A THR 79  2 97.56 1 79  
+A ARG 80  2 90.56 1 80  
+A LYS 81  2 90.66 1 81  
+A ILE 82  2 96.88 1 82  
+A VAL 83  2 97.53 1 83  
+A GLY 84  2 95.65 1 84  
+A TYR 85  2 91.43 1 85  
+A PHE 86  2 95.74 1 86  
+A LEU 87  2 96.01 1 87  
+A GLY 88  2 93.33 1 88  
+A ASN 89  2 89.98 1 89  
+A PRO 90  2 94.32 1 90  
+A ILE 91  2 95.84 1 91  
+A GLN 92  2 85.43 1 92  
+A TYR 93  2 95.41 1 93  
+A ILE 94  2 89.32 1 94  
+A PRO 95  2 89.86 1 95  
+A SER 96  2 83.19 1 96  
+A GLY 97  2 79.41 1 97  
+A ILE 98  2 69.61 1 98  
+A SER 99  2 73.95 1 99  
+A LYS 100 2 71.32 1 100 
+A LYS 101 2 87.81 1 101 
+A LYS 102 2 81.55 1 102 
+A GLU 103 2 83.21 1 103 
+A LEU 104 2 92.17 1 104 
+A ILE 105 2 93.57 1 105 
+A ASP 106 2 91.09 1 106 
+A GLU 107 2 90.35 1 107 
+A LEU 108 2 94.95 1 108 
+A ASN 109 2 93.75 1 109 
+A ILE 110 2 92.91 1 110 
+A TYR 111 2 92.04 1 111 
+A THR 112 2 93.38 1 112 
+A GLN 113 2 86.19 1 113 
+A TYR 114 2 77.65 1 114 
+A GLU 115 2 86.01 1 115 
+A ASN 116 2 88.91 1 116 
+A LYS 117 2 94.69 1 117 
+A ALA 118 2 97.14 1 118 
+A SER 119 2 94.99 1 119 
+A VAL 120 2 97.20 1 120 
+A ASP 121 2 97.42 1 121 
+A LYS 122 2 92.82 1 122 
+A GLU 123 2 94.65 1 123 
+A LEU 124 2 97.48 1 124 
+A GLY 125 2 98.46 1 125 
+A GLU 126 2 95.76 1 126 
+A TYR 127 2 97.85 1 127 
+A GLN 128 2 95.12 1 128 
+A SER 129 2 97.86 1 129 
+A ILE 130 2 98.05 1 130 
+A CYS 131 2 96.44 1 131 
+A GLY 132 2 98.04 1 132 
+A THR 133 2 96.66 1 133 
+A ALA 134 2 98.43 1 134 
+A TYR 135 2 98.27 1 135 
+A ARG 136 2 95.80 1 136 
+A ILE 137 2 94.64 1 137 
+A ILE 138 2 90.09 1 138 
+A TYR 139 2 81.46 1 139 
+A ARG 140 2 70.48 1 140 
+A ASP 141 2 67.71 1 141 
+A GLY 142 2 66.75 1 142 
+A ASP 143 2 62.95 1 143 
+A PHE 144 2 59.83 1 144 
+A THR 145 2 47.82 1 145 
+A GLY 146 2 57.73 1 146 
+A ARG 147 2 52.61 1 147 
+A LYS 148 2 55.48 1 148 
+A ASN 149 2 65.76 1 149 
+A ASP 150 2 73.06 1 150 
+A THR 151 2 77.25 1 151 
+A VAL 152 2 83.79 1 152 
+A PRO 153 2 84.14 1 153 
+A PHE 154 2 88.35 1 154 
+A GLU 155 2 82.09 1 155 
+A ASP 156 2 91.01 1 156 
+A ARG 157 2 78.44 1 157 
+A ALA 158 2 97.15 1 158 
+A LEU 159 2 97.07 1 159 
+A ASP 160 2 96.28 1 160 
+A PRO 161 2 97.74 1 161 
+A SER 162 2 95.25 1 162 
+A THR 163 2 96.20 1 163 
+A THR 164 2 97.07 1 164 
+A PHE 165 2 97.63 1 165 
+A MET 166 2 93.44 1 166 
+A VAL 167 2 97.73 1 167 
+A TYR 168 2 97.30 1 168 
+A GLU 169 2 90.47 1 169 
+A SER 170 2 92.61 1 170 
+A ASN 171 2 89.99 1 171 
+A ILE 172 2 90.20 1 172 
+A SER 173 2 90.18 1 173 
+A GLY 174 2 93.85 1 174 
+A TYR 175 2 83.06 1 175 
+A PRO 176 2 95.04 1 176 
+A LEU 177 2 94.86 1 177 
+A LEU 178 2 94.43 1 178 
+A GLY 179 2 97.08 1 179 
+A VAL 180 2 97.04 1 180 
+A THR 181 2 94.24 1 181 
+A TYR 182 2 95.55 1 182 
+A TYR 183 2 78.43 1 183 
+A ASP 184 2 89.66 1 184 
+A VAL 185 2 88.80 1 185 
+A TYR 186 2 88.04 1 186 
+A ASP 187 2 82.69 1 187 
+A ALA 188 2 89.93 1 188 
+A ASP 189 2 87.20 1 189 
+A GLY 190 2 89.37 1 190 
+A LYS 191 2 80.20 1 191 
+A PHE 192 2 86.13 1 192 
+A LYS 193 2 78.73 1 193 
+A GLY 194 2 91.15 1 194 
+A ILE 195 2 88.43 1 195 
+A ARG 196 2 86.09 1 196 
+A LEU 197 2 91.60 1 197 
+A TYR 198 2 91.97 1 198 
+A ALA 199 2 95.52 1 199 
+A TYR 200 2 93.66 1 200 
+A SER 201 2 93.25 1 201 
+A ASP 202 2 87.67 1 202 
+A PHE 203 2 87.26 1 203 
+A GLY 204 2 90.27 1 204 
+A ARG 205 2 84.78 1 205 
+A TYR 206 2 93.23 1 206 
+A GLU 207 2 88.47 1 207 
+A PHE 208 2 94.56 1 208 
+A ILE 209 2 87.20 1 209 
+A SER 210 2 88.54 1 210 
+A ASP 211 2 79.78 1 211 
+A GLY 212 2 76.56 1 212 
+A LEU 213 2 65.06 1 213 
+A GLU 214 2 71.06 1 214 
+A PRO 215 2 86.81 1 215 
+A LEU 216 2 88.29 1 216 
+A SER 217 2 88.93 1 217 
+A GLU 218 2 82.06 1 218 
+A ASP 219 2 86.73 1 219 
+A ASN 220 2 88.95 1 220 
+A LEU 221 2 91.15 1 221 
+A VAL 222 2 89.24 1 222 
+A GLU 223 2 84.37 1 223 
+A PHE 224 2 88.53 1 224 
+A ILE 225 2 83.97 1 225 
+A PRO 226 2 83.86 1 226 
+A TYR 227 2 67.73 1 227 
+A ASN 228 2 75.98 1 228 
+A VAL 229 2 83.87 1 229 
+A GLY 230 2 88.53 1 230 
+A GLY 231 2 91.52 1 231 
+A ILE 232 2 93.94 1 232 
+A PRO 233 2 95.07 1 233 
+A ILE 234 2 96.79 1 234 
+A ILE 235 2 95.78 1 235 
+A GLU 236 2 97.30 1 236 
+A TYR 237 2 98.14 1 237 
+A PRO 238 2 97.96 1 238 
+A ASN 239 2 96.79 1 239 
+A ASN 240 2 96.56 1 240 
+A SER 241 2 94.98 1 241 
+A TRP 242 2 93.04 1 242 
+A ARG 243 2 94.67 1 243 
+A ILE 244 2 96.62 1 244 
+A GLY 245 2 97.93 1 245 
+A ASP 246 2 97.18 1 246 
+A TRP 247 2 97.84 1 247 
+A GLU 248 2 96.66 1 248 
+A LEU 249 2 96.12 1 249 
+A VAL 250 2 97.18 1 250 
+A ILE 251 2 97.21 1 251 
+A GLY 252 2 97.55 1 252 
+A LEU 253 2 95.99 1 253 
+A MET 254 2 96.81 1 254 
+A ASP 255 2 97.05 1 255 
+A ALA 256 2 97.80 1 256 
+A ILE 257 2 96.91 1 257 
+A ASN 258 2 96.40 1 258 
+A GLU 259 2 88.45 1 259 
+A LEU 260 2 93.94 1 260 
+A ASN 261 2 92.91 1 261 
+A SER 262 2 94.72 1 262 
+A GLY 263 2 92.93 1 263 
+A ARG 264 2 83.52 1 264 
+A LEU 265 2 88.83 1 265 
+A ASP 266 2 90.02 1 266 
+A ASP 267 2 82.98 1 267 
+A ILE 268 2 85.52 1 268 
+A GLU 269 2 81.99 1 269 
+A GLN 270 2 78.58 1 270 
+A VAL 271 2 79.65 1 271 
+A ILE 272 2 77.81 1 272 
+A GLN 273 2 74.06 1 273 
+A SER 274 2 74.08 1 274 
+A LEU 275 2 70.11 1 275 
+A ILE 276 2 72.36 1 276 
+A VAL 277 2 77.10 1 277 
+A PHE 278 2 78.03 1 278 
+A LEU 279 2 78.82 1 279 
+A ASN 280 2 79.33 1 280 
+A ALA 281 2 80.36 1 281 
+A GLU 282 2 75.48 1 282 
+A ILE 283 2 77.50 1 283 
+A ASP 284 2 82.68 1 284 
+A SER 285 2 84.48 1 285 
+A GLU 286 2 80.08 1 286 
+A THR 287 2 81.80 1 287 
+A TYR 288 2 77.63 1 288 
+A ASP 289 2 79.61 1 289 
+A GLU 290 2 74.38 1 290 
+A MET 291 2 74.86 1 291 
+A ARG 292 2 67.63 1 292 
+A ARG 293 2 69.85 1 293 
+A GLN 294 2 74.93 1 294 
+A GLY 295 2 75.81 1 295 
+A VAL 296 2 74.02 1 296 
+A VAL 297 2 73.19 1 297 
+A MET 298 2 71.18 1 298 
+A LEU 299 2 72.41 1 299 
+A ASN 300 2 73.88 1 300 
+A SER 301 2 75.88 1 301 
+A SER 302 2 77.08 1 302 
+A GLU 303 2 73.79 1 303 
+A ASN 304 2 78.00 1 304 
+A LEU 305 2 76.50 1 305 
+A LYS 306 2 73.50 1 306 
+A SER 307 2 78.59 1 307 
+A ASP 308 2 80.17 1 308 
+A VAL 309 2 79.33 1 309 
+A LYS 310 2 74.30 1 310 
+A THR 311 2 75.01 1 311 
+A ILE 312 2 70.97 1 312 
+A VAL 313 2 68.81 1 313 
+A ASN 314 2 68.31 1 314 
+A GLN 315 2 65.83 1 315 
+A LEU 316 2 72.44 1 316 
+A ASP 317 2 80.23 1 317 
+A GLN 318 2 76.42 1 318 
+A ASN 319 2 82.47 1 319 
+A GLY 320 2 90.12 1 320 
+A MET 321 2 83.88 1 321 
+A ASN 322 2 86.76 1 322 
+A LEU 323 2 88.05 1 323 
+A PHE 324 2 92.67 1 324 
+A ALA 325 2 94.00 1 325 
+A GLN 326 2 88.05 1 326 
+A GLU 327 2 87.96 1 327 
+A LEU 328 2 95.84 1 328 
+A GLU 329 2 90.23 1 329 
+A GLU 330 2 85.76 1 330 
+A LEU 331 2 92.67 1 331 
+A LEU 332 2 96.58 1 332 
+A TYR 333 2 89.67 1 333 
+A SER 334 2 91.57 1 334 
+A LEU 335 2 95.49 1 335 
+A VAL 336 2 94.57 1 336 
+A GLY 337 2 94.00 1 337 
+A VAL 338 2 91.66 1 338 
+A PRO 339 2 88.91 1 339 
+A SER 340 2 81.83 1 340 
+A ARG 341 2 63.83 1 341 
+A HIS 342 2 55.73 1 342 
+A ASP 343 2 45.01 1 343 
+A GLY 344 2 54.05 1 344 
+A ALA 345 2 50.31 1 345 
+A SER 346 2 48.71 1 346 
+A GLY 347 2 57.09 1 347 
+A GLY 348 2 60.62 1 348 
+A ASP 349 2 53.23 1 349 
+A THR 350 2 60.35 1 350 
+A GLY 351 2 60.71 1 351 
+A LEU 352 2 58.41 1 352 
+A ALA 353 2 65.03 1 353 
+A ILE 354 2 60.83 1 354 
+A GLU 355 2 56.86 1 355 
+A LEU 356 2 55.16 1 356 
+A ARG 357 2 47.58 1 357 
+A ASP 358 2 58.85 1 358 
+A GLY 359 2 80.36 1 359 
+A TRP 360 2 78.18 1 360 
+A ALA 361 2 86.65 1 361 
+A ASP 362 2 89.04 1 362 
+A LEU 363 2 92.40 1 363 
+A GLU 364 2 86.75 1 364 
+A ILE 365 2 92.59 1 365 
+A ILE 366 2 94.06 1 366 
+A CYS 367 2 94.97 1 367 
+A LYS 368 2 87.43 1 368 
+A ASN 369 2 94.13 1 369 
+A LYS 370 2 94.88 1 370 
+A GLU 371 2 91.80 1 371 
+A LEU 372 2 95.63 1 372 
+A ILE 373 2 94.54 1 373 
+A PHE 374 2 97.83 1 374 
+A LYS 375 2 92.19 1 375 
+A GLU 376 2 89.92 1 376 
+A SER 377 2 97.69 1 377 
+A GLU 378 2 95.54 1 378 
+A LYS 379 2 92.62 1 379 
+A LYS 380 2 93.77 1 380 
+A THR 381 2 95.90 1 381 
+A LEU 382 2 93.48 1 382 
+A ASN 383 2 89.26 1 383 
+A ILE 384 2 92.78 1 384 
+A LEU 385 2 93.59 1 385 
+A LEU 386 2 94.44 1 386 
+A HIS 387 2 89.35 1 387 
+A ILE 388 2 91.33 1 388 
+A PHE 389 2 93.31 1 389 
+A ASN 390 2 92.24 1 390 
+A ILE 391 2 86.92 1 391 
+A GLY 392 2 88.00 1 392 
+A ARG 393 2 87.59 1 393 
+A SER 394 2 90.51 1 394 
+A GLU 395 2 84.40 1 395 
+A LYS 396 2 88.50 1 396 
+A LEU 397 2 91.49 1 397 
+A ASP 398 2 88.04 1 398 
+A LYS 399 2 85.66 1 399 
+A LEU 400 2 90.25 1 400 
+A ASP 401 2 91.61 1 401 
+A LEU 402 2 89.70 1 402 
+A ASP 403 2 89.22 1 403 
+A ILE 404 2 94.64 1 404 
+A LYS 405 2 82.96 1 405 
+A PHE 406 2 93.76 1 406 
+A SER 407 2 85.89 1 407 
+A ARG 408 2 79.69 1 408 
+A ASN 409 2 63.78 1 409 
+A LYS 410 2 58.23 1 410 
+A ASN 411 2 58.65 1 411 
+A ASN 412 2 58.33 1 412 
+A ASN 413 2 64.02 1 413 
+A LEU 414 2 69.19 1 414 
+A LEU 415 2 73.00 1 415 
+A VAL 416 2 74.69 1 416 
+A LYS 417 2 71.92 1 417 
+A THR 418 2 77.57 1 418 
+A GLN 419 2 72.76 1 419 
+A SER 420 2 81.44 1 420 
+A TYR 421 2 82.09 1 421 
+A GLN 422 2 77.97 1 422 
+A SER 423 2 79.06 1 423 
+A LEU 424 2 78.69 1 424 
+A LEU 425 2 77.38 1 425 
+A SER 426 2 79.58 1 426 
+A THR 427 2 78.98 1 427 
+A ARG 428 2 75.78 1 428 
+A THR 429 2 80.79 1 429 
+A LEU 430 2 76.31 1 430 
+A SER 431 2 82.65 1 431 
+A PRO 432 2 82.80 1 432 
+A GLU 433 2 73.34 1 433 
+A ASP 434 2 80.90 1 434 
+A CYS 435 2 80.71 1 435 
+A LEU 436 2 76.63 1 436 
+A SER 437 2 77.21 1 437 
+A ILE 438 2 78.83 1 438 
+A VAL 439 2 75.68 1 439 
+A ASP 440 2 69.62 1 440 
+A LEU 441 2 67.09 1 441 
+A VAL 442 2 66.57 1 442 
+A SER 443 2 65.40 1 443 
+A ASP 444 2 66.78 1 444 
+A PRO 445 2 76.76 1 445 
+A ASN 446 2 73.12 1 446 
+A ASP 447 2 70.69 1 447 
+A TYR 448 2 75.80 1 448 
+A ILE 449 2 81.81 1 449 
+A GLU 450 2 73.23 1 450 
+A ARG 451 2 72.63 1 451 
+A GLY 452 2 82.31 1 452 
+A LEU 453 2 79.82 1 453 
+A ALA 454 2 80.69 1 454 
+A PHE 455 2 78.05 1 455 
+A TRP 456 2 78.66 1 456 
+A GLU 457 2 73.03 1 457 
+A LYS 458 2 72.28 1 458 
+A ARG 459 2 69.30 1 459 
+A GLU 460 2 70.64 1 460 
+A THR 461 2 77.45 1 461 
+A GLU 462 2 69.59 1 462 
+A GLU 463 2 68.58 1 463 
+A VAL 464 2 72.49 1 464 
+A SER 465 2 69.19 1 465 
+A GLU 466 2 61.02 1 466 
+A ASN 467 2 62.12 1 467 
+A GLY 468 2 63.71 1 468 
+A LEU 469 2 56.79 1 469 
+A LEU 470 2 51.16 1 470 
+A ASP 471 2 50.39 1 471 
+A ASP 472 2 51.96 1 472 
+A VAL 473 2 52.80 1 473 
+A GLU 474 2 43.86 1 474 
+A LYS 475 2 45.67 1 475 
+A GLY 476 2 50.10 1 476 
+A ASP 477 2 42.26 1 477 
+A GLU 478 2 41.47 1 478 
+A GLY 479 2 48.90 1 479 
+A ASN 480 2 41.54 1 480 
+A ASN 481 2 41.20 1 481 
+A ASP 482 2 41.66 1 482 
+A SER 483 2 39.40 1 483 
+A VAL 484 2 37.39 1 484 
+A ASP 485 2 37.92 1 485 
+A SER 486 2 38.80 1 486 
+A PRO 487 2 38.97 1 487 
+A ILE 488 2 33.28 1 488 
+A ILE 489 2 32.66 1 489 
+A ASN 490 2 26.78 1 490 
+#
+_ma_software_group.group_id    1
+_ma_software_group.ordinal_id  1
+_ma_software_group.software_id 1
+#
+_ma_target_entity.data_id   1
+_ma_target_entity.entity_id 1
+_ma_target_entity.origin    .
+#
+_ma_target_entity_instance.asym_id   A
+_ma_target_entity_instance.details   .
+_ma_target_entity_instance.entity_id 1
+#
+loop_
+_pdbx_data_usage.details
+_pdbx_data_usage.id
+_pdbx_data_usage.type
+_pdbx_data_usage.url
+;Non-commercial use only, by using this file you agree to the terms of use found
+at https://github.com/google-deepmind/alphafold3/blob/main/OUTPUT_TERMS_OF_USE.md.
+To request access to the AlphaFold 3 model parameters, follow the process set
+out at https://github.com/google-deepmind/alphafold3. You may only use these if
+received directly from Google. Use is subject to terms of use available at
+https://github.com/google-deepmind/alphafold3/blob/main/WEIGHTS_TERMS_OF_USE.md.
+;
+1 license    https://github.com/google-deepmind/alphafold3/blob/main/OUTPUT_TERMS_OF_USE.md 
+;AlphaFold 3 and its output are not intended for, have not been validated for,
+and are not approved for clinical use. They are provided "as-is" without any
+warranty of any kind, whether expressed or implied. No warranty is given that
+use shall not infringe the rights of any third party.
+;
+2 disclaimer ?                                                                              
+#
+loop_
+_pdbx_poly_seq_scheme.asym_id
+_pdbx_poly_seq_scheme.auth_seq_num
+_pdbx_poly_seq_scheme.entity_id
+_pdbx_poly_seq_scheme.hetero
+_pdbx_poly_seq_scheme.mon_id
+_pdbx_poly_seq_scheme.pdb_ins_code
+_pdbx_poly_seq_scheme.pdb_seq_num
+_pdbx_poly_seq_scheme.pdb_strand_id
+_pdbx_poly_seq_scheme.seq_id
+A 1   1 n VAL . 1   A 1   
+A 2   1 n LEU . 2   A 2   
+A 3   1 n THR . 3   A 3   
+A 4   1 n LYS . 4   A 4   
+A 5   1 n GLY . 5   A 5   
+A 6   1 n ARG . 6   A 6   
+A 7   1 n LYS . 7   A 7   
+A 8   1 n ILE . 8   A 8   
+A 9   1 n ILE . 9   A 9   
+A 10  1 n LYS . 10  A 10  
+A 11  1 n VAL . 11  A 11  
+A 12  1 n ASP . 12  A 12  
+A 13  1 n VAL . 13  A 13  
+A 14  1 n SER . 14  A 14  
+A 15  1 n ARG . 15  A 15  
+A 16  1 n ASN . 16  A 16  
+A 17  1 n GLU . 17  A 17  
+A 18  1 n LEU . 18  A 18  
+A 19  1 n GLU . 19  A 19  
+A 20  1 n ASN . 20  A 20  
+A 21  1 n VAL . 21  A 21  
+A 22  1 n ASN . 22  A 22  
+A 23  1 n THR . 23  A 23  
+A 24  1 n VAL . 24  A 24  
+A 25  1 n CYS . 25  A 25  
+A 26  1 n ASN . 26  A 26  
+A 27  1 n VAL . 27  A 27  
+A 28  1 n ILE . 28  A 28  
+A 29  1 n ASN . 29  A 29  
+A 30  1 n SER . 30  A 30  
+A 31  1 n ALA . 31  A 31  
+A 32  1 n PHE . 32  A 32  
+A 33  1 n PRO . 33  A 33  
+A 34  1 n VAL . 34  A 34  
+A 35  1 n HIS . 35  A 35  
+A 36  1 n LEU . 36  A 36  
+A 37  1 n LYS . 37  A 37  
+A 38  1 n ASN . 38  A 38  
+A 39  1 n LYS . 39  A 39  
+A 40  1 n ILE . 40  A 40  
+A 41  1 n GLU . 41  A 41  
+A 42  1 n ILE . 42  A 42  
+A 43  1 n ASP . 43  A 43  
+A 44  1 n TYR . 44  A 44  
+A 45  1 n LEU . 45  A 45  
+A 46  1 n MET . 46  A 46  
+A 47  1 n ASP . 47  A 47  
+A 48  1 n TYR . 48  A 48  
+A 49  1 n TYR . 49  A 49  
+A 50  1 n LYS . 50  A 50  
+A 51  1 n GLY . 51  A 51  
+A 52  1 n ASN . 52  A 52  
+A 53  1 n GLN . 53  A 53  
+A 54  1 n PRO . 54  A 54  
+A 55  1 n ILE . 55  A 55  
+A 56  1 n LEU . 56  A 56  
+A 57  1 n ASN . 57  A 57  
+A 58  1 n LYS . 58  A 58  
+A 59  1 n VAL . 59  A 59  
+A 60  1 n LYS . 60  A 60  
+A 61  1 n GLU . 61  A 61  
+A 62  1 n ILE . 62  A 62  
+A 63  1 n ARG . 63  A 63  
+A 64  1 n SER . 64  A 64  
+A 65  1 n GLU . 65  A 65  
+A 66  1 n ILE . 66  A 66  
+A 67  1 n ASN . 67  A 67  
+A 68  1 n ASN . 68  A 68  
+A 69  1 n LYS . 69  A 69  
+A 70  1 n LEU . 70  A 70  
+A 71  1 n VAL . 71  A 71  
+A 72  1 n LEU . 72  A 72  
+A 73  1 n ASN . 73  A 73  
+A 74  1 n HIS . 74  A 74  
+A 75  1 n ALA . 75  A 75  
+A 76  1 n GLN . 76  A 76  
+A 77  1 n MET . 77  A 77  
+A 78  1 n ILE . 78  A 78  
+A 79  1 n THR . 79  A 79  
+A 80  1 n ARG . 80  A 80  
+A 81  1 n LYS . 81  A 81  
+A 82  1 n ILE . 82  A 82  
+A 83  1 n VAL . 83  A 83  
+A 84  1 n GLY . 84  A 84  
+A 85  1 n TYR . 85  A 85  
+A 86  1 n PHE . 86  A 86  
+A 87  1 n LEU . 87  A 87  
+A 88  1 n GLY . 88  A 88  
+A 89  1 n ASN . 89  A 89  
+A 90  1 n PRO . 90  A 90  
+A 91  1 n ILE . 91  A 91  
+A 92  1 n GLN . 92  A 92  
+A 93  1 n TYR . 93  A 93  
+A 94  1 n ILE . 94  A 94  
+A 95  1 n PRO . 95  A 95  
+A 96  1 n SER . 96  A 96  
+A 97  1 n GLY . 97  A 97  
+A 98  1 n ILE . 98  A 98  
+A 99  1 n SER . 99  A 99  
+A 100 1 n LYS . 100 A 100 
+A 101 1 n LYS . 101 A 101 
+A 102 1 n LYS . 102 A 102 
+A 103 1 n GLU . 103 A 103 
+A 104 1 n LEU . 104 A 104 
+A 105 1 n ILE . 105 A 105 
+A 106 1 n ASP . 106 A 106 
+A 107 1 n GLU . 107 A 107 
+A 108 1 n LEU . 108 A 108 
+A 109 1 n ASN . 109 A 109 
+A 110 1 n ILE . 110 A 110 
+A 111 1 n TYR . 111 A 111 
+A 112 1 n THR . 112 A 112 
+A 113 1 n GLN . 113 A 113 
+A 114 1 n TYR . 114 A 114 
+A 115 1 n GLU . 115 A 115 
+A 116 1 n ASN . 116 A 116 
+A 117 1 n LYS . 117 A 117 
+A 118 1 n ALA . 118 A 118 
+A 119 1 n SER . 119 A 119 
+A 120 1 n VAL . 120 A 120 
+A 121 1 n ASP . 121 A 121 
+A 122 1 n LYS . 122 A 122 
+A 123 1 n GLU . 123 A 123 
+A 124 1 n LEU . 124 A 124 
+A 125 1 n GLY . 125 A 125 
+A 126 1 n GLU . 126 A 126 
+A 127 1 n TYR . 127 A 127 
+A 128 1 n GLN . 128 A 128 
+A 129 1 n SER . 129 A 129 
+A 130 1 n ILE . 130 A 130 
+A 131 1 n CYS . 131 A 131 
+A 132 1 n GLY . 132 A 132 
+A 133 1 n THR . 133 A 133 
+A 134 1 n ALA . 134 A 134 
+A 135 1 n TYR . 135 A 135 
+A 136 1 n ARG . 136 A 136 
+A 137 1 n ILE . 137 A 137 
+A 138 1 n ILE . 138 A 138 
+A 139 1 n TYR . 139 A 139 
+A 140 1 n ARG . 140 A 140 
+A 141 1 n ASP . 141 A 141 
+A 142 1 n GLY . 142 A 142 
+A 143 1 n ASP . 143 A 143 
+A 144 1 n PHE . 144 A 144 
+A 145 1 n THR . 145 A 145 
+A 146 1 n GLY . 146 A 146 
+A 147 1 n ARG . 147 A 147 
+A 148 1 n LYS . 148 A 148 
+A 149 1 n ASN . 149 A 149 
+A 150 1 n ASP . 150 A 150 
+A 151 1 n THR . 151 A 151 
+A 152 1 n VAL . 152 A 152 
+A 153 1 n PRO . 153 A 153 
+A 154 1 n PHE . 154 A 154 
+A 155 1 n GLU . 155 A 155 
+A 156 1 n ASP . 156 A 156 
+A 157 1 n ARG . 157 A 157 
+A 158 1 n ALA . 158 A 158 
+A 159 1 n LEU . 159 A 159 
+A 160 1 n ASP . 160 A 160 
+A 161 1 n PRO . 161 A 161 
+A 162 1 n SER . 162 A 162 
+A 163 1 n THR . 163 A 163 
+A 164 1 n THR . 164 A 164 
+A 165 1 n PHE . 165 A 165 
+A 166 1 n MET . 166 A 166 
+A 167 1 n VAL . 167 A 167 
+A 168 1 n TYR . 168 A 168 
+A 169 1 n GLU . 169 A 169 
+A 170 1 n SER . 170 A 170 
+A 171 1 n ASN . 171 A 171 
+A 172 1 n ILE . 172 A 172 
+A 173 1 n SER . 173 A 173 
+A 174 1 n GLY . 174 A 174 
+A 175 1 n TYR . 175 A 175 
+A 176 1 n PRO . 176 A 176 
+A 177 1 n LEU . 177 A 177 
+A 178 1 n LEU . 178 A 178 
+A 179 1 n GLY . 179 A 179 
+A 180 1 n VAL . 180 A 180 
+A 181 1 n THR . 181 A 181 
+A 182 1 n TYR . 182 A 182 
+A 183 1 n TYR . 183 A 183 
+A 184 1 n ASP . 184 A 184 
+A 185 1 n VAL . 185 A 185 
+A 186 1 n TYR . 186 A 186 
+A 187 1 n ASP . 187 A 187 
+A 188 1 n ALA . 188 A 188 
+A 189 1 n ASP . 189 A 189 
+A 190 1 n GLY . 190 A 190 
+A 191 1 n LYS . 191 A 191 
+A 192 1 n PHE . 192 A 192 
+A 193 1 n LYS . 193 A 193 
+A 194 1 n GLY . 194 A 194 
+A 195 1 n ILE . 195 A 195 
+A 196 1 n ARG . 196 A 196 
+A 197 1 n LEU . 197 A 197 
+A 198 1 n TYR . 198 A 198 
+A 199 1 n ALA . 199 A 199 
+A 200 1 n TYR . 200 A 200 
+A 201 1 n SER . 201 A 201 
+A 202 1 n ASP . 202 A 202 
+A 203 1 n PHE . 203 A 203 
+A 204 1 n GLY . 204 A 204 
+A 205 1 n ARG . 205 A 205 
+A 206 1 n TYR . 206 A 206 
+A 207 1 n GLU . 207 A 207 
+A 208 1 n PHE . 208 A 208 
+A 209 1 n ILE . 209 A 209 
+A 210 1 n SER . 210 A 210 
+A 211 1 n ASP . 211 A 211 
+A 212 1 n GLY . 212 A 212 
+A 213 1 n LEU . 213 A 213 
+A 214 1 n GLU . 214 A 214 
+A 215 1 n PRO . 215 A 215 
+A 216 1 n LEU . 216 A 216 
+A 217 1 n SER . 217 A 217 
+A 218 1 n GLU . 218 A 218 
+A 219 1 n ASP . 219 A 219 
+A 220 1 n ASN . 220 A 220 
+A 221 1 n LEU . 221 A 221 
+A 222 1 n VAL . 222 A 222 
+A 223 1 n GLU . 223 A 223 
+A 224 1 n PHE . 224 A 224 
+A 225 1 n ILE . 225 A 225 
+A 226 1 n PRO . 226 A 226 
+A 227 1 n TYR . 227 A 227 
+A 228 1 n ASN . 228 A 228 
+A 229 1 n VAL . 229 A 229 
+A 230 1 n GLY . 230 A 230 
+A 231 1 n GLY . 231 A 231 
+A 232 1 n ILE . 232 A 232 
+A 233 1 n PRO . 233 A 233 
+A 234 1 n ILE . 234 A 234 
+A 235 1 n ILE . 235 A 235 
+A 236 1 n GLU . 236 A 236 
+A 237 1 n TYR . 237 A 237 
+A 238 1 n PRO . 238 A 238 
+A 239 1 n ASN . 239 A 239 
+A 240 1 n ASN . 240 A 240 
+A 241 1 n SER . 241 A 241 
+A 242 1 n TRP . 242 A 242 
+A 243 1 n ARG . 243 A 243 
+A 244 1 n ILE . 244 A 244 
+A 245 1 n GLY . 245 A 245 
+A 246 1 n ASP . 246 A 246 
+A 247 1 n TRP . 247 A 247 
+A 248 1 n GLU . 248 A 248 
+A 249 1 n LEU . 249 A 249 
+A 250 1 n VAL . 250 A 250 
+A 251 1 n ILE . 251 A 251 
+A 252 1 n GLY . 252 A 252 
+A 253 1 n LEU . 253 A 253 
+A 254 1 n MET . 254 A 254 
+A 255 1 n ASP . 255 A 255 
+A 256 1 n ALA . 256 A 256 
+A 257 1 n ILE . 257 A 257 
+A 258 1 n ASN . 258 A 258 
+A 259 1 n GLU . 259 A 259 
+A 260 1 n LEU . 260 A 260 
+A 261 1 n ASN . 261 A 261 
+A 262 1 n SER . 262 A 262 
+A 263 1 n GLY . 263 A 263 
+A 264 1 n ARG . 264 A 264 
+A 265 1 n LEU . 265 A 265 
+A 266 1 n ASP . 266 A 266 
+A 267 1 n ASP . 267 A 267 
+A 268 1 n ILE . 268 A 268 
+A 269 1 n GLU . 269 A 269 
+A 270 1 n GLN . 270 A 270 
+A 271 1 n VAL . 271 A 271 
+A 272 1 n ILE . 272 A 272 
+A 273 1 n GLN . 273 A 273 
+A 274 1 n SER . 274 A 274 
+A 275 1 n LEU . 275 A 275 
+A 276 1 n ILE . 276 A 276 
+A 277 1 n VAL . 277 A 277 
+A 278 1 n PHE . 278 A 278 
+A 279 1 n LEU . 279 A 279 
+A 280 1 n ASN . 280 A 280 
+A 281 1 n ALA . 281 A 281 
+A 282 1 n GLU . 282 A 282 
+A 283 1 n ILE . 283 A 283 
+A 284 1 n ASP . 284 A 284 
+A 285 1 n SER . 285 A 285 
+A 286 1 n GLU . 286 A 286 
+A 287 1 n THR . 287 A 287 
+A 288 1 n TYR . 288 A 288 
+A 289 1 n ASP . 289 A 289 
+A 290 1 n GLU . 290 A 290 
+A 291 1 n MET . 291 A 291 
+A 292 1 n ARG . 292 A 292 
+A 293 1 n ARG . 293 A 293 
+A 294 1 n GLN . 294 A 294 
+A 295 1 n GLY . 295 A 295 
+A 296 1 n VAL . 296 A 296 
+A 297 1 n VAL . 297 A 297 
+A 298 1 n MET . 298 A 298 
+A 299 1 n LEU . 299 A 299 
+A 300 1 n ASN . 300 A 300 
+A 301 1 n SER . 301 A 301 
+A 302 1 n SER . 302 A 302 
+A 303 1 n GLU . 303 A 303 
+A 304 1 n ASN . 304 A 304 
+A 305 1 n LEU . 305 A 305 
+A 306 1 n LYS . 306 A 306 
+A 307 1 n SER . 307 A 307 
+A 308 1 n ASP . 308 A 308 
+A 309 1 n VAL . 309 A 309 
+A 310 1 n LYS . 310 A 310 
+A 311 1 n THR . 311 A 311 
+A 312 1 n ILE . 312 A 312 
+A 313 1 n VAL . 313 A 313 
+A 314 1 n ASN . 314 A 314 
+A 315 1 n GLN . 315 A 315 
+A 316 1 n LEU . 316 A 316 
+A 317 1 n ASP . 317 A 317 
+A 318 1 n GLN . 318 A 318 
+A 319 1 n ASN . 319 A 319 
+A 320 1 n GLY . 320 A 320 
+A 321 1 n MET . 321 A 321 
+A 322 1 n ASN . 322 A 322 
+A 323 1 n LEU . 323 A 323 
+A 324 1 n PHE . 324 A 324 
+A 325 1 n ALA . 325 A 325 
+A 326 1 n GLN . 326 A 326 
+A 327 1 n GLU . 327 A 327 
+A 328 1 n LEU . 328 A 328 
+A 329 1 n GLU . 329 A 329 
+A 330 1 n GLU . 330 A 330 
+A 331 1 n LEU . 331 A 331 
+A 332 1 n LEU . 332 A 332 
+A 333 1 n TYR . 333 A 333 
+A 334 1 n SER . 334 A 334 
+A 335 1 n LEU . 335 A 335 
+A 336 1 n VAL . 336 A 336 
+A 337 1 n GLY . 337 A 337 
+A 338 1 n VAL . 338 A 338 
+A 339 1 n PRO . 339 A 339 
+A 340 1 n SER . 340 A 340 
+A 341 1 n ARG . 341 A 341 
+A 342 1 n HIS . 342 A 342 
+A 343 1 n ASP . 343 A 343 
+A 344 1 n GLY . 344 A 344 
+A 345 1 n ALA . 345 A 345 
+A 346 1 n SER . 346 A 346 
+A 347 1 n GLY . 347 A 347 
+A 348 1 n GLY . 348 A 348 
+A 349 1 n ASP . 349 A 349 
+A 350 1 n THR . 350 A 350 
+A 351 1 n GLY . 351 A 351 
+A 352 1 n LEU . 352 A 352 
+A 353 1 n ALA . 353 A 353 
+A 354 1 n ILE . 354 A 354 
+A 355 1 n GLU . 355 A 355 
+A 356 1 n LEU . 356 A 356 
+A 357 1 n ARG . 357 A 357 
+A 358 1 n ASP . 358 A 358 
+A 359 1 n GLY . 359 A 359 
+A 360 1 n TRP . 360 A 360 
+A 361 1 n ALA . 361 A 361 
+A 362 1 n ASP . 362 A 362 
+A 363 1 n LEU . 363 A 363 
+A 364 1 n GLU . 364 A 364 
+A 365 1 n ILE . 365 A 365 
+A 366 1 n ILE . 366 A 366 
+A 367 1 n CYS . 367 A 367 
+A 368 1 n LYS . 368 A 368 
+A 369 1 n ASN . 369 A 369 
+A 370 1 n LYS . 370 A 370 
+A 371 1 n GLU . 371 A 371 
+A 372 1 n LEU . 372 A 372 
+A 373 1 n ILE . 373 A 373 
+A 374 1 n PHE . 374 A 374 
+A 375 1 n LYS . 375 A 375 
+A 376 1 n GLU . 376 A 376 
+A 377 1 n SER . 377 A 377 
+A 378 1 n GLU . 378 A 378 
+A 379 1 n LYS . 379 A 379 
+A 380 1 n LYS . 380 A 380 
+A 381 1 n THR . 381 A 381 
+A 382 1 n LEU . 382 A 382 
+A 383 1 n ASN . 383 A 383 
+A 384 1 n ILE . 384 A 384 
+A 385 1 n LEU . 385 A 385 
+A 386 1 n LEU . 386 A 386 
+A 387 1 n HIS . 387 A 387 
+A 388 1 n ILE . 388 A 388 
+A 389 1 n PHE . 389 A 389 
+A 390 1 n ASN . 390 A 390 
+A 391 1 n ILE . 391 A 391 
+A 392 1 n GLY . 392 A 392 
+A 393 1 n ARG . 393 A 393 
+A 394 1 n SER . 394 A 394 
+A 395 1 n GLU . 395 A 395 
+A 396 1 n LYS . 396 A 396 
+A 397 1 n LEU . 397 A 397 
+A 398 1 n ASP . 398 A 398 
+A 399 1 n LYS . 399 A 399 
+A 400 1 n LEU . 400 A 400 
+A 401 1 n ASP . 401 A 401 
+A 402 1 n LEU . 402 A 402 
+A 403 1 n ASP . 403 A 403 
+A 404 1 n ILE . 404 A 404 
+A 405 1 n LYS . 405 A 405 
+A 406 1 n PHE . 406 A 406 
+A 407 1 n SER . 407 A 407 
+A 408 1 n ARG . 408 A 408 
+A 409 1 n ASN . 409 A 409 
+A 410 1 n LYS . 410 A 410 
+A 411 1 n ASN . 411 A 411 
+A 412 1 n ASN . 412 A 412 
+A 413 1 n ASN . 413 A 413 
+A 414 1 n LEU . 414 A 414 
+A 415 1 n LEU . 415 A 415 
+A 416 1 n VAL . 416 A 416 
+A 417 1 n LYS . 417 A 417 
+A 418 1 n THR . 418 A 418 
+A 419 1 n GLN . 419 A 419 
+A 420 1 n SER . 420 A 420 
+A 421 1 n TYR . 421 A 421 
+A 422 1 n GLN . 422 A 422 
+A 423 1 n SER . 423 A 423 
+A 424 1 n LEU . 424 A 424 
+A 425 1 n LEU . 425 A 425 
+A 426 1 n SER . 426 A 426 
+A 427 1 n THR . 427 A 427 
+A 428 1 n ARG . 428 A 428 
+A 429 1 n THR . 429 A 429 
+A 430 1 n LEU . 430 A 430 
+A 431 1 n SER . 431 A 431 
+A 432 1 n PRO . 432 A 432 
+A 433 1 n GLU . 433 A 433 
+A 434 1 n ASP . 434 A 434 
+A 435 1 n CYS . 435 A 435 
+A 436 1 n LEU . 436 A 436 
+A 437 1 n SER . 437 A 437 
+A 438 1 n ILE . 438 A 438 
+A 439 1 n VAL . 439 A 439 
+A 440 1 n ASP . 440 A 440 
+A 441 1 n LEU . 441 A 441 
+A 442 1 n VAL . 442 A 442 
+A 443 1 n SER . 443 A 443 
+A 444 1 n ASP . 444 A 444 
+A 445 1 n PRO . 445 A 445 
+A 446 1 n ASN . 446 A 446 
+A 447 1 n ASP . 447 A 447 
+A 448 1 n TYR . 448 A 448 
+A 449 1 n ILE . 449 A 449 
+A 450 1 n GLU . 450 A 450 
+A 451 1 n ARG . 451 A 451 
+A 452 1 n GLY . 452 A 452 
+A 453 1 n LEU . 453 A 453 
+A 454 1 n ALA . 454 A 454 
+A 455 1 n PHE . 455 A 455 
+A 456 1 n TRP . 456 A 456 
+A 457 1 n GLU . 457 A 457 
+A 458 1 n LYS . 458 A 458 
+A 459 1 n ARG . 459 A 459 
+A 460 1 n GLU . 460 A 460 
+A 461 1 n THR . 461 A 461 
+A 462 1 n GLU . 462 A 462 
+A 463 1 n GLU . 463 A 463 
+A 464 1 n VAL . 464 A 464 
+A 465 1 n SER . 465 A 465 
+A 466 1 n GLU . 466 A 466 
+A 467 1 n ASN . 467 A 467 
+A 468 1 n GLY . 468 A 468 
+A 469 1 n LEU . 469 A 469 
+A 470 1 n LEU . 470 A 470 
+A 471 1 n ASP . 471 A 471 
+A 472 1 n ASP . 472 A 472 
+A 473 1 n VAL . 473 A 473 
+A 474 1 n GLU . 474 A 474 
+A 475 1 n LYS . 475 A 475 
+A 476 1 n GLY . 476 A 476 
+A 477 1 n ASP . 477 A 477 
+A 478 1 n GLU . 478 A 478 
+A 479 1 n GLY . 479 A 479 
+A 480 1 n ASN . 480 A 480 
+A 481 1 n ASN . 481 A 481 
+A 482 1 n ASP . 482 A 482 
+A 483 1 n SER . 483 A 483 
+A 484 1 n VAL . 484 A 484 
+A 485 1 n ASP . 485 A 485 
+A 486 1 n SER . 486 A 486 
+A 487 1 n PRO . 487 A 487 
+A 488 1 n ILE . 488 A 488 
+A 489 1 n ILE . 489 A 489 
+A 490 1 n ASN . 490 A 490 
+#
+_software.classification other
+_software.date           ?
+_software.description    "Structure prediction"
+_software.name           AlphaFold
+_software.pdbx_ordinal   1
+_software.type           package
+_software.version        "AlphaFold-beta-20231127 (f8da1e0e9aad31c35e8ec28a847ac31d347296c663066adf775550622fa131b6)"
+#
+_struct_asym.entity_id 1
+_struct_asym.id        A
+#
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_alt_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_entity_id
+_atom_site.label_seq_id
+_atom_site.pdbx_PDB_ins_code
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+_atom_site.occupancy
+_atom_site.B_iso_or_equiv
+_atom_site.auth_seq_id
+_atom_site.auth_asym_id
+_atom_site.pdbx_PDB_model_num
+ATOM 1    N N   . VAL A 1 1   ? -18.045 12.427  6.949   1.00 65.96 1   A 1 
+ATOM 2    C CA  . VAL A 1 1   ? -18.540 11.151  7.535   1.00 73.27 1   A 1 
+ATOM 3    C C   . VAL A 1 1   ? -17.661 10.833  8.730   1.00 74.47 1   A 1 
+ATOM 4    O O   . VAL A 1 1   ? -16.461 11.031  8.629   1.00 69.37 1   A 1 
+ATOM 5    C CB  . VAL A 1 1   ? -18.515 10.021  6.484   1.00 68.68 1   A 1 
+ATOM 6    C CG1 . VAL A 1 1   ? -18.929 8.675   7.061   1.00 62.18 1   A 1 
+ATOM 7    C CG2 . VAL A 1 1   ? -19.482 10.368  5.330   1.00 63.29 1   A 1 
+ATOM 8    N N   . LEU A 1 2   ? -18.228 10.441  9.893   1.00 77.36 2   A 1 
+ATOM 9    C CA  . LEU A 1 2   ? -17.411 9.978   11.023  1.00 78.43 2   A 1 
+ATOM 10   C C   . LEU A 1 2   ? -17.186 8.475   10.852  1.00 80.74 2   A 1 
+ATOM 11   O O   . LEU A 1 2   ? -18.116 7.697   11.075  1.00 75.88 2   A 1 
+ATOM 12   C CB  . LEU A 1 2   ? -18.096 10.314  12.361  1.00 73.39 2   A 1 
+ATOM 13   C CG  . LEU A 1 2   ? -17.270 9.896   13.604  1.00 64.06 2   A 1 
+ATOM 14   C CD1 . LEU A 1 2   ? -16.048 10.786  13.812  1.00 60.59 2   A 1 
+ATOM 15   C CD2 . LEU A 1 2   ? -18.135 9.986   14.864  1.00 60.83 2   A 1 
+ATOM 16   N N   . THR A 1 3   ? -16.008 8.086   10.436  1.00 83.52 3   A 1 
+ATOM 17   C CA  . THR A 1 3   ? -15.609 6.693   10.245  1.00 84.13 3   A 1 
+ATOM 18   C C   . THR A 1 3   ? -14.963 6.153   11.523  1.00 85.20 3   A 1 
+ATOM 19   O O   . THR A 1 3   ? -14.339 6.893   12.283  1.00 81.07 3   A 1 
+ATOM 20   C CB  . THR A 1 3   ? -14.683 6.566   9.026   1.00 81.37 3   A 1 
+ATOM 21   O OG1 . THR A 1 3   ? -13.598 7.448   9.176   1.00 77.51 3   A 1 
+ATOM 22   C CG2 . THR A 1 3   ? -15.388 6.943   7.722   1.00 75.79 3   A 1 
+ATOM 23   N N   . LYS A 1 4   ? -15.180 4.868   11.814  1.00 90.61 4   A 1 
+ATOM 24   C CA  . LYS A 1 4   ? -14.694 4.200   13.042  1.00 90.06 4   A 1 
+ATOM 25   C C   . LYS A 1 4   ? -14.128 2.808   12.761  1.00 92.56 4   A 1 
+ATOM 26   O O   . LYS A 1 4   ? -14.137 1.945   13.638  1.00 87.63 4   A 1 
+ATOM 27   C CB  . LYS A 1 4   ? -15.809 4.135   14.103  1.00 84.79 4   A 1 
+ATOM 28   C CG  . LYS A 1 4   ? -16.261 5.510   14.605  1.00 78.38 4   A 1 
+ATOM 29   C CD  . LYS A 1 4   ? -17.248 5.340   15.767  1.00 73.88 4   A 1 
+ATOM 30   C CE  . LYS A 1 4   ? -17.669 6.716   16.271  1.00 66.64 4   A 1 
+ATOM 31   N NZ  . LYS A 1 4   ? -18.605 6.609   17.416  1.00 58.42 4   A 1 
+ATOM 32   N N   . GLY A 1 5   ? -13.682 2.571   11.536  1.00 93.78 5   A 1 
+ATOM 33   C CA  . GLY A 1 5   ? -13.335 1.257   11.019  1.00 95.62 5   A 1 
+ATOM 34   C C   . GLY A 1 5   ? -14.554 0.451   10.563  1.00 96.65 5   A 1 
+ATOM 35   O O   . GLY A 1 5   ? -15.704 0.786   10.858  1.00 94.78 5   A 1 
+ATOM 36   N N   . ARG A 1 6   ? -14.293 -0.623  9.827   1.00 97.81 6   A 1 
+ATOM 37   C CA  . ARG A 1 6   ? -15.334 -1.478  9.252   1.00 97.80 6   A 1 
+ATOM 38   C C   . ARG A 1 6   ? -15.860 -2.458  10.292  1.00 97.95 6   A 1 
+ATOM 39   O O   . ARG A 1 6   ? -15.101 -3.085  11.031  1.00 97.16 6   A 1 
+ATOM 40   C CB  . ARG A 1 6   ? -14.794 -2.174  7.998   1.00 97.31 6   A 1 
+ATOM 41   C CG  . ARG A 1 6   ? -14.936 -1.412  6.665   1.00 95.57 6   A 1 
+ATOM 42   C CD  . ARG A 1 6   ? -14.864 0.109   6.684   1.00 94.93 6   A 1 
+ATOM 43   N NE  . ARG A 1 6   ? -13.521 0.568   7.067   1.00 93.79 6   A 1 
+ATOM 44   C CZ  . ARG A 1 6   ? -13.200 1.757   7.526   1.00 95.34 6   A 1 
+ATOM 45   N NH1 . ARG A 1 6   ? -14.053 2.708   7.755   1.00 86.58 6   A 1 
+ATOM 46   N NH2 . ARG A 1 6   ? -11.968 2.012   7.760   1.00 90.52 6   A 1 
+ATOM 47   N N   . LYS A 1 7   ? -17.180 -2.594  10.333  1.00 97.71 7   A 1 
+ATOM 48   C CA  . LYS A 1 7   ? -17.849 -3.506  11.257  1.00 97.63 7   A 1 
+ATOM 49   C C   . LYS A 1 7   ? -17.718 -4.951  10.771  1.00 98.07 7   A 1 
+ATOM 50   O O   . LYS A 1 7   ? -18.085 -5.260  9.642   1.00 97.40 7   A 1 
+ATOM 51   C CB  . LYS A 1 7   ? -19.310 -3.068  11.437  1.00 96.63 7   A 1 
+ATOM 52   C CG  . LYS A 1 7   ? -19.990 -3.894  12.531  1.00 85.89 7   A 1 
+ATOM 53   C CD  . LYS A 1 7   ? -21.416 -3.406  12.777  1.00 77.75 7   A 1 
+ATOM 54   C CE  . LYS A 1 7   ? -22.053 -4.277  13.864  1.00 68.48 7   A 1 
+ATOM 55   N NZ  . LYS A 1 7   ? -23.451 -3.883  14.130  1.00 57.14 7   A 1 
+ATOM 56   N N   . ILE A 1 8   ? -17.274 -5.828  11.659  1.00 97.80 8   A 1 
+ATOM 57   C CA  . ILE A 1 8   ? -17.231 -7.273  11.396  1.00 98.05 8   A 1 
+ATOM 58   C C   . ILE A 1 8   ? -18.666 -7.804  11.300  1.00 98.18 8   A 1 
+ATOM 59   O O   . ILE A 1 8   ? -19.480 -7.567  12.197  1.00 97.47 8   A 1 
+ATOM 60   C CB  . ILE A 1 8   ? -16.440 -8.030  12.489  1.00 97.70 8   A 1 
+ATOM 61   C CG1 . ILE A 1 8   ? -15.040 -7.423  12.702  1.00 95.65 8   A 1 
+ATOM 62   C CG2 . ILE A 1 8   ? -16.330 -9.522  12.104  1.00 94.92 8   A 1 
+ATOM 63   C CD1 . ILE A 1 8   ? -14.256 -8.033  13.868  1.00 90.12 8   A 1 
+ATOM 64   N N   . ILE A 1 9   ? -18.947 -8.536  10.233  1.00 98.15 9   A 1 
+ATOM 65   C CA  . ILE A 1 9   ? -20.244 -9.174  10.013  1.00 98.32 9   A 1 
+ATOM 66   C C   . ILE A 1 9   ? -20.225 -10.528 10.724  1.00 98.35 9   A 1 
+ATOM 67   O O   . ILE A 1 9   ? -19.423 -11.397 10.390  1.00 97.86 9   A 1 
+ATOM 68   C CB  . ILE A 1 9   ? -20.542 -9.290  8.506   1.00 98.21 9   A 1 
+ATOM 69   C CG1 . ILE A 1 9   ? -20.485 -7.898  7.828   1.00 97.54 9   A 1 
+ATOM 70   C CG2 . ILE A 1 9   ? -21.927 -9.935  8.321   1.00 97.37 9   A 1 
+ATOM 71   C CD1 . ILE A 1 9   ? -20.632 -7.929  6.307   1.00 95.60 9   A 1 
+ATOM 72   N N   . LYS A 1 10  ? -21.099 -10.688 11.718  1.00 97.90 10  A 1 
+ATOM 73   C CA  . LYS A 1 10  ? -21.227 -11.927 12.493  1.00 97.80 10  A 1 
+ATOM 74   C C   . LYS A 1 10  ? -22.651 -12.450 12.419  1.00 97.82 10  A 1 
+ATOM 75   O O   . LYS A 1 10  ? -23.592 -11.662 12.510  1.00 96.76 10  A 1 
+ATOM 76   C CB  . LYS A 1 10  ? -20.810 -11.718 13.955  1.00 97.04 10  A 1 
+ATOM 77   C CG  . LYS A 1 10  ? -19.317 -11.398 14.106  1.00 95.34 10  A 1 
+ATOM 78   C CD  . LYS A 1 10  ? -18.919 -11.416 15.583  1.00 92.35 10  A 1 
+ATOM 79   C CE  . LYS A 1 10  ? -17.413 -11.186 15.727  1.00 87.08 10  A 1 
+ATOM 80   N NZ  . LYS A 1 10  ? -16.950 -11.492 17.102  1.00 79.63 10  A 1 
+ATOM 81   N N   . VAL A 1 11  ? -22.781 -13.764 12.305  1.00 97.45 11  A 1 
+ATOM 82   C CA  . VAL A 1 11  ? -24.065 -14.470 12.309  1.00 97.16 11  A 1 
+ATOM 83   C C   . VAL A 1 11  ? -24.007 -15.664 13.259  1.00 96.99 11  A 1 
+ATOM 84   O O   . VAL A 1 11  ? -22.949 -16.252 13.472  1.00 95.46 11  A 1 
+ATOM 85   C CB  . VAL A 1 11  ? -24.496 -14.902 10.896  1.00 96.27 11  A 1 
+ATOM 86   C CG1 . VAL A 1 11  ? -24.703 -13.685 9.983   1.00 89.28 11  A 1 
+ATOM 87   C CG2 . VAL A 1 11  ? -23.511 -15.871 10.243  1.00 89.10 11  A 1 
+ATOM 88   N N   . ASP A 1 12  ? -25.150 -16.001 13.826  1.00 96.40 12  A 1 
+ATOM 89   C CA  . ASP A 1 12  ? -25.312 -17.151 14.718  1.00 95.72 12  A 1 
+ATOM 90   C C   . ASP A 1 12  ? -25.799 -18.363 13.916  1.00 95.58 12  A 1 
+ATOM 91   O O   . ASP A 1 12  ? -26.959 -18.754 13.980  1.00 92.58 12  A 1 
+ATOM 92   C CB  . ASP A 1 12  ? -26.241 -16.764 15.878  1.00 94.22 12  A 1 
+ATOM 93   C CG  . ASP A 1 12  ? -26.208 -17.769 17.039  1.00 89.63 12  A 1 
+ATOM 94   O OD1 . ASP A 1 12  ? -25.186 -18.477 17.170  1.00 83.18 12  A 1 
+ATOM 95   O OD2 . ASP A 1 12  ? -27.156 -17.713 17.861  1.00 82.83 12  A 1 
+ATOM 96   N N   . VAL A 1 13  ? -24.917 -18.866 13.066  1.00 95.19 13  A 1 
+ATOM 97   C CA  . VAL A 1 13  ? -25.139 -20.030 12.200  1.00 95.00 13  A 1 
+ATOM 98   C C   . VAL A 1 13  ? -23.890 -20.892 12.277  1.00 94.59 13  A 1 
+ATOM 99   O O   . VAL A 1 13  ? -22.774 -20.372 12.247  1.00 91.03 13  A 1 
+ATOM 100  C CB  . VAL A 1 13  ? -25.435 -19.603 10.748  1.00 93.76 13  A 1 
+ATOM 101  C CG1 . VAL A 1 13  ? -25.554 -20.789 9.787   1.00 88.10 13  A 1 
+ATOM 102  C CG2 . VAL A 1 13  ? -26.755 -18.822 10.663  1.00 87.79 13  A 1 
+ATOM 103  N N   . SER A 1 14  ? -24.073 -22.199 12.372  1.00 93.52 14  A 1 
+ATOM 104  C CA  . SER A 1 14  ? -22.954 -23.134 12.357  1.00 92.30 14  A 1 
+ATOM 105  C C   . SER A 1 14  ? -22.520 -23.460 10.929  1.00 92.76 14  A 1 
+ATOM 106  O O   . SER A 1 14  ? -23.306 -23.422 9.981   1.00 90.69 14  A 1 
+ATOM 107  C CB  . SER A 1 14  ? -23.296 -24.400 13.141  1.00 89.57 14  A 1 
+ATOM 108  O OG  . SER A 1 14  ? -24.244 -25.181 12.449  1.00 80.43 14  A 1 
+ATOM 109  N N   . ARG A 1 15  ? -21.262 -23.849 10.778  1.00 91.80 15  A 1 
+ATOM 110  C CA  . ARG A 1 15  ? -20.672 -24.241 9.488   1.00 90.88 15  A 1 
+ATOM 111  C C   . ARG A 1 15  ? -21.528 -25.260 8.716   1.00 91.76 15  A 1 
+ATOM 112  O O   . ARG A 1 15  ? -21.738 -25.092 7.524   1.00 89.24 15  A 1 
+ATOM 113  C CB  . ARG A 1 15  ? -19.274 -24.802 9.781   1.00 88.11 15  A 1 
+ATOM 114  C CG  . ARG A 1 15  ? -18.495 -25.170 8.520   1.00 78.64 15  A 1 
+ATOM 115  C CD  . ARG A 1 15  ? -17.204 -25.882 8.934   1.00 75.52 15  A 1 
+ATOM 116  N NE  . ARG A 1 15  ? -16.363 -26.162 7.769   1.00 67.09 15  A 1 
+ATOM 117  C CZ  . ARG A 1 15  ? -15.447 -27.084 7.626   1.00 60.46 15  A 1 
+ATOM 118  N NH1 . ARG A 1 15  ? -15.194 -27.966 8.541   1.00 55.10 15  A 1 
+ATOM 119  N NH2 . ARG A 1 15  ? -14.746 -27.107 6.534   1.00 51.38 15  A 1 
+ATOM 120  N N   . ASN A 1 16  ? -22.038 -26.289 9.401   1.00 91.70 16  A 1 
+ATOM 121  C CA  . ASN A 1 16  ? -22.764 -27.395 8.761   1.00 91.30 16  A 1 
+ATOM 122  C C   . ASN A 1 16  ? -24.129 -26.972 8.190   1.00 92.32 16  A 1 
+ATOM 123  O O   . ASN A 1 16  ? -24.627 -27.600 7.269   1.00 89.78 16  A 1 
+ATOM 124  C CB  . ASN A 1 16  ? -22.947 -28.527 9.784   1.00 89.25 16  A 1 
+ATOM 125  C CG  . ASN A 1 16  ? -21.653 -29.153 10.270  1.00 84.83 16  A 1 
+ATOM 126  O OD1 . ASN A 1 16  ? -20.576 -29.015 9.722   1.00 74.97 16  A 1 
+ATOM 127  N ND2 . ASN A 1 16  ? -21.713 -29.869 11.368  1.00 77.04 16  A 1 
+ATOM 128  N N   . GLU A 1 17  ? -24.718 -25.900 8.714   1.00 91.46 17  A 1 
+ATOM 129  C CA  . GLU A 1 17  ? -26.005 -25.388 8.224   1.00 91.75 17  A 1 
+ATOM 130  C C   . GLU A 1 17  ? -25.878 -24.702 6.855   1.00 92.31 17  A 1 
+ATOM 131  O O   . GLU A 1 17  ? -26.877 -24.559 6.150   1.00 90.32 17  A 1 
+ATOM 132  C CB  . GLU A 1 17  ? -26.603 -24.439 9.269   1.00 91.38 17  A 1 
+ATOM 133  C CG  . GLU A 1 17  ? -27.075 -25.195 10.523  1.00 88.35 17  A 1 
+ATOM 134  C CD  . GLU A 1 17  ? -27.378 -24.252 11.696  1.00 87.24 17  A 1 
+ATOM 135  O OE1 . GLU A 1 17  ? -28.473 -24.362 12.279  1.00 78.97 17  A 1 
+ATOM 136  O OE2 . GLU A 1 17  ? -26.459 -23.478 12.046  1.00 80.63 17  A 1 
+ATOM 137  N N   . LEU A 1 18  ? -24.661 -24.335 6.446   1.00 91.72 18  A 1 
+ATOM 138  C CA  . LEU A 1 18  ? -24.390 -23.716 5.143   1.00 91.41 18  A 1 
+ATOM 139  C C   . LEU A 1 18  ? -24.438 -24.701 3.959   1.00 90.91 18  A 1 
+ATOM 140  O O   . LEU A 1 18  ? -24.296 -24.267 2.818   1.00 87.67 18  A 1 
+ATOM 141  C CB  . LEU A 1 18  ? -23.038 -22.981 5.181   1.00 91.17 18  A 1 
+ATOM 142  C CG  . LEU A 1 18  ? -22.948 -21.846 6.210   1.00 91.33 18  A 1 
+ATOM 143  C CD1 . LEU A 1 18  ? -21.520 -21.305 6.215   1.00 87.26 18  A 1 
+ATOM 144  C CD2 . LEU A 1 18  ? -23.891 -20.690 5.883   1.00 88.10 18  A 1 
+ATOM 145  N N   . GLU A 1 19  ? -24.665 -25.996 4.193   1.00 90.90 19  A 1 
+ATOM 146  C CA  . GLU A 1 19  ? -25.031 -26.938 3.123   1.00 89.58 19  A 1 
+ATOM 147  C C   . GLU A 1 19  ? -26.408 -26.611 2.524   1.00 89.88 19  A 1 
+ATOM 148  O O   . GLU A 1 19  ? -26.679 -26.911 1.360   1.00 86.85 19  A 1 
+ATOM 149  C CB  . GLU A 1 19  ? -25.050 -28.381 3.662   1.00 87.14 19  A 1 
+ATOM 150  C CG  . GLU A 1 19  ? -23.643 -28.923 3.957   1.00 78.82 19  A 1 
+ATOM 151  C CD  . GLU A 1 19  ? -23.614 -30.390 4.430   1.00 76.27 19  A 1 
+ATOM 152  O OE1 . GLU A 1 19  ? -22.516 -30.846 4.835   1.00 69.42 19  A 1 
+ATOM 153  O OE2 . GLU A 1 19  ? -24.666 -31.070 4.381   1.00 69.63 19  A 1 
+ATOM 154  N N   . ASN A 1 20  ? -27.283 -25.984 3.313   1.00 91.98 20  A 1 
+ATOM 155  C CA  . ASN A 1 20  ? -28.615 -25.604 2.873   1.00 92.66 20  A 1 
+ATOM 156  C C   . ASN A 1 20  ? -28.591 -24.213 2.214   1.00 93.79 20  A 1 
+ATOM 157  O O   . ASN A 1 20  ? -28.264 -23.209 2.851   1.00 93.07 20  A 1 
+ATOM 158  C CB  . ASN A 1 20  ? -29.576 -25.698 4.072   1.00 91.14 20  A 1 
+ATOM 159  C CG  . ASN A 1 20  ? -31.026 -25.470 3.684   1.00 88.30 20  A 1 
+ATOM 160  O OD1 . ASN A 1 20  ? -31.365 -24.689 2.816   1.00 79.87 20  A 1 
+ATOM 161  N ND2 . ASN A 1 20  ? -31.950 -26.140 4.326   1.00 79.96 20  A 1 
+ATOM 162  N N   . VAL A 1 21  ? -29.018 -24.149 0.950   1.00 93.41 21  A 1 
+ATOM 163  C CA  . VAL A 1 21  ? -29.095 -22.915 0.149   1.00 94.31 21  A 1 
+ATOM 164  C C   . VAL A 1 21  ? -29.942 -21.835 0.832   1.00 95.25 21  A 1 
+ATOM 165  O O   . VAL A 1 21  ? -29.532 -20.676 0.879   1.00 94.52 21  A 1 
+ATOM 166  C CB  . VAL A 1 21  ? -29.653 -23.220 -1.258  1.00 92.93 21  A 1 
+ATOM 167  C CG1 . VAL A 1 21  ? -29.727 -21.956 -2.123  1.00 87.58 21  A 1 
+ATOM 168  C CG2 . VAL A 1 21  ? -28.779 -24.250 -1.985  1.00 87.63 21  A 1 
+ATOM 169  N N   . ASN A 1 22  ? -31.073 -22.200 1.438   1.00 95.66 22  A 1 
+ATOM 170  C CA  . ASN A 1 22  ? -31.906 -21.248 2.183   1.00 95.52 22  A 1 
+ATOM 171  C C   . ASN A 1 22  ? -31.147 -20.593 3.339   1.00 96.12 22  A 1 
+ATOM 172  O O   . ASN A 1 22  ? -31.297 -19.397 3.594   1.00 95.20 22  A 1 
+ATOM 173  C CB  . ASN A 1 22  ? -33.150 -21.964 2.736   1.00 94.08 22  A 1 
+ATOM 174  C CG  . ASN A 1 22  ? -34.235 -22.136 1.699   1.00 83.16 22  A 1 
+ATOM 175  O OD1 . ASN A 1 22  ? -34.548 -21.219 0.965   1.00 72.88 22  A 1 
+ATOM 176  N ND2 . ASN A 1 22  ? -34.860 -23.283 1.647   1.00 72.61 22  A 1 
+ATOM 177  N N   . THR A 1 23  ? -30.315 -21.364 4.042   1.00 95.61 23  A 1 
+ATOM 178  C CA  . THR A 1 23  ? -29.491 -20.824 5.132   1.00 95.88 23  A 1 
+ATOM 179  C C   . THR A 1 23  ? -28.462 -19.846 4.584   1.00 96.47 23  A 1 
+ATOM 180  O O   . THR A 1 23  ? -28.304 -18.760 5.144   1.00 95.76 23  A 1 
+ATOM 181  C CB  . THR A 1 23  ? -28.812 -21.938 5.935   1.00 95.26 23  A 1 
+ATOM 182  O OG1 . THR A 1 23  ? -29.789 -22.824 6.428   1.00 90.39 23  A 1 
+ATOM 183  C CG2 . THR A 1 23  ? -28.065 -21.391 7.151   1.00 89.87 23  A 1 
+ATOM 184  N N   . VAL A 1 24  ? -27.827 -20.161 3.445   1.00 95.88 24  A 1 
+ATOM 185  C CA  . VAL A 1 24  ? -26.888 -19.252 2.768   1.00 96.11 24  A 1 
+ATOM 186  C C   . VAL A 1 24  ? -27.583 -17.947 2.365   1.00 96.54 24  A 1 
+ATOM 187  O O   . VAL A 1 24  ? -27.084 -16.867 2.692   1.00 96.09 24  A 1 
+ATOM 188  C CB  . VAL A 1 24  ? -26.226 -19.939 1.556   1.00 95.48 24  A 1 
+ATOM 189  C CG1 . VAL A 1 24  ? -25.294 -18.992 0.791   1.00 93.53 24  A 1 
+ATOM 190  C CG2 . VAL A 1 24  ? -25.387 -21.143 2.005   1.00 93.37 24  A 1 
+ATOM 191  N N   . CYS A 1 25  ? -28.771 -18.018 1.742   1.00 96.31 25  A 1 
+ATOM 192  C CA  . CYS A 1 25  ? -29.567 -16.833 1.398   1.00 96.30 25  A 1 
+ATOM 193  C C   . CYS A 1 25  ? -29.885 -15.979 2.636   1.00 96.30 25  A 1 
+ATOM 194  O O   . CYS A 1 25  ? -29.665 -14.767 2.636   1.00 95.65 25  A 1 
+ATOM 195  C CB  . CYS A 1 25  ? -30.866 -17.273 0.701   1.00 95.82 25  A 1 
+ATOM 196  S SG  . CYS A 1 25  ? -30.489 -17.999 -0.919  1.00 93.31 25  A 1 
+ATOM 197  N N   . ASN A 1 26  ? -30.333 -16.603 3.722   1.00 97.01 26  A 1 
+ATOM 198  C CA  . ASN A 1 26  ? -30.647 -15.906 4.972   1.00 96.74 26  A 1 
+ATOM 199  C C   . ASN A 1 26  ? -29.414 -15.233 5.593   1.00 96.83 26  A 1 
+ATOM 200  O O   . ASN A 1 26  ? -29.501 -14.092 6.062   1.00 95.85 26  A 1 
+ATOM 201  C CB  . ASN A 1 26  ? -31.284 -16.908 5.950   1.00 96.18 26  A 1 
+ATOM 202  C CG  . ASN A 1 26  ? -32.702 -17.288 5.554   1.00 91.19 26  A 1 
+ATOM 203  O OD1 . ASN A 1 26  ? -33.442 -16.517 4.969   1.00 80.37 26  A 1 
+ATOM 204  N ND2 . ASN A 1 26  ? -33.141 -18.472 5.910   1.00 80.71 26  A 1 
+ATOM 205  N N   . VAL A 1 27  ? -28.266 -15.910 5.571   1.00 96.95 27  A 1 
+ATOM 206  C CA  . VAL A 1 27  ? -26.986 -15.354 6.035   1.00 96.94 27  A 1 
+ATOM 207  C C   . VAL A 1 27  ? -26.611 -14.123 5.217   1.00 97.06 27  A 1 
+ATOM 208  O O   . VAL A 1 27  ? -26.348 -13.074 5.806   1.00 96.54 27  A 1 
+ATOM 209  C CB  . VAL A 1 27  ? -25.876 -16.425 6.013   1.00 96.65 27  A 1 
+ATOM 210  C CG1 . VAL A 1 27  ? -24.473 -15.826 6.173   1.00 95.19 27  A 1 
+ATOM 211  C CG2 . VAL A 1 27  ? -26.088 -17.414 7.170   1.00 95.12 27  A 1 
+ATOM 212  N N   . ILE A 1 28  ? -26.668 -14.207 3.886   1.00 96.91 28  A 1 
+ATOM 213  C CA  . ILE A 1 28  ? -26.359 -13.073 3.002   1.00 96.72 28  A 1 
+ATOM 214  C C   . ILE A 1 28  ? -27.328 -11.913 3.261   1.00 96.61 28  A 1 
+ATOM 215  O O   . ILE A 1 28  ? -26.885 -10.789 3.503   1.00 95.86 28  A 1 
+ATOM 216  C CB  . ILE A 1 28  ? -26.361 -13.511 1.521   1.00 96.42 28  A 1 
+ATOM 217  C CG1 . ILE A 1 28  ? -25.217 -14.516 1.249   1.00 95.47 28  A 1 
+ATOM 218  C CG2 . ILE A 1 28  ? -26.188 -12.282 0.600   1.00 95.20 28  A 1 
+ATOM 219  C CD1 . ILE A 1 28  ? -25.354 -15.260 -0.084  1.00 93.21 28  A 1 
+ATOM 220  N N   . ASN A 1 29  ? -28.633 -12.178 3.296   1.00 96.86 29  A 1 
+ATOM 221  C CA  . ASN A 1 29  ? -29.664 -11.164 3.539   1.00 96.40 29  A 1 
+ATOM 222  C C   . ASN A 1 29  ? -29.474 -10.447 4.887   1.00 96.30 29  A 1 
+ATOM 223  O O   . ASN A 1 29  ? -29.654 -9.232  4.980   1.00 95.51 29  A 1 
+ATOM 224  C CB  . ASN A 1 29  ? -31.047 -11.838 3.473   1.00 95.90 29  A 1 
+ATOM 225  C CG  . ASN A 1 29  ? -31.446 -12.268 2.070   1.00 95.18 29  A 1 
+ATOM 226  O OD1 . ASN A 1 29  ? -31.018 -11.709 1.074   1.00 89.36 29  A 1 
+ATOM 227  N ND2 . ASN A 1 29  ? -32.312 -13.247 1.954   1.00 89.21 29  A 1 
+ATOM 228  N N   . SER A 1 30  ? -29.070 -11.175 5.925   1.00 96.64 30  A 1 
+ATOM 229  C CA  . SER A 1 30  ? -28.782 -10.593 7.242   1.00 96.43 30  A 1 
+ATOM 230  C C   . SER A 1 30  ? -27.464 -9.804  7.288   1.00 96.78 30  A 1 
+ATOM 231  O O   . SER A 1 30  ? -27.362 -8.807  8.007   1.00 95.62 30  A 1 
+ATOM 232  C CB  . SER A 1 30  ? -28.803 -11.694 8.310   1.00 95.49 30  A 1 
+ATOM 233  O OG  . SER A 1 30  ? -27.640 -12.498 8.269   1.00 80.10 30  A 1 
+ATOM 234  N N   . ALA A 1 31  ? -26.475 -10.214 6.496   1.00 96.65 31  A 1 
+ATOM 235  C CA  . ALA A 1 31  ? -25.157 -9.589  6.403   1.00 96.65 31  A 1 
+ATOM 236  C C   . ALA A 1 31  ? -25.166 -8.299  5.569   1.00 96.71 31  A 1 
+ATOM 237  O O   . ALA A 1 31  ? -24.477 -7.330  5.905   1.00 96.16 31  A 1 
+ATOM 238  C CB  . ALA A 1 31  ? -24.204 -10.626 5.794   1.00 96.53 31  A 1 
+ATOM 239  N N   . PHE A 1 32  ? -25.964 -8.278  4.510   1.00 96.33 32  A 1 
+ATOM 240  C CA  . PHE A 1 32  ? -25.963 -7.227  3.492   1.00 95.69 32  A 1 
+ATOM 241  C C   . PHE A 1 32  ? -26.192 -5.805  4.049   1.00 95.83 32  A 1 
+ATOM 242  O O   . PHE A 1 32  ? -25.419 -4.911  3.700   1.00 95.01 32  A 1 
+ATOM 243  C CB  . PHE A 1 32  ? -26.958 -7.607  2.384   1.00 94.46 32  A 1 
+ATOM 244  C CG  . PHE A 1 32  ? -26.624 -7.005  1.033   1.00 93.04 32  A 1 
+ATOM 245  C CD1 . PHE A 1 32  ? -27.374 -5.927  0.519   1.00 88.84 32  A 1 
+ATOM 246  C CD2 . PHE A 1 32  ? -25.566 -7.540  0.274   1.00 89.13 32  A 1 
+ATOM 247  C CE1 . PHE A 1 32  ? -27.071 -5.401  -0.748  1.00 87.71 32  A 1 
+ATOM 248  C CE2 . PHE A 1 32  ? -25.262 -7.010  -0.992  1.00 88.04 32  A 1 
+ATOM 249  C CZ  . PHE A 1 32  ? -26.017 -5.940  -1.505  1.00 88.73 32  A 1 
+ATOM 250  N N   . PRO A 1 33  ? -27.120 -5.546  4.988   1.00 96.30 33  A 1 
+ATOM 251  C CA  . PRO A 1 33  ? -27.289 -4.213  5.580   1.00 96.18 33  A 1 
+ATOM 252  C C   . PRO A 1 33  ? -26.059 -3.697  6.345   1.00 96.62 33  A 1 
+ATOM 253  O O   . PRO A 1 33  ? -25.837 -2.487  6.425   1.00 96.13 33  A 1 
+ATOM 254  C CB  . PRO A 1 33  ? -28.492 -4.334  6.523   1.00 95.10 33  A 1 
+ATOM 255  C CG  . PRO A 1 33  ? -29.287 -5.511  5.959   1.00 93.04 33  A 1 
+ATOM 256  C CD  . PRO A 1 33  ? -28.187 -6.431  5.446   1.00 95.26 33  A 1 
+ATOM 257  N N   . VAL A 1 34  ? -25.277 -4.594  6.951   1.00 96.61 34  A 1 
+ATOM 258  C CA  . VAL A 1 34  ? -24.026 -4.226  7.631   1.00 97.13 34  A 1 
+ATOM 259  C C   . VAL A 1 34  ? -22.946 -3.937  6.598   1.00 97.36 34  A 1 
+ATOM 260  O O   . VAL A 1 34  ? -22.241 -2.935  6.728   1.00 96.97 34  A 1 
+ATOM 261  C CB  . VAL A 1 34  ? -23.562 -5.310  8.622   1.00 97.17 34  A 1 
+ATOM 262  C CG1 . VAL A 1 34  ? -22.294 -4.869  9.369   1.00 95.95 34  A 1 
+ATOM 263  C CG2 . VAL A 1 34  ? -24.639 -5.610  9.675   1.00 95.64 34  A 1 
+ATOM 264  N N   . HIS A 1 35  ? -22.866 -4.763  5.553   1.00 97.28 35  A 1 
+ATOM 265  C CA  . HIS A 1 35  ? -21.958 -4.538  4.434   1.00 97.17 35  A 1 
+ATOM 266  C C   . HIS A 1 35  ? -22.235 -3.199  3.733   1.00 96.79 35  A 1 
+ATOM 267  O O   . HIS A 1 35  ? -21.302 -2.433  3.528   1.00 96.27 35  A 1 
+ATOM 268  C CB  . HIS A 1 35  ? -22.048 -5.708  3.451   1.00 97.15 35  A 1 
+ATOM 269  C CG  . HIS A 1 35  ? -21.217 -5.447  2.228   1.00 97.11 35  A 1 
+ATOM 270  N ND1 . HIS A 1 35  ? -19.849 -5.262  2.200   1.00 92.19 35  A 1 
+ATOM 271  C CD2 . HIS A 1 35  ? -21.697 -5.226  0.969   1.00 93.32 35  A 1 
+ATOM 272  C CE1 . HIS A 1 35  ? -19.525 -4.929  0.942   1.00 93.73 35  A 1 
+ATOM 273  N NE2 . HIS A 1 35  ? -20.611 -4.898  0.169   1.00 94.13 35  A 1 
+ATOM 274  N N   . LEU A 1 36  ? -23.494 -2.848  3.463   1.00 96.54 36  A 1 
+ATOM 275  C CA  . LEU A 1 36  ? -23.849 -1.562  2.846   1.00 96.00 36  A 1 
+ATOM 276  C C   . LEU A 1 36  ? -23.396 -0.355  3.682   1.00 96.10 36  A 1 
+ATOM 277  O O   . LEU A 1 36  ? -22.969 0.652   3.122   1.00 95.66 36  A 1 
+ATOM 278  C CB  . LEU A 1 36  ? -25.367 -1.494  2.613   1.00 95.25 36  A 1 
+ATOM 279  C CG  . LEU A 1 36  ? -25.899 -2.385  1.477   1.00 91.69 36  A 1 
+ATOM 280  C CD1 . LEU A 1 36  ? -27.418 -2.214  1.401   1.00 87.24 36  A 1 
+ATOM 281  C CD2 . LEU A 1 36  ? -25.301 -2.027  0.115   1.00 87.75 36  A 1 
+ATOM 282  N N   . LYS A 1 37  ? -23.441 -0.450  5.015   1.00 96.47 37  A 1 
+ATOM 283  C CA  . LYS A 1 37  ? -22.886 0.602   5.888   1.00 96.44 37  A 1 
+ATOM 284  C C   . LYS A 1 37  ? -21.368 0.698   5.753   1.00 96.80 37  A 1 
+ATOM 285  O O   . LYS A 1 37  ? -20.855 1.807   5.634   1.00 96.45 37  A 1 
+ATOM 286  C CB  . LYS A 1 37  ? -23.274 0.359   7.347   1.00 96.07 37  A 1 
+ATOM 287  C CG  . LYS A 1 37  ? -24.768 0.604   7.571   1.00 85.55 37  A 1 
+ATOM 288  C CD  . LYS A 1 37  ? -25.145 0.261   9.013   1.00 80.41 37  A 1 
+ATOM 289  C CE  . LYS A 1 37  ? -26.653 0.454   9.163   1.00 70.47 37  A 1 
+ATOM 290  N NZ  . LYS A 1 37  ? -27.108 0.156   10.543  1.00 60.21 37  A 1 
+ATOM 291  N N   . ASN A 1 38  ? -20.678 -0.439  5.744   1.00 97.30 38  A 1 
+ATOM 292  C CA  . ASN A 1 38  ? -19.236 -0.470  5.504   1.00 97.61 38  A 1 
+ATOM 293  C C   . ASN A 1 38  ? -18.902 0.086   4.111   1.00 97.71 38  A 1 
+ATOM 294  O O   . ASN A 1 38  ? -17.987 0.892   3.997   1.00 97.46 38  A 1 
+ATOM 295  C CB  . ASN A 1 38  ? -18.705 -1.906  5.654   1.00 97.72 38  A 1 
+ATOM 296  C CG  . ASN A 1 38  ? -18.709 -2.455  7.070   1.00 97.66 38  A 1 
+ATOM 297  O OD1 . ASN A 1 38  ? -18.802 -1.761  8.073   1.00 94.48 38  A 1 
+ATOM 298  N ND2 . ASN A 1 38  ? -18.553 -3.753  7.200   1.00 94.22 38  A 1 
+ATOM 299  N N   . LYS A 1 39  ? -19.678 -0.269  3.080   1.00 97.49 39  A 1 
+ATOM 300  C CA  . LYS A 1 39  ? -19.526 0.225   1.707   1.00 97.36 39  A 1 
+ATOM 301  C C   . LYS A 1 39  ? -19.586 1.749   1.628   1.00 97.47 39  A 1 
+ATOM 302  O O   . LYS A 1 39  ? -18.716 2.346   1.018   1.00 97.02 39  A 1 
+ATOM 303  C CB  . LYS A 1 39  ? -20.574 -0.441  0.798   1.00 96.86 39  A 1 
+ATOM 304  C CG  . LYS A 1 39  ? -20.541 0.169   -0.615  1.00 96.16 39  A 1 
+ATOM 305  C CD  . LYS A 1 39  ? -21.355 -0.643  -1.631  1.00 94.29 39  A 1 
+ATOM 306  C CE  . LYS A 1 39  ? -21.375 0.055   -3.005  1.00 90.04 39  A 1 
+ATOM 307  N NZ  . LYS A 1 39  ? -20.017 0.371   -3.525  1.00 84.65 39  A 1 
+ATOM 308  N N   . ILE A 1 40  ? -20.552 2.388   2.290   1.00 96.75 40  A 1 
+ATOM 309  C CA  . ILE A 1 40  ? -20.660 3.862   2.301   1.00 96.60 40  A 1 
+ATOM 310  C C   . ILE A 1 40  ? -19.387 4.508   2.874   1.00 96.94 40  A 1 
+ATOM 311  O O   . ILE A 1 40  ? -18.922 5.527   2.365   1.00 96.71 40  A 1 
+ATOM 312  C CB  . ILE A 1 40  ? -21.914 4.301   3.093   1.00 96.06 40  A 1 
+ATOM 313  C CG1 . ILE A 1 40  ? -23.203 3.906   2.333   1.00 94.21 40  A 1 
+ATOM 314  C CG2 . ILE A 1 40  ? -21.926 5.823   3.364   1.00 93.94 40  A 1 
+ATOM 315  C CD1 . ILE A 1 40  ? -24.468 3.944   3.206   1.00 88.02 40  A 1 
+ATOM 316  N N   . GLU A 1 41  ? -18.828 3.927   3.937   1.00 97.01 41  A 1 
+ATOM 317  C CA  . GLU A 1 41  ? -17.577 4.421   4.520   1.00 97.33 41  A 1 
+ATOM 318  C C   . GLU A 1 41  ? -16.377 4.154   3.599   1.00 97.66 41  A 1 
+ATOM 319  O O   . GLU A 1 41  ? -15.533 5.036   3.442   1.00 97.51 41  A 1 
+ATOM 320  C CB  . GLU A 1 41  ? -17.336 3.791   5.900   1.00 97.19 41  A 1 
+ATOM 321  C CG  . GLU A 1 41  ? -18.377 4.183   6.962   1.00 96.23 41  A 1 
+ATOM 322  C CD  . GLU A 1 41  ? -18.074 3.600   8.356   1.00 95.35 41  A 1 
+ATOM 323  O OE1 . GLU A 1 41  ? -18.945 3.742   9.250   1.00 90.21 41  A 1 
+ATOM 324  O OE2 . GLU A 1 41  ? -16.967 3.040   8.567   1.00 91.11 41  A 1 
+ATOM 325  N N   . ILE A 1 42  ? -16.313 2.976   2.979   1.00 98.01 42  A 1 
+ATOM 326  C CA  . ILE A 1 42  ? -15.265 2.594   2.021   1.00 98.19 42  A 1 
+ATOM 327  C C   . ILE A 1 42  ? -15.289 3.515   0.799   1.00 98.18 42  A 1 
+ATOM 328  O O   . ILE A 1 42  ? -14.253 4.074   0.450   1.00 98.05 42  A 1 
+ATOM 329  C CB  . ILE A 1 42  ? -15.415 1.103   1.630   1.00 98.22 42  A 1 
+ATOM 330  C CG1 . ILE A 1 42  ? -14.991 0.201   2.814   1.00 97.71 42  A 1 
+ATOM 331  C CG2 . ILE A 1 42  ? -14.588 0.751   0.383   1.00 97.70 42  A 1 
+ATOM 332  C CD1 . ILE A 1 42  ? -15.450 -1.258  2.684   1.00 95.46 42  A 1 
+ATOM 333  N N   . ASP A 1 43  ? -16.456 3.727   0.197   1.00 97.83 43  A 1 
+ATOM 334  C CA  . ASP A 1 43  ? -16.618 4.592   -0.976  1.00 97.60 43  A 1 
+ATOM 335  C C   . ASP A 1 43  ? -16.180 6.031   -0.651  1.00 97.77 43  A 1 
+ATOM 336  O O   . ASP A 1 43  ? -15.424 6.637   -1.414  1.00 97.45 43  A 1 
+ATOM 337  C CB  . ASP A 1 43  ? -18.080 4.546   -1.471  1.00 97.15 43  A 1 
+ATOM 338  C CG  . ASP A 1 43  ? -18.534 3.206   -2.087  1.00 96.13 43  A 1 
+ATOM 339  O OD1 . ASP A 1 43  ? -17.700 2.380   -2.506  1.00 93.40 43  A 1 
+ATOM 340  O OD2 . ASP A 1 43  ? -19.766 2.975   -2.186  1.00 93.05 43  A 1 
+ATOM 341  N N   . TYR A 1 44  ? -16.545 6.552   0.530   1.00 97.50 44  A 1 
+ATOM 342  C CA  . TYR A 1 44  ? -16.078 7.865   0.996   1.00 97.57 44  A 1 
+ATOM 343  C C   . TYR A 1 44  ? -14.549 7.930   1.127   1.00 97.81 44  A 1 
+ATOM 344  O O   . TYR A 1 44  ? -13.935 8.908   0.697   1.00 97.61 44  A 1 
+ATOM 345  C CB  . TYR A 1 44  ? -16.747 8.209   2.338   1.00 97.47 44  A 1 
+ATOM 346  C CG  . TYR A 1 44  ? -16.192 9.471   2.984   1.00 97.42 44  A 1 
+ATOM 347  C CD1 . TYR A 1 44  ? -15.224 9.379   4.012   1.00 96.59 44  A 1 
+ATOM 348  C CD2 . TYR A 1 44  ? -16.589 10.734  2.512   1.00 96.78 44  A 1 
+ATOM 349  C CE1 . TYR A 1 44  ? -14.665 10.550  4.563   1.00 96.36 44  A 1 
+ATOM 350  C CE2 . TYR A 1 44  ? -16.032 11.911  3.062   1.00 96.43 44  A 1 
+ATOM 351  C CZ  . TYR A 1 44  ? -15.068 11.816  4.089   1.00 96.60 44  A 1 
+ATOM 352  O OH  . TYR A 1 44  ? -14.525 12.949  4.618   1.00 95.49 44  A 1 
+ATOM 353  N N   . LEU A 1 45  ? -13.913 6.913   1.719   1.00 97.86 45  A 1 
+ATOM 354  C CA  . LEU A 1 45  ? -12.456 6.872   1.887   1.00 98.10 45  A 1 
+ATOM 355  C C   . LEU A 1 45  ? -11.734 6.739   0.537   1.00 98.19 45  A 1 
+ATOM 356  O O   . LEU A 1 45  ? -10.716 7.394   0.311   1.00 98.07 45  A 1 
+ATOM 357  C CB  . LEU A 1 45  ? -12.084 5.710   2.828   1.00 98.11 45  A 1 
+ATOM 358  C CG  . LEU A 1 45  ? -12.517 5.898   4.292   1.00 97.66 45  A 1 
+ATOM 359  C CD1 . LEU A 1 45  ? -12.340 4.579   5.045   1.00 97.12 45  A 1 
+ATOM 360  C CD2 . LEU A 1 45  ? -11.698 6.969   5.013   1.00 96.78 45  A 1 
+ATOM 361  N N   . MET A 1 46  ? -12.286 5.950   -0.384  1.00 98.41 46  A 1 
+ATOM 362  C CA  . MET A 1 46  ? -11.764 5.809   -1.745  1.00 98.40 46  A 1 
+ATOM 363  C C   . MET A 1 46  ? -11.875 7.116   -2.538  1.00 98.44 46  A 1 
+ATOM 364  O O   . MET A 1 46  ? -10.922 7.512   -3.212  1.00 98.12 46  A 1 
+ATOM 365  C CB  . MET A 1 46  ? -12.509 4.670   -2.464  1.00 98.13 46  A 1 
+ATOM 366  C CG  . MET A 1 46  ? -12.100 3.286   -1.944  1.00 94.30 46  A 1 
+ATOM 367  S SD  . MET A 1 46  ? -10.362 2.837   -2.253  1.00 88.32 46  A 1 
+ATOM 368  C CE  . MET A 1 46  ? -10.415 2.489   -4.025  1.00 73.37 46  A 1 
+ATOM 369  N N   . ASP A 1 47  ? -12.998 7.825   -2.420  1.00 98.16 47  A 1 
+ATOM 370  C CA  . ASP A 1 47  ? -13.177 9.144   -3.033  1.00 98.07 47  A 1 
+ATOM 371  C C   . ASP A 1 47  ? -12.221 10.182  -2.439  1.00 98.25 47  A 1 
+ATOM 372  O O   . ASP A 1 47  ? -11.570 10.920  -3.182  1.00 97.85 47  A 1 
+ATOM 373  C CB  . ASP A 1 47  ? -14.633 9.600   -2.869  1.00 97.58 47  A 1 
+ATOM 374  C CG  . ASP A 1 47  ? -15.591 9.020   -3.916  1.00 95.58 47  A 1 
+ATOM 375  O OD1 . ASP A 1 47  ? -15.101 8.463   -4.934  1.00 90.99 47  A 1 
+ATOM 376  O OD2 . ASP A 1 47  ? -16.805 9.277   -3.756  1.00 90.58 47  A 1 
+ATOM 377  N N   . TYR A 1 48  ? -12.074 10.198  -1.113  1.00 98.04 48  A 1 
+ATOM 378  C CA  . TYR A 1 48  ? -11.132 11.079  -0.418  1.00 98.18 48  A 1 
+ATOM 379  C C   . TYR A 1 48  ? -9.692  10.830  -0.883  1.00 98.33 48  A 1 
+ATOM 380  O O   . TYR A 1 48  ? -8.963  11.776  -1.202  1.00 98.00 48  A 1 
+ATOM 381  C CB  . TYR A 1 48  ? -11.282 10.890  1.101   1.00 98.10 48  A 1 
+ATOM 382  C CG  . TYR A 1 48  ? -10.585 11.965  1.919   1.00 98.24 48  A 1 
+ATOM 383  C CD1 . TYR A 1 48  ? -9.185  11.963  2.068   1.00 97.85 48  A 1 
+ATOM 384  C CD2 . TYR A 1 48  ? -11.344 12.987  2.523   1.00 97.86 48  A 1 
+ATOM 385  C CE1 . TYR A 1 48  ? -8.544  12.987  2.788   1.00 97.70 48  A 1 
+ATOM 386  C CE2 . TYR A 1 48  ? -10.711 14.010  3.253   1.00 97.69 48  A 1 
+ATOM 387  C CZ  . TYR A 1 48  ? -9.305  14.016  3.376   1.00 97.93 48  A 1 
+ATOM 388  O OH  . TYR A 1 48  ? -8.681  15.014  4.060   1.00 97.46 48  A 1 
+ATOM 389  N N   . TYR A 1 49  ? -9.289  9.565   -0.996  1.00 98.31 49  A 1 
+ATOM 390  C CA  . TYR A 1 49  ? -7.981  9.158   -1.523  1.00 98.45 49  A 1 
+ATOM 391  C C   . TYR A 1 49  ? -7.760  9.615   -2.974  1.00 98.45 49  A 1 
+ATOM 392  O O   . TYR A 1 49  ? -6.663  10.056  -3.331  1.00 98.04 49  A 1 
+ATOM 393  C CB  . TYR A 1 49  ? -7.852  7.635   -1.411  1.00 98.45 49  A 1 
+ATOM 394  C CG  . TYR A 1 49  ? -6.588  7.085   -2.041  1.00 98.49 49  A 1 
+ATOM 395  C CD1 . TYR A 1 49  ? -6.614  6.559   -3.352  1.00 97.82 49  A 1 
+ATOM 396  C CD2 . TYR A 1 49  ? -5.377  7.125   -1.329  1.00 97.98 49  A 1 
+ATOM 397  C CE1 . TYR A 1 49  ? -5.435  6.065   -3.938  1.00 97.77 49  A 1 
+ATOM 398  C CE2 . TYR A 1 49  ? -4.194  6.632   -1.912  1.00 97.81 49  A 1 
+ATOM 399  C CZ  . TYR A 1 49  ? -4.222  6.098   -3.217  1.00 97.96 49  A 1 
+ATOM 400  O OH  . TYR A 1 49  ? -3.082  5.612   -3.774  1.00 97.09 49  A 1 
+ATOM 401  N N   . LYS A 1 50  ? -8.804  9.568   -3.810  1.00 98.22 50  A 1 
+ATOM 402  C CA  . LYS A 1 50  ? -8.775  10.037  -5.207  1.00 98.19 50  A 1 
+ATOM 403  C C   . LYS A 1 50  ? -8.789  11.566  -5.337  1.00 98.18 50  A 1 
+ATOM 404  O O   . LYS A 1 50  ? -8.672  12.074  -6.447  1.00 97.09 50  A 1 
+ATOM 405  C CB  . LYS A 1 50  ? -9.933  9.386   -5.981  1.00 97.83 50  A 1 
+ATOM 406  C CG  . LYS A 1 50  ? -9.733  7.870   -6.185  1.00 97.06 50  A 1 
+ATOM 407  C CD  . LYS A 1 50  ? -11.030 7.232   -6.700  1.00 95.28 50  A 1 
+ATOM 408  C CE  . LYS A 1 50  ? -10.895 5.705   -6.777  1.00 90.75 50  A 1 
+ATOM 409  N NZ  . LYS A 1 50  ? -12.208 5.052   -7.021  1.00 85.24 50  A 1 
+ATOM 410  N N   . GLY A 1 51  ? -8.905  12.303  -4.229  1.00 97.88 51  A 1 
+ATOM 411  C CA  . GLY A 1 51  ? -8.861  13.767  -4.188  1.00 97.86 51  A 1 
+ATOM 412  C C   . GLY A 1 51  ? -10.222 14.454  -4.127  1.00 98.14 51  A 1 
+ATOM 413  O O   . GLY A 1 51  ? -10.265 15.684  -4.129  1.00 97.22 51  A 1 
+ATOM 414  N N   . ASN A 1 52  ? -11.317 13.709  -4.030  1.00 98.25 52  A 1 
+ATOM 415  C CA  . ASN A 1 52  ? -12.642 14.271  -3.766  1.00 98.16 52  A 1 
+ATOM 416  C C   . ASN A 1 52  ? -12.793 14.572  -2.264  1.00 98.23 52  A 1 
+ATOM 417  O O   . ASN A 1 52  ? -13.400 13.820  -1.507  1.00 97.49 52  A 1 
+ATOM 418  C CB  . ASN A 1 52  ? -13.712 13.318  -4.311  1.00 97.54 52  A 1 
+ATOM 419  C CG  . ASN A 1 52  ? -15.113 13.894  -4.202  1.00 95.76 52  A 1 
+ATOM 420  O OD1 . ASN A 1 52  ? -15.320 15.095  -4.068  1.00 88.63 52  A 1 
+ATOM 421  N ND2 . ASN A 1 52  ? -16.120 13.054  -4.279  1.00 87.92 52  A 1 
+ATOM 422  N N   . GLN A 1 53  ? -12.181 15.674  -1.828  1.00 97.94 53  A 1 
+ATOM 423  C CA  . GLN A 1 53  ? -12.098 16.053  -0.418  1.00 98.17 53  A 1 
+ATOM 424  C C   . GLN A 1 53  ? -13.091 17.182  -0.072  1.00 98.29 53  A 1 
+ATOM 425  O O   . GLN A 1 53  ? -13.450 17.971  -0.952  1.00 97.84 53  A 1 
+ATOM 426  C CB  . GLN A 1 53  ? -10.648 16.421  -0.067  1.00 97.95 53  A 1 
+ATOM 427  C CG  . GLN A 1 53  ? -9.700  15.226  -0.279  1.00 97.47 53  A 1 
+ATOM 428  C CD  . GLN A 1 53  ? -8.265  15.472  0.163   1.00 97.60 53  A 1 
+ATOM 429  O OE1 . GLN A 1 53  ? -7.907  16.486  0.738   1.00 93.54 53  A 1 
+ATOM 430  N NE2 . GLN A 1 53  ? -7.374  14.533  -0.091  1.00 92.97 53  A 1 
+ATOM 431  N N   . PRO A 1 54  ? -13.503 17.318  1.210   1.00 98.17 54  A 1 
+ATOM 432  C CA  . PRO A 1 54  ? -14.523 18.288  1.629   1.00 98.09 54  A 1 
+ATOM 433  C C   . PRO A 1 54  ? -14.251 19.738  1.219   1.00 98.29 54  A 1 
+ATOM 434  O O   . PRO A 1 54  ? -15.196 20.479  0.941   1.00 97.73 54  A 1 
+ATOM 435  C CB  . PRO A 1 54  ? -14.597 18.158  3.155   1.00 97.46 54  A 1 
+ATOM 436  C CG  . PRO A 1 54  ? -14.242 16.696  3.392   1.00 95.93 54  A 1 
+ATOM 437  C CD  . PRO A 1 54  ? -13.180 16.432  2.324   1.00 97.64 54  A 1 
+ATOM 438  N N   . ILE A 1 55  ? -12.990 20.137  1.110   1.00 98.00 55  A 1 
+ATOM 439  C CA  . ILE A 1 55  ? -12.596 21.489  0.677   1.00 98.24 55  A 1 
+ATOM 440  C C   . ILE A 1 55  ? -13.183 21.885  -0.689  1.00 98.38 55  A 1 
+ATOM 441  O O   . ILE A 1 55  ? -13.477 23.061  -0.915  1.00 98.07 55  A 1 
+ATOM 442  C CB  . ILE A 1 55  ? -11.057 21.617  0.687   1.00 98.02 55  A 1 
+ATOM 443  C CG1 . ILE A 1 55  ? -10.565 23.069  0.510   1.00 97.01 55  A 1 
+ATOM 444  C CG2 . ILE A 1 55  ? -10.388 20.741  -0.387  1.00 96.74 55  A 1 
+ATOM 445  C CD1 . ILE A 1 55  ? -11.045 24.021  1.608   1.00 94.50 55  A 1 
+ATOM 446  N N   . LEU A 1 56  ? -13.431 20.922  -1.585  1.00 98.02 56  A 1 
+ATOM 447  C CA  . LEU A 1 56  ? -14.044 21.182  -2.894  1.00 97.98 56  A 1 
+ATOM 448  C C   . LEU A 1 56  ? -15.480 21.715  -2.773  1.00 97.98 56  A 1 
+ATOM 449  O O   . LEU A 1 56  ? -15.956 22.416  -3.672  1.00 97.28 56  A 1 
+ATOM 450  C CB  . LEU A 1 56  ? -14.011 19.899  -3.740  1.00 97.93 56  A 1 
+ATOM 451  C CG  . LEU A 1 56  ? -12.599 19.404  -4.103  1.00 97.36 56  A 1 
+ATOM 452  C CD1 . LEU A 1 56  ? -12.713 18.113  -4.906  1.00 95.44 56  A 1 
+ATOM 453  C CD2 . LEU A 1 56  ? -11.828 20.431  -4.944  1.00 95.59 56  A 1 
+ATOM 454  N N   . ASN A 1 57  ? -16.131 21.456  -1.646  1.00 98.10 57  A 1 
+ATOM 455  C CA  . ASN A 1 57  ? -17.473 21.936  -1.317  1.00 97.71 57  A 1 
+ATOM 456  C C   . ASN A 1 57  ? -17.465 23.221  -0.473  1.00 97.69 57  A 1 
+ATOM 457  O O   . ASN A 1 57  ? -18.522 23.659  -0.021  1.00 96.38 57  A 1 
+ATOM 458  C CB  . ASN A 1 57  ? -18.254 20.792  -0.650  1.00 97.17 57  A 1 
+ATOM 459  C CG  . ASN A 1 57  ? -18.395 19.596  -1.575  1.00 95.34 57  A 1 
+ATOM 460  O OD1 . ASN A 1 57  ? -18.709 19.730  -2.743  1.00 86.29 57  A 1 
+ATOM 461  N ND2 . ASN A 1 57  ? -18.166 18.402  -1.087  1.00 85.70 57  A 1 
+ATOM 462  N N   . LYS A 1 58  ? -16.307 23.854  -0.266  1.00 97.36 58  A 1 
+ATOM 463  C CA  . LYS A 1 58  ? -16.185 25.137  0.439   1.00 97.06 58  A 1 
+ATOM 464  C C   . LYS A 1 58  ? -17.093 26.175  -0.219  1.00 97.21 58  A 1 
+ATOM 465  O O   . LYS A 1 58  ? -17.010 26.421  -1.428  1.00 96.20 58  A 1 
+ATOM 466  C CB  . LYS A 1 58  ? -14.712 25.578  0.442   1.00 96.03 58  A 1 
+ATOM 467  C CG  . LYS A 1 58  ? -14.453 26.922  1.148   1.00 95.58 58  A 1 
+ATOM 468  C CD  . LYS A 1 58  ? -12.979 27.327  0.971   1.00 93.62 58  A 1 
+ATOM 469  C CE  . LYS A 1 58  ? -12.676 28.726  1.502   1.00 88.87 58  A 1 
+ATOM 470  N NZ  . LYS A 1 58  ? -11.326 29.176  1.077   1.00 85.84 58  A 1 
+ATOM 471  N N   . VAL A 1 59  ? -17.918 26.816  0.598   1.00 96.64 59  A 1 
+ATOM 472  C CA  . VAL A 1 59  ? -18.770 27.944  0.205   1.00 96.13 59  A 1 
+ATOM 473  C C   . VAL A 1 59  ? -18.341 29.164  1.005   1.00 95.54 59  A 1 
+ATOM 474  O O   . VAL A 1 59  ? -18.097 29.074  2.206   1.00 93.36 59  A 1 
+ATOM 475  C CB  . VAL A 1 59  ? -20.263 27.627  0.410   1.00 95.32 59  A 1 
+ATOM 476  C CG1 . VAL A 1 59  ? -21.150 28.806  -0.014  1.00 91.04 59  A 1 
+ATOM 477  C CG2 . VAL A 1 59  ? -20.690 26.408  -0.421  1.00 91.23 59  A 1 
+ATOM 478  N N   . LYS A 1 60  ? -18.245 30.306  0.328   1.00 93.95 60  A 1 
+ATOM 479  C CA  . LYS A 1 60  ? -17.924 31.591  0.951   1.00 91.83 60  A 1 
+ATOM 480  C C   . LYS A 1 60  ? -19.086 32.550  0.710   1.00 92.23 60  A 1 
+ATOM 481  O O   . LYS A 1 60  ? -19.446 32.808  -0.433  1.00 89.19 60  A 1 
+ATOM 482  C CB  . LYS A 1 60  ? -16.589 32.079  0.378   1.00 88.14 60  A 1 
+ATOM 483  C CG  . LYS A 1 60  ? -16.023 33.286  1.133   1.00 83.16 60  A 1 
+ATOM 484  C CD  . LYS A 1 60  ? -14.665 33.645  0.521   1.00 81.57 60  A 1 
+ATOM 485  C CE  . LYS A 1 60  ? -14.022 34.853  1.188   1.00 75.43 60  A 1 
+ATOM 486  N NZ  . LYS A 1 60  ? -12.770 35.200  0.483   1.00 70.19 60  A 1 
+ATOM 487  N N   . GLU A 1 61  ? -19.666 33.067  1.794   1.00 88.45 61  A 1 
+ATOM 488  C CA  . GLU A 1 61  ? -20.828 33.965  1.713   1.00 87.23 61  A 1 
+ATOM 489  C C   . GLU A 1 61  ? -20.424 35.395  1.337   1.00 86.87 61  A 1 
+ATOM 490  O O   . GLU A 1 61  ? -21.093 36.061  0.551   1.00 81.65 61  A 1 
+ATOM 491  C CB  . GLU A 1 61  ? -21.570 33.979  3.058   1.00 86.03 61  A 1 
+ATOM 492  C CG  . GLU A 1 61  ? -22.168 32.613  3.433   1.00 79.57 61  A 1 
+ATOM 493  C CD  . GLU A 1 61  ? -22.981 32.647  4.741   1.00 73.23 61  A 1 
+ATOM 494  O OE1 . GLU A 1 61  ? -23.624 31.615  5.035   1.00 66.24 61  A 1 
+ATOM 495  O OE2 . GLU A 1 61  ? -22.957 33.691  5.435   1.00 69.02 61  A 1 
+ATOM 496  N N   . ILE A 1 62  ? -19.304 35.873  1.886   1.00 85.08 62  A 1 
+ATOM 497  C CA  . ILE A 1 62  ? -18.786 37.222  1.647   1.00 82.15 62  A 1 
+ATOM 498  C C   . ILE A 1 62  ? -17.661 37.138  0.615   1.00 80.61 62  A 1 
+ATOM 499  O O   . ILE A 1 62  ? -16.688 36.408  0.824   1.00 75.42 62  A 1 
+ATOM 500  C CB  . ILE A 1 62  ? -18.323 37.881  2.967   1.00 79.93 62  A 1 
+ATOM 501  C CG1 . ILE A 1 62  ? -19.475 37.915  4.001   1.00 74.86 62  A 1 
+ATOM 502  C CG2 . ILE A 1 62  ? -17.798 39.303  2.692   1.00 75.37 62  A 1 
+ATOM 503  C CD1 . ILE A 1 62  ? -19.066 38.438  5.384   1.00 68.17 62  A 1 
+ATOM 504  N N   . ARG A 1 63  ? -17.775 37.938  -0.460  1.00 82.72 63  A 1 
+ATOM 505  C CA  . ARG A 1 63  ? -16.836 37.946  -1.589  1.00 82.29 63  A 1 
+ATOM 506  C C   . ARG A 1 63  ? -16.661 36.546  -2.191  1.00 85.12 63  A 1 
+ATOM 507  O O   . ARG A 1 63  ? -15.563 35.994  -2.228  1.00 83.16 63  A 1 
+ATOM 508  C CB  . ARG A 1 63  ? -15.495 38.591  -1.209  1.00 79.36 63  A 1 
+ATOM 509  C CG  . ARG A 1 63  ? -15.617 40.033  -0.708  1.00 75.90 63  A 1 
+ATOM 510  C CD  . ARG A 1 63  ? -14.240 40.714  -0.685  1.00 71.17 63  A 1 
+ATOM 511  N NE  . ARG A 1 63  ? -13.734 40.885  -2.053  1.00 65.86 63  A 1 
+ATOM 512  C CZ  . ARG A 1 63  ? -12.545 41.316  -2.429  1.00 60.06 63  A 1 
+ATOM 513  N NH1 . ARG A 1 63  ? -11.617 41.660  -1.581  1.00 57.13 63  A 1 
+ATOM 514  N NH2 . ARG A 1 63  ? -12.281 41.405  -3.700  1.00 54.55 63  A 1 
+ATOM 515  N N   . SER A 1 64  ? -17.774 35.973  -2.638  1.00 85.42 64  A 1 
+ATOM 516  C CA  . SER A 1 64  ? -17.823 34.629  -3.229  1.00 87.17 64  A 1 
+ATOM 517  C C   . SER A 1 64  ? -16.992 34.480  -4.507  1.00 88.45 64  A 1 
+ATOM 518  O O   . SER A 1 64  ? -16.667 33.359  -4.887  1.00 85.11 64  A 1 
+ATOM 519  C CB  . SER A 1 64  ? -19.274 34.243  -3.518  1.00 85.67 64  A 1 
+ATOM 520  O OG  . SER A 1 64  ? -19.903 35.207  -4.343  1.00 80.79 64  A 1 
+ATOM 521  N N   . GLU A 1 65  ? -16.634 35.603  -5.149  1.00 90.48 65  A 1 
+ATOM 522  C CA  . GLU A 1 65  ? -15.745 35.639  -6.309  1.00 90.11 65  A 1 
+ATOM 523  C C   . GLU A 1 65  ? -14.305 35.206  -5.990  1.00 91.44 65  A 1 
+ATOM 524  O O   . GLU A 1 65  ? -13.587 34.784  -6.886  1.00 88.63 65  A 1 
+ATOM 525  C CB  . GLU A 1 65  ? -15.797 37.042  -6.962  1.00 87.02 65  A 1 
+ATOM 526  C CG  . GLU A 1 65  ? -15.075 38.211  -6.241  1.00 78.23 65  A 1 
+ATOM 527  C CD  . GLU A 1 65  ? -15.744 38.770  -4.965  1.00 75.18 65  A 1 
+ATOM 528  O OE1 . GLU A 1 65  ? -15.123 39.663  -4.330  1.00 67.67 65  A 1 
+ATOM 529  O OE2 . GLU A 1 65  ? -16.842 38.309  -4.585  1.00 68.40 65  A 1 
+ATOM 530  N N   . ILE A 1 66  ? -13.896 35.284  -4.712  1.00 89.46 66  A 1 
+ATOM 531  C CA  . ILE A 1 66  ? -12.591 34.832  -4.218  1.00 89.71 66  A 1 
+ATOM 532  C C   . ILE A 1 66  ? -12.824 33.619  -3.319  1.00 91.11 66  A 1 
+ATOM 533  O O   . ILE A 1 66  ? -13.094 33.762  -2.122  1.00 89.75 66  A 1 
+ATOM 534  C CB  . ILE A 1 66  ? -11.840 35.968  -3.490  1.00 87.43 66  A 1 
+ATOM 535  C CG1 . ILE A 1 66  ? -11.636 37.189  -4.413  1.00 84.15 66  A 1 
+ATOM 536  C CG2 . ILE A 1 66  ? -10.484 35.449  -2.973  1.00 83.92 66  A 1 
+ATOM 537  C CD1 . ILE A 1 66  ? -11.053 38.405  -3.695  1.00 78.59 66  A 1 
+ATOM 538  N N   . ASN A 1 67  ? -12.765 32.438  -3.886  1.00 92.92 67  A 1 
+ATOM 539  C CA  . ASN A 1 67  ? -13.019 31.178  -3.195  1.00 94.88 67  A 1 
+ATOM 540  C C   . ASN A 1 67  ? -12.104 30.070  -3.728  1.00 95.81 67  A 1 
+ATOM 541  O O   . ASN A 1 67  ? -12.515 29.232  -4.539  1.00 94.18 67  A 1 
+ATOM 542  C CB  . ASN A 1 67  ? -14.511 30.836  -3.313  1.00 93.88 67  A 1 
+ATOM 543  C CG  . ASN A 1 67  ? -14.901 29.610  -2.504  1.00 94.40 67  A 1 
+ATOM 544  O OD1 . ASN A 1 67  ? -14.241 29.177  -1.577  1.00 89.45 67  A 1 
+ATOM 545  N ND2 . ASN A 1 67  ? -16.033 29.024  -2.813  1.00 89.85 67  A 1 
+ATOM 546  N N   . ASN A 1 68  ? -10.870 30.074  -3.273  1.00 95.90 68  A 1 
+ATOM 547  C CA  . ASN A 1 68  ? -9.890  29.059  -3.622  1.00 96.18 68  A 1 
+ATOM 548  C C   . ASN A 1 68  ? -10.196 27.725  -2.932  1.00 96.87 68  A 1 
+ATOM 549  O O   . ASN A 1 68  ? -10.572 27.672  -1.755  1.00 96.01 68  A 1 
+ATOM 550  C CB  . ASN A 1 68  ? -8.483  29.574  -3.303  1.00 95.27 68  A 1 
+ATOM 551  C CG  . ASN A 1 68  ? -8.055  30.602  -4.324  1.00 93.73 68  A 1 
+ATOM 552  O OD1 . ASN A 1 68  ? -7.695  30.237  -5.431  1.00 86.41 68  A 1 
+ATOM 553  N ND2 . ASN A 1 68  ? -8.132  31.875  -4.018  1.00 86.19 68  A 1 
+ATOM 554  N N   . LYS A 1 69  ? -10.022 26.635  -3.670  1.00 96.87 69  A 1 
+ATOM 555  C CA  . LYS A 1 69  ? -10.288 25.256  -3.252  1.00 97.41 69  A 1 
+ATOM 556  C C   . LYS A 1 69  ? -9.060  24.400  -3.553  1.00 97.60 69  A 1 
+ATOM 557  O O   . LYS A 1 69  ? -8.982  23.746  -4.595  1.00 96.17 69  A 1 
+ATOM 558  C CB  . LYS A 1 69  ? -11.546 24.725  -3.955  1.00 96.79 69  A 1 
+ATOM 559  C CG  . LYS A 1 69  ? -12.802 25.539  -3.625  1.00 96.54 69  A 1 
+ATOM 560  C CD  . LYS A 1 69  ? -14.022 24.946  -4.338  1.00 95.45 69  A 1 
+ATOM 561  C CE  . LYS A 1 69  ? -15.247 25.815  -4.060  1.00 91.51 69  A 1 
+ATOM 562  N NZ  . LYS A 1 69  ? -16.504 25.118  -4.411  1.00 87.09 69  A 1 
+ATOM 563  N N   . LEU A 1 70  ? -8.087  24.450  -2.659  1.00 97.55 70  A 1 
+ATOM 564  C CA  . LEU A 1 70  ? -6.824  23.733  -2.811  1.00 97.31 70  A 1 
+ATOM 565  C C   . LEU A 1 70  ? -6.891  22.372  -2.106  1.00 97.72 70  A 1 
+ATOM 566  O O   . LEU A 1 70  ? -7.105  22.305  -0.895  1.00 96.64 70  A 1 
+ATOM 567  C CB  . LEU A 1 70  ? -5.684  24.618  -2.275  1.00 95.82 70  A 1 
+ATOM 568  C CG  . LEU A 1 70  ? -4.281  24.016  -2.470  1.00 89.00 70  A 1 
+ATOM 569  C CD1 . LEU A 1 70  ? -3.908  23.896  -3.953  1.00 82.81 70  A 1 
+ATOM 570  C CD2 . LEU A 1 70  ? -3.242  24.907  -1.791  1.00 83.15 70  A 1 
+ATOM 571  N N   . VAL A 1 71  ? -6.675  21.298  -2.859  1.00 97.85 71  A 1 
+ATOM 572  C CA  . VAL A 1 71  ? -6.562  19.935  -2.319  1.00 97.88 71  A 1 
+ATOM 573  C C   . VAL A 1 71  ? -5.087  19.555  -2.220  1.00 97.68 71  A 1 
+ATOM 574  O O   . VAL A 1 71  ? -4.427  19.328  -3.237  1.00 96.53 71  A 1 
+ATOM 575  C CB  . VAL A 1 71  ? -7.347  18.915  -3.171  1.00 97.51 71  A 1 
+ATOM 576  C CG1 . VAL A 1 71  ? -7.204  17.490  -2.619  1.00 95.80 71  A 1 
+ATOM 577  C CG2 . VAL A 1 71  ? -8.843  19.247  -3.221  1.00 95.50 71  A 1 
+ATOM 578  N N   . LEU A 1 72  ? -4.588  19.444  -0.993  1.00 97.98 72  A 1 
+ATOM 579  C CA  . LEU A 1 72  ? -3.303  18.822  -0.683  1.00 97.59 72  A 1 
+ATOM 580  C C   . LEU A 1 72  ? -3.568  17.362  -0.304  1.00 97.54 72  A 1 
+ATOM 581  O O   . LEU A 1 72  ? -4.019  17.064  0.803   1.00 96.23 72  A 1 
+ATOM 582  C CB  . LEU A 1 72  ? -2.596  19.605  0.438   1.00 96.84 72  A 1 
+ATOM 583  C CG  . LEU A 1 72  ? -2.320  21.089  0.121   1.00 95.30 72  A 1 
+ATOM 584  C CD1 . LEU A 1 72  ? -1.629  21.740  1.314   1.00 91.06 72  A 1 
+ATOM 585  C CD2 . LEU A 1 72  ? -1.430  21.268  -1.114  1.00 90.59 72  A 1 
+ATOM 586  N N   . ASN A 1 73  ? -3.340  16.444  -1.248  1.00 97.45 73  A 1 
+ATOM 587  C CA  . ASN A 1 73  ? -3.738  15.046  -1.072  1.00 97.64 73  A 1 
+ATOM 588  C C   . ASN A 1 73  ? -2.735  14.249  -0.211  1.00 97.65 73  A 1 
+ATOM 589  O O   . ASN A 1 73  ? -1.979  13.404  -0.703  1.00 96.32 73  A 1 
+ATOM 590  C CB  . ASN A 1 73  ? -4.047  14.417  -2.442  1.00 96.92 73  A 1 
+ATOM 591  C CG  . ASN A 1 73  ? -4.824  13.115  -2.306  1.00 97.06 73  A 1 
+ATOM 592  O OD1 . ASN A 1 73  ? -4.951  12.534  -1.239  1.00 94.28 73  A 1 
+ATOM 593  N ND2 . ASN A 1 73  ? -5.389  12.631  -3.386  1.00 94.04 73  A 1 
+ATOM 594  N N   . HIS A 1 74  ? -2.743  14.516  1.088   1.00 98.01 74  A 1 
+ATOM 595  C CA  . HIS A 1 74  ? -1.915  13.801  2.065   1.00 97.79 74  A 1 
+ATOM 596  C C   . HIS A 1 74  ? -2.305  12.324  2.186   1.00 98.04 74  A 1 
+ATOM 597  O O   . HIS A 1 74  ? -1.421  11.490  2.368   1.00 97.55 74  A 1 
+ATOM 598  C CB  . HIS A 1 74  ? -1.990  14.493  3.429   1.00 97.02 74  A 1 
+ATOM 599  C CG  . HIS A 1 74  ? -1.361  15.864  3.430   1.00 95.98 74  A 1 
+ATOM 600  N ND1 . HIS A 1 74  ? -0.012  16.154  3.487   1.00 87.06 74  A 1 
+ATOM 601  C CD2 . HIS A 1 74  ? -2.036  17.051  3.376   1.00 88.22 74  A 1 
+ATOM 602  C CE1 . HIS A 1 74  ? 0.118   17.493  3.475   1.00 89.08 74  A 1 
+ATOM 603  N NE2 . HIS A 1 74  ? -1.087  18.073  3.403   1.00 90.19 74  A 1 
+ATOM 604  N N   . ALA A 1 75  ? -3.579  11.972  1.991   1.00 97.90 75  A 1 
+ATOM 605  C CA  . ALA A 1 75  ? -4.054  10.585  2.035   1.00 98.17 75  A 1 
+ATOM 606  C C   . ALA A 1 75  ? -3.316  9.695   1.021   1.00 98.27 75  A 1 
+ATOM 607  O O   . ALA A 1 75  ? -2.773  8.647   1.378   1.00 97.82 75  A 1 
+ATOM 608  C CB  . ALA A 1 75  ? -5.570  10.587  1.783   1.00 97.91 75  A 1 
+ATOM 609  N N   . GLN A 1 76  ? -3.201  10.156  -0.225  1.00 98.20 76  A 1 
+ATOM 610  C CA  . GLN A 1 76  ? -2.453  9.440   -1.262  1.00 97.93 76  A 1 
+ATOM 611  C C   . GLN A 1 76  ? -0.963  9.315   -0.913  1.00 97.89 76  A 1 
+ATOM 612  O O   . GLN A 1 76  ? -0.353  8.262   -1.117  1.00 97.11 76  A 1 
+ATOM 613  C CB  . GLN A 1 76  ? -2.634  10.166  -2.603  1.00 97.07 76  A 1 
+ATOM 614  C CG  . GLN A 1 76  ? -2.089  9.337   -3.767  1.00 87.32 76  A 1 
+ATOM 615  C CD  . GLN A 1 76  ? -2.084  10.096  -5.088  1.00 82.57 76  A 1 
+ATOM 616  O OE1 . GLN A 1 76  ? -1.609  11.218  -5.189  1.00 73.05 76  A 1 
+ATOM 617  N NE2 . GLN A 1 76  ? -2.544  9.497   -6.161  1.00 68.34 76  A 1 
+ATOM 618  N N   . MET A 1 77  ? -0.364  10.389  -0.394  1.00 97.90 77  A 1 
+ATOM 619  C CA  . MET A 1 77  ? 1.041   10.394  0.007   1.00 97.45 77  A 1 
+ATOM 620  C C   . MET A 1 77  ? 1.315   9.386   1.131   1.00 97.68 77  A 1 
+ATOM 621  O O   . MET A 1 77  ? 2.299   8.647   1.054   1.00 97.05 77  A 1 
+ATOM 622  C CB  . MET A 1 77  ? 1.440   11.816  0.424   1.00 96.04 77  A 1 
+ATOM 623  C CG  . MET A 1 77  ? 2.907   11.900  0.857   1.00 91.02 77  A 1 
+ATOM 624  S SD  . MET A 1 77  ? 3.323   13.341  1.870   1.00 85.36 77  A 1 
+ATOM 625  C CE  . MET A 1 77  ? 2.361   12.980  3.360   1.00 73.31 77  A 1 
+ATOM 626  N N   . ILE A 1 78  ? 0.456   9.347   2.156   1.00 97.80 78  A 1 
+ATOM 627  C CA  . ILE A 1 78  ? 0.578   8.443   3.306   1.00 97.99 78  A 1 
+ATOM 628  C C   . ILE A 1 78  ? 0.477   6.989   2.844   1.00 98.06 78  A 1 
+ATOM 629  O O   . ILE A 1 78  ? 1.402   6.213   3.084   1.00 97.79 78  A 1 
+ATOM 630  C CB  . ILE A 1 78  ? -0.482  8.793   4.376   1.00 97.93 78  A 1 
+ATOM 631  C CG1 . ILE A 1 78  ? -0.168  10.163  5.032   1.00 97.34 78  A 1 
+ATOM 632  C CG2 . ILE A 1 78  ? -0.546  7.698   5.459   1.00 97.20 78  A 1 
+ATOM 633  C CD1 . ILE A 1 78  ? -1.375  10.791  5.740   1.00 95.56 78  A 1 
+ATOM 634  N N   . THR A 1 79  ? -0.583  6.640   2.106   1.00 98.26 79  A 1 
+ATOM 635  C CA  . THR A 1 79  ? -0.756  5.286   1.553   1.00 98.40 79  A 1 
+ATOM 636  C C   . THR A 1 79  ? 0.455   4.871   0.722   1.00 98.28 79  A 1 
+ATOM 637  O O   . THR A 1 79  ? 1.017   3.800   0.942   1.00 97.73 79  A 1 
+ATOM 638  C CB  . THR A 1 79  ? -2.029  5.198   0.700   1.00 98.24 79  A 1 
+ATOM 639  O OG1 . THR A 1 79  ? -3.150  5.413   1.516   1.00 95.98 79  A 1 
+ATOM 640  C CG2 . THR A 1 79  ? -2.220  3.842   0.020   1.00 96.03 79  A 1 
+ATOM 641  N N   . ARG A 1 80  ? 0.924   5.733   -0.175  1.00 98.12 80  A 1 
+ATOM 642  C CA  . ARG A 1 80  ? 2.099   5.444   -1.011  1.00 97.75 80  A 1 
+ATOM 643  C C   . ARG A 1 80  ? 3.359   5.179   -0.185  1.00 97.52 80  A 1 
+ATOM 644  O O   . ARG A 1 80  ? 4.126   4.286   -0.535  1.00 96.60 80  A 1 
+ATOM 645  C CB  . ARG A 1 80  ? 2.304   6.606   -1.994  1.00 97.00 80  A 1 
+ATOM 646  C CG  . ARG A 1 80  ? 3.505   6.381   -2.932  1.00 94.79 80  A 1 
+ATOM 647  C CD  . ARG A 1 80  ? 3.653   7.543   -3.922  1.00 93.07 80  A 1 
+ATOM 648  N NE  . ARG A 1 80  ? 3.962   8.814   -3.237  1.00 86.48 80  A 1 
+ATOM 649  C CZ  . ARG A 1 80  ? 3.922   10.025  -3.769  1.00 83.61 80  A 1 
+ATOM 650  N NH1 . ARG A 1 80  ? 3.611   10.217  -5.020  1.00 75.15 80  A 1 
+ATOM 651  N NH2 . ARG A 1 80  ? 4.189   11.074  -3.038  1.00 76.12 80  A 1 
+ATOM 652  N N   . LYS A 1 81  ? 3.597   5.958   0.883   1.00 97.08 81  A 1 
+ATOM 653  C CA  . LYS A 1 81  ? 4.773   5.778   1.751   1.00 96.52 81  A 1 
+ATOM 654  C C   . LYS A 1 81  ? 4.693   4.475   2.547   1.00 96.71 81  A 1 
+ATOM 655  O O   . LYS A 1 81  ? 5.647   3.704   2.529   1.00 96.08 81  A 1 
+ATOM 656  C CB  . LYS A 1 81  ? 4.943   6.979   2.700   1.00 95.53 81  A 1 
+ATOM 657  C CG  . LYS A 1 81  ? 5.532   8.228   2.015   1.00 91.46 81  A 1 
+ATOM 658  C CD  . LYS A 1 81  ? 5.676   9.354   3.053   1.00 87.40 81  A 1 
+ATOM 659  C CE  . LYS A 1 81  ? 6.324   10.620  2.494   1.00 81.40 81  A 1 
+ATOM 660  N NZ  . LYS A 1 81  ? 6.533   11.632  3.571   1.00 73.72 81  A 1 
+ATOM 661  N N   . ILE A 1 82  ? 3.552   4.223   3.200   1.00 97.01 82  A 1 
+ATOM 662  C CA  . ILE A 1 82  ? 3.374   3.037   4.047   1.00 97.34 82  A 1 
+ATOM 663  C C   . ILE A 1 82  ? 3.396   1.765   3.199   1.00 97.23 82  A 1 
+ATOM 664  O O   . ILE A 1 82  ? 4.193   0.871   3.468   1.00 96.74 82  A 1 
+ATOM 665  C CB  . ILE A 1 82  ? 2.088   3.161   4.904   1.00 97.52 82  A 1 
+ATOM 666  C CG1 . ILE A 1 82  ? 2.249   4.321   5.916   1.00 96.98 82  A 1 
+ATOM 667  C CG2 . ILE A 1 82  ? 1.798   1.840   5.641   1.00 96.88 82  A 1 
+ATOM 668  C CD1 . ILE A 1 82  ? 0.998   4.615   6.750   1.00 95.33 82  A 1 
+ATOM 669  N N   . VAL A 1 83  ? 2.578   1.695   2.151   1.00 97.83 83  A 1 
+ATOM 670  C CA  . VAL A 1 83  ? 2.482   0.506   1.285   1.00 97.96 83  A 1 
+ATOM 671  C C   . VAL A 1 83  ? 3.776   0.286   0.506   1.00 97.69 83  A 1 
+ATOM 672  O O   . VAL A 1 83  ? 4.261   -0.838  0.430   1.00 96.94 83  A 1 
+ATOM 673  C CB  . VAL A 1 83  ? 1.274   0.606   0.333   1.00 97.97 83  A 1 
+ATOM 674  C CG1 . VAL A 1 83  ? 1.169   -0.617  -0.589  1.00 97.20 83  A 1 
+ATOM 675  C CG2 . VAL A 1 83  ? -0.033  0.702   1.125   1.00 97.11 83  A 1 
+ATOM 676  N N   . GLY A 1 84  ? 4.384   1.353   -0.014  1.00 96.75 84  A 1 
+ATOM 677  C CA  . GLY A 1 84  ? 5.658   1.262   -0.730  1.00 95.96 84  A 1 
+ATOM 678  C C   . GLY A 1 84  ? 6.813   0.772   0.148   1.00 95.53 84  A 1 
+ATOM 679  O O   . GLY A 1 84  ? 7.672   0.041   -0.334  1.00 94.36 84  A 1 
+ATOM 680  N N   . TYR A 1 85  ? 6.820   1.127   1.429   1.00 95.42 85  A 1 
+ATOM 681  C CA  . TYR A 1 85  ? 7.818   0.618   2.376   1.00 94.55 85  A 1 
+ATOM 682  C C   . TYR A 1 85  ? 7.502   -0.806  2.852   1.00 94.76 85  A 1 
+ATOM 683  O O   . TYR A 1 85  ? 8.404   -1.629  3.009   1.00 93.74 85  A 1 
+ATOM 684  C CB  . TYR A 1 85  ? 7.922   1.597   3.551   1.00 93.36 85  A 1 
+ATOM 685  C CG  . TYR A 1 85  ? 9.052   1.276   4.510   1.00 92.26 85  A 1 
+ATOM 686  C CD1 . TYR A 1 85  ? 8.787   0.621   5.729   1.00 89.90 85  A 1 
+ATOM 687  C CD2 . TYR A 1 85  ? 10.376  1.622   4.176   1.00 89.88 85  A 1 
+ATOM 688  C CE1 . TYR A 1 85  ? 9.846   0.314   6.607   1.00 88.79 85  A 1 
+ATOM 689  C CE2 . TYR A 1 85  ? 11.434  1.312   5.054   1.00 88.62 85  A 1 
+ATOM 690  C CZ  . TYR A 1 85  ? 11.171  0.654   6.271   1.00 88.87 85  A 1 
+ATOM 691  O OH  . TYR A 1 85  ? 12.192  0.345   7.109   1.00 86.96 85  A 1 
+ATOM 692  N N   . PHE A 1 86  ? 6.215   -1.112  3.071   1.00 95.99 86  A 1 
+ATOM 693  C CA  . PHE A 1 86  ? 5.757   -2.399  3.590   1.00 96.29 86  A 1 
+ATOM 694  C C   . PHE A 1 86  ? 5.820   -3.529  2.553   1.00 96.12 86  A 1 
+ATOM 695  O O   . PHE A 1 86  ? 6.314   -4.612  2.860   1.00 94.90 86  A 1 
+ATOM 696  C CB  . PHE A 1 86  ? 4.333   -2.219  4.146   1.00 96.45 86  A 1 
+ATOM 697  C CG  . PHE A 1 86  ? 3.690   -3.482  4.703   1.00 96.88 86  A 1 
+ATOM 698  C CD1 . PHE A 1 86  ? 2.360   -3.810  4.364   1.00 95.11 86  A 1 
+ATOM 699  C CD2 . PHE A 1 86  ? 4.420   -4.338  5.545   1.00 95.40 86  A 1 
+ATOM 700  C CE1 . PHE A 1 86  ? 1.778   -4.989  4.854   1.00 95.02 86  A 1 
+ATOM 701  C CE2 . PHE A 1 86  ? 3.838   -5.526  6.024   1.00 95.12 86  A 1 
+ATOM 702  C CZ  . PHE A 1 86  ? 2.520   -5.851  5.674   1.00 95.82 86  A 1 
+ATOM 703  N N   . LEU A 1 87  ? 5.340   -3.274  1.337   1.00 96.57 87  A 1 
+ATOM 704  C CA  . LEU A 1 87  ? 5.155   -4.262  0.261   1.00 96.70 87  A 1 
+ATOM 705  C C   . LEU A 1 87  ? 5.908   -3.885  -1.027  1.00 96.11 87  A 1 
+ATOM 706  O O   . LEU A 1 87  ? 5.574   -4.347  -2.113  1.00 93.91 87  A 1 
+ATOM 707  C CB  . LEU A 1 87  ? 3.642   -4.467  0.009   1.00 96.88 87  A 1 
+ATOM 708  C CG  . LEU A 1 87  ? 2.858   -5.034  1.208   1.00 96.87 87  A 1 
+ATOM 709  C CD1 . LEU A 1 87  ? 1.361   -5.020  0.907   1.00 95.66 87  A 1 
+ATOM 710  C CD2 . LEU A 1 87  ? 3.264   -6.472  1.541   1.00 95.41 87  A 1 
+ATOM 711  N N   . GLY A 1 88  ? 6.920   -3.025  -0.918  1.00 95.05 88  A 1 
+ATOM 712  C CA  . GLY A 1 88  ? 7.747   -2.646  -2.071  1.00 93.56 88  A 1 
+ATOM 713  C C   . GLY A 1 88  ? 8.608   -3.790  -2.615  1.00 93.45 88  A 1 
+ATOM 714  O O   . GLY A 1 88  ? 8.951   -3.782  -3.795  1.00 91.25 88  A 1 
+ATOM 715  N N   . ASN A 1 89  ? 8.928   -4.775  -1.776  1.00 94.45 89  A 1 
+ATOM 716  C CA  . ASN A 1 89  ? 9.566   -6.023  -2.189  1.00 94.03 89  A 1 
+ATOM 717  C C   . ASN A 1 89  ? 8.552   -7.180  -2.112  1.00 95.25 89  A 1 
+ATOM 718  O O   . ASN A 1 89  ? 7.739   -7.201  -1.184  1.00 94.58 89  A 1 
+ATOM 719  C CB  . ASN A 1 89  ? 10.789  -6.303  -1.307  1.00 92.02 89  A 1 
+ATOM 720  C CG  . ASN A 1 89  ? 11.893  -5.275  -1.461  1.00 88.13 89  A 1 
+ATOM 721  O OD1 . ASN A 1 89  ? 12.244  -4.820  -2.535  1.00 81.13 89  A 1 
+ATOM 722  N ND2 . ASN A 1 89  ? 12.508  -4.874  -0.373  1.00 80.22 89  A 1 
+ATOM 723  N N   . PRO A 1 90  ? 8.619   -8.158  -3.028  1.00 95.13 90  A 1 
+ATOM 724  C CA  . PRO A 1 90  ? 7.755   -9.331  -2.994  1.00 95.25 90  A 1 
+ATOM 725  C C   . PRO A 1 90  ? 7.861   -10.098 -1.671  1.00 95.80 90  A 1 
+ATOM 726  O O   . PRO A 1 90  ? 8.957   -10.299 -1.140  1.00 94.92 90  A 1 
+ATOM 727  C CB  . PRO A 1 90  ? 8.183   -10.205 -4.177  1.00 93.84 90  A 1 
+ATOM 728  C CG  . PRO A 1 90  ? 8.798   -9.201  -5.156  1.00 91.24 90  A 1 
+ATOM 729  C CD  . PRO A 1 90  ? 9.449   -8.178  -4.228  1.00 94.05 90  A 1 
+ATOM 730  N N   . ILE A 1 91  ? 6.716   -10.572 -1.174  1.00 96.15 91  A 1 
+ATOM 731  C CA  . ILE A 1 91  ? 6.664   -11.545 -0.079  1.00 96.67 91  A 1 
+ATOM 732  C C   . ILE A 1 91  ? 7.161   -12.885 -0.625  1.00 96.45 91  A 1 
+ATOM 733  O O   . ILE A 1 91  ? 6.711   -13.326 -1.683  1.00 95.47 91  A 1 
+ATOM 734  C CB  . ILE A 1 91  ? 5.238   -11.655 0.501   1.00 96.91 91  A 1 
+ATOM 735  C CG1 . ILE A 1 91  ? 4.763   -10.286 1.042   1.00 96.06 91  A 1 
+ATOM 736  C CG2 . ILE A 1 91  ? 5.196   -12.725 1.610   1.00 95.83 91  A 1 
+ATOM 737  C CD1 . ILE A 1 91  ? 3.295   -10.273 1.488   1.00 93.18 91  A 1 
+ATOM 738  N N   . GLN A 1 92  ? 8.060   -13.530 0.104   1.00 95.58 92  A 1 
+ATOM 739  C CA  . GLN A 1 92  ? 8.643   -14.811 -0.285  1.00 94.60 92  A 1 
+ATOM 740  C C   . GLN A 1 92  ? 8.283   -15.900 0.723   1.00 95.52 92  A 1 
+ATOM 741  O O   . GLN A 1 92  ? 8.236   -15.662 1.934   1.00 94.99 92  A 1 
+ATOM 742  C CB  . GLN A 1 92  ? 10.167  -14.679 -0.439  1.00 91.95 92  A 1 
+ATOM 743  C CG  . GLN A 1 92  ? 10.544  -13.775 -1.626  1.00 81.13 92  A 1 
+ATOM 744  C CD  . GLN A 1 92  ? 12.051  -13.668 -1.845  1.00 79.25 92  A 1 
+ATOM 745  O OE1 . GLN A 1 92  ? 12.864  -13.722 -0.931  1.00 69.97 92  A 1 
+ATOM 746  N NE2 . GLN A 1 92  ? 12.489  -13.478 -3.070  1.00 65.90 92  A 1 
+ATOM 747  N N   . TYR A 1 93  ? 8.070   -17.110 0.224   1.00 95.15 93  A 1 
+ATOM 748  C CA  . TYR A 1 93  ? 8.008   -18.311 1.041   1.00 95.54 93  A 1 
+ATOM 749  C C   . TYR A 1 93  ? 9.413   -18.900 1.149   1.00 94.95 93  A 1 
+ATOM 750  O O   . TYR A 1 93  ? 10.057  -19.156 0.140   1.00 93.91 93  A 1 
+ATOM 751  C CB  . TYR A 1 93  ? 6.995   -19.296 0.460   1.00 96.10 93  A 1 
+ATOM 752  C CG  . TYR A 1 93  ? 5.599   -18.724 0.283   1.00 96.44 93  A 1 
+ATOM 753  C CD1 . TYR A 1 93  ? 4.908   -18.163 1.377   1.00 95.33 93  A 1 
+ATOM 754  C CD2 . TYR A 1 93  ? 4.994   -18.740 -0.991  1.00 95.43 93  A 1 
+ATOM 755  C CE1 . TYR A 1 93  ? 3.615   -17.626 1.200   1.00 95.35 93  A 1 
+ATOM 756  C CE2 . TYR A 1 93  ? 3.704   -18.210 -1.169  1.00 95.40 93  A 1 
+ATOM 757  C CZ  . TYR A 1 93  ? 3.011   -17.655 -0.076  1.00 96.05 93  A 1 
+ATOM 758  O OH  . TYR A 1 93  ? 1.765   -17.151 -0.259  1.00 95.30 93  A 1 
+ATOM 759  N N   . ILE A 1 94  ? 9.879   -19.096 2.374   1.00 93.47 94  A 1 
+ATOM 760  C CA  . ILE A 1 94  ? 11.208  -19.647 2.661   1.00 92.22 94  A 1 
+ATOM 761  C C   . ILE A 1 94  ? 11.078  -20.952 3.453   1.00 92.38 94  A 1 
+ATOM 762  O O   . ILE A 1 94  ? 10.081  -21.131 4.156   1.00 91.62 94  A 1 
+ATOM 763  C CB  . ILE A 1 94  ? 12.111  -18.619 3.383   1.00 90.55 94  A 1 
+ATOM 764  C CG1 . ILE A 1 94  ? 11.547  -18.184 4.752   1.00 86.49 94  A 1 
+ATOM 765  C CG2 . ILE A 1 94  ? 12.365  -17.408 2.461   1.00 86.10 94  A 1 
+ATOM 766  C CD1 . ILE A 1 94  ? 12.558  -17.417 5.612   1.00 81.77 94  A 1 
+ATOM 767  N N   . PRO A 1 95  ? 12.048  -21.866 3.388   1.00 91.97 95  A 1 
+ATOM 768  C CA  . PRO A 1 95  ? 12.055  -23.066 4.218   1.00 91.00 95  A 1 
+ATOM 769  C C   . PRO A 1 95  ? 11.975  -22.727 5.713   1.00 90.80 95  A 1 
+ATOM 770  O O   . PRO A 1 95  ? 12.688  -21.854 6.210   1.00 89.17 95  A 1 
+ATOM 771  C CB  . PRO A 1 95  ? 13.346  -23.811 3.868   1.00 89.32 95  A 1 
+ATOM 772  C CG  . PRO A 1 95  ? 13.678  -23.319 2.457   1.00 87.19 95  A 1 
+ATOM 773  C CD  . PRO A 1 95  ? 13.191  -21.875 2.477   1.00 89.55 95  A 1 
+ATOM 774  N N   . SER A 1 96  ? 11.110  -23.439 6.439   1.00 90.69 96  A 1 
+ATOM 775  C CA  . SER A 1 96  ? 11.008  -23.348 7.892   1.00 88.07 96  A 1 
+ATOM 776  C C   . SER A 1 96  ? 11.946  -24.369 8.540   1.00 84.86 96  A 1 
+ATOM 777  O O   . SER A 1 96  ? 11.742  -25.582 8.446   1.00 73.07 96  A 1 
+ATOM 778  C CB  . SER A 1 96  ? 9.561   -23.564 8.331   1.00 86.14 96  A 1 
+ATOM 779  O OG  . SER A 1 96  ? 9.434   -23.370 9.725   1.00 76.28 96  A 1 
+ATOM 780  N N   . GLY A 1 97  ? 12.979  -23.894 9.219   1.00 82.16 97  A 1 
+ATOM 781  C CA  . GLY A 1 97  ? 13.949  -24.751 9.903   1.00 79.46 97  A 1 
+ATOM 782  C C   . GLY A 1 97  ? 14.739  -25.652 8.945   1.00 80.50 97  A 1 
+ATOM 783  O O   . GLY A 1 97  ? 15.325  -25.187 7.978   1.00 75.51 97  A 1 
+ATOM 784  N N   . ILE A 1 98  ? 14.760  -26.967 9.219   1.00 76.47 98  A 1 
+ATOM 785  C CA  . ILE A 1 98  ? 15.552  -27.963 8.462   1.00 76.33 98  A 1 
+ATOM 786  C C   . ILE A 1 98  ? 14.680  -28.684 7.415   1.00 78.40 98  A 1 
+ATOM 787  O O   . ILE A 1 98  ? 14.845  -29.879 7.159   1.00 71.00 98  A 1 
+ATOM 788  C CB  . ILE A 1 98  ? 16.313  -28.935 9.415   1.00 71.31 98  A 1 
+ATOM 789  C CG1 . ILE A 1 98  ? 16.976  -28.201 10.610  1.00 63.89 98  A 1 
+ATOM 790  C CG2 . ILE A 1 98  ? 17.408  -29.721 8.654   1.00 61.88 98  A 1 
+ATOM 791  C CD1 . ILE A 1 98  ? 17.592  -29.134 11.672  1.00 57.58 98  A 1 
+ATOM 792  N N   . SER A 1 99  ? 13.692  -28.001 6.829   1.00 76.03 99  A 1 
+ATOM 793  C CA  . SER A 1 99  ? 12.876  -28.621 5.777   1.00 76.77 99  A 1 
+ATOM 794  C C   . SER A 1 99  ? 13.741  -28.964 4.565   1.00 79.10 99  A 1 
+ATOM 795  O O   . SER A 1 99  ? 14.447  -28.116 4.022   1.00 74.98 99  A 1 
+ATOM 796  C CB  . SER A 1 99  ? 11.696  -27.752 5.349   1.00 71.39 99  A 1 
+ATOM 797  O OG  . SER A 1 99  ? 10.916  -28.499 4.424   1.00 65.44 99  A 1 
+ATOM 798  N N   . LYS A 1 100 ? 13.668  -30.234 4.127   1.00 81.37 100 A 1 
+ATOM 799  C CA  . LYS A 1 100 ? 14.397  -30.731 2.946   1.00 81.72 100 A 1 
+ATOM 800  C C   . LYS A 1 100 ? 13.653  -30.492 1.629   1.00 85.52 100 A 1 
+ATOM 801  O O   . LYS A 1 100 ? 14.108  -30.943 0.588   1.00 81.19 100 A 1 
+ATOM 802  C CB  . LYS A 1 100 ? 14.744  -32.215 3.122   1.00 76.01 100 A 1 
+ATOM 803  C CG  . LYS A 1 100 ? 15.714  -32.454 4.285   1.00 70.70 100 A 1 
+ATOM 804  C CD  . LYS A 1 100 ? 16.139  -33.926 4.309   1.00 62.93 100 A 1 
+ATOM 805  C CE  . LYS A 1 100 ? 17.132  -34.163 5.446   1.00 57.16 100 A 1 
+ATOM 806  N NZ  . LYS A 1 100 ? 17.628  -35.557 5.435   1.00 45.30 100 A 1 
+ATOM 807  N N   . LYS A 1 101 ? 12.492  -29.818 1.671   1.00 88.13 101 A 1 
+ATOM 808  C CA  . LYS A 1 101 ? 11.601  -29.643 0.513   1.00 90.16 101 A 1 
+ATOM 809  C C   . LYS A 1 101 ? 11.815  -28.306 -0.201  1.00 91.44 101 A 1 
+ATOM 810  O O   . LYS A 1 101 ? 10.860  -27.699 -0.679  1.00 89.30 101 A 1 
+ATOM 811  C CB  . LYS A 1 101 ? 10.142  -29.841 0.941   1.00 89.10 101 A 1 
+ATOM 812  C CG  . LYS A 1 101 ? 9.860   -31.210 1.564   1.00 90.17 101 A 1 
+ATOM 813  C CD  . LYS A 1 101 ? 8.371   -31.248 1.901   1.00 88.30 101 A 1 
+ATOM 814  C CE  . LYS A 1 101 ? 7.971   -32.461 2.723   1.00 85.28 101 A 1 
+ATOM 815  N NZ  . LYS A 1 101 ? 6.626   -32.215 3.282   1.00 78.38 101 A 1 
+ATOM 816  N N   . LYS A 1 102 ? 13.056  -27.847 -0.261  1.00 92.28 102 A 1 
+ATOM 817  C CA  . LYS A 1 102 ? 13.416  -26.554 -0.867  1.00 91.18 102 A 1 
+ATOM 818  C C   . LYS A 1 102 ? 12.921  -26.435 -2.313  1.00 92.55 102 A 1 
+ATOM 819  O O   . LYS A 1 102 ? 12.274  -25.455 -2.642  1.00 91.82 102 A 1 
+ATOM 820  C CB  . LYS A 1 102 ? 14.931  -26.350 -0.749  1.00 88.07 102 A 1 
+ATOM 821  C CG  . LYS A 1 102 ? 15.357  -24.965 -1.254  1.00 79.53 102 A 1 
+ATOM 822  C CD  . LYS A 1 102 ? 16.868  -24.751 -1.085  1.00 74.86 102 A 1 
+ATOM 823  C CE  . LYS A 1 102 ? 17.252  -23.401 -1.684  1.00 65.78 102 A 1 
+ATOM 824  N NZ  . LYS A 1 102 ? 18.709  -23.166 -1.595  1.00 57.87 102 A 1 
+ATOM 825  N N   . GLU A 1 103 ? 13.124  -27.468 -3.128  1.00 90.71 103 A 1 
+ATOM 826  C CA  . GLU A 1 103 ? 12.703  -27.481 -4.537  1.00 91.66 103 A 1 
+ATOM 827  C C   . GLU A 1 103 ? 11.194  -27.233 -4.714  1.00 93.19 103 A 1 
+ATOM 828  O O   . GLU A 1 103 ? 10.779  -26.496 -5.602  1.00 92.26 103 A 1 
+ATOM 829  C CB  . GLU A 1 103 ? 13.069  -28.834 -5.171  1.00 90.62 103 A 1 
+ATOM 830  C CG  . GLU A 1 103 ? 14.589  -29.100 -5.211  1.00 81.54 103 A 1 
+ATOM 831  C CD  . GLU A 1 103 ? 14.959  -30.466 -5.823  1.00 75.70 103 A 1 
+ATOM 832  O OE1 . GLU A 1 103 ? 16.178  -30.736 -5.923  1.00 66.75 103 A 1 
+ATOM 833  O OE2 . GLU A 1 103 ? 14.041  -31.249 -6.155  1.00 66.45 103 A 1 
+ATOM 834  N N   . LEU A 1 104 ? 10.353  -27.806 -3.834  1.00 93.64 104 A 1 
+ATOM 835  C CA  . LEU A 1 104 ? 8.902   -27.591 -3.876  1.00 94.52 104 A 1 
+ATOM 836  C C   . LEU A 1 104 ? 8.512   -26.172 -3.443  1.00 95.30 104 A 1 
+ATOM 837  O O   . LEU A 1 104 ? 7.537   -25.617 -3.944  1.00 94.70 104 A 1 
+ATOM 838  C CB  . LEU A 1 104 ? 8.196   -28.615 -2.973  1.00 94.21 104 A 1 
+ATOM 839  C CG  . LEU A 1 104 ? 8.304   -30.085 -3.414  1.00 91.85 104 A 1 
+ATOM 840  C CD1 . LEU A 1 104 ? 7.584   -30.960 -2.385  1.00 86.38 104 A 1 
+ATOM 841  C CD2 . LEU A 1 104 ? 7.652   -30.337 -4.772  1.00 86.79 104 A 1 
+ATOM 842  N N   . ILE A 1 105 ? 9.251   -25.585 -2.508  1.00 94.78 105 A 1 
+ATOM 843  C CA  . ILE A 1 105 ? 9.040   -24.200 -2.063  1.00 95.03 105 A 1 
+ATOM 844  C C   . ILE A 1 105 ? 9.443   -23.227 -3.173  1.00 95.27 105 A 1 
+ATOM 845  O O   . ILE A 1 105 ? 8.707   -22.279 -3.449  1.00 94.73 105 A 1 
+ATOM 846  C CB  . ILE A 1 105 ? 9.799   -23.931 -0.743  1.00 94.56 105 A 1 
+ATOM 847  C CG1 . ILE A 1 105 ? 9.234   -24.826 0.386   1.00 93.13 105 A 1 
+ATOM 848  C CG2 . ILE A 1 105 ? 9.692   -22.445 -0.349  1.00 92.90 105 A 1 
+ATOM 849  C CD1 . ILE A 1 105 ? 10.079  -24.837 1.664   1.00 88.17 105 A 1 
+ATOM 850  N N   . ASP A 1 106 ? 10.552  -23.496 -3.852  1.00 94.55 106 A 1 
+ATOM 851  C CA  . ASP A 1 106 ? 11.003  -22.706 -4.997  1.00 93.96 106 A 1 
+ATOM 852  C C   . ASP A 1 106 ? 9.992   -22.780 -6.146  1.00 94.73 106 A 1 
+ATOM 853  O O   . ASP A 1 106 ? 9.638   -21.753 -6.727  1.00 94.42 106 A 1 
+ATOM 854  C CB  . ASP A 1 106 ? 12.400  -23.175 -5.443  1.00 92.61 106 A 1 
+ATOM 855  C CG  . ASP A 1 106 ? 13.521  -22.864 -4.433  1.00 89.07 106 A 1 
+ATOM 856  O OD1 . ASP A 1 106 ? 13.333  -21.951 -3.596  1.00 84.84 106 A 1 
+ATOM 857  O OD2 . ASP A 1 106 ? 14.584  -23.521 -4.528  1.00 84.58 106 A 1 
+ATOM 858  N N   . GLU A 1 107 ? 9.438   -23.965 -6.418  1.00 93.90 107 A 1 
+ATOM 859  C CA  . GLU A 1 107 ? 8.364   -24.127 -7.406  1.00 94.42 107 A 1 
+ATOM 860  C C   . GLU A 1 107 ? 7.102   -23.333 -7.020  1.00 95.13 107 A 1 
+ATOM 861  O O   . GLU A 1 107 ? 6.531   -22.638 -7.862  1.00 94.27 107 A 1 
+ATOM 862  C CB  . GLU A 1 107 ? 8.053   -25.623 -7.581  1.00 93.75 107 A 1 
+ATOM 863  C CG  . GLU A 1 107 ? 7.151   -25.878 -8.800  1.00 88.52 107 A 1 
+ATOM 864  C CD  . GLU A 1 107 ? 6.695   -27.341 -8.940  1.00 89.06 107 A 1 
+ATOM 865  O OE1 . GLU A 1 107 ? 5.878   -27.621 -9.850  1.00 80.87 107 A 1 
+ATOM 866  O OE2 . GLU A 1 107 ? 6.984   -28.203 -8.084  1.00 83.20 107 A 1 
+ATOM 867  N N   . LEU A 1 108 ? 6.695   -23.356 -5.747  1.00 95.36 108 A 1 
+ATOM 868  C CA  . LEU A 1 108 ? 5.572   -22.546 -5.259  1.00 95.79 108 A 1 
+ATOM 869  C C   . LEU A 1 108 ? 5.839   -21.042 -5.435  1.00 96.00 108 A 1 
+ATOM 870  O O   . LEU A 1 108 ? 4.942   -20.299 -5.838  1.00 95.44 108 A 1 
+ATOM 871  C CB  . LEU A 1 108 ? 5.290   -22.904 -3.787  1.00 95.82 108 A 1 
+ATOM 872  C CG  . LEU A 1 108 ? 4.126   -22.112 -3.155  1.00 95.30 108 A 1 
+ATOM 873  C CD1 . LEU A 1 108 ? 2.782   -22.437 -3.803  1.00 92.94 108 A 1 
+ATOM 874  C CD2 . LEU A 1 108 ? 4.028   -22.433 -1.662  1.00 92.92 108 A 1 
+ATOM 875  N N   . ASN A 1 109 ? 7.058   -20.587 -5.167  1.00 96.35 109 A 1 
+ATOM 876  C CA  . ASN A 1 109 ? 7.460   -19.199 -5.394  1.00 95.91 109 A 1 
+ATOM 877  C C   . ASN A 1 109 ? 7.408   -18.824 -6.881  1.00 96.06 109 A 1 
+ATOM 878  O O   . ASN A 1 109 ? 6.919   -17.749 -7.217  1.00 95.30 109 A 1 
+ATOM 879  C CB  . ASN A 1 109 ? 8.863   -18.959 -4.806  1.00 95.23 109 A 1 
+ATOM 880  C CG  . ASN A 1 109 ? 8.870   -18.781 -3.300  1.00 94.35 109 A 1 
+ATOM 881  O OD1 . ASN A 1 109 ? 8.002   -18.155 -2.710  1.00 88.36 109 A 1 
+ATOM 882  N ND2 . ASN A 1 109 ? 9.893   -19.262 -2.630  1.00 88.47 109 A 1 
+ATOM 883  N N   . ILE A 1 110 ? 7.840   -19.716 -7.777  1.00 95.31 110 A 1 
+ATOM 884  C CA  . ILE A 1 110 ? 7.735   -19.502 -9.230  1.00 95.17 110 A 1 
+ATOM 885  C C   . ILE A 1 110 ? 6.267   -19.357 -9.647  1.00 95.21 110 A 1 
+ATOM 886  O O   . ILE A 1 110 ? 5.934   -18.435 -10.386 1.00 94.28 110 A 1 
+ATOM 887  C CB  . ILE A 1 110 ? 8.450   -20.639 -9.999  1.00 94.75 110 A 1 
+ATOM 888  C CG1 . ILE A 1 110 ? 9.983   -20.540 -9.792  1.00 92.08 110 A 1 
+ATOM 889  C CG2 . ILE A 1 110 ? 8.128   -20.592 -11.508 1.00 91.95 110 A 1 
+ATOM 890  C CD1 . ILE A 1 110 ? 10.743  -21.813 -10.183 1.00 84.55 110 A 1 
+ATOM 891  N N   . TYR A 1 111 ? 5.379   -20.222 -9.143  1.00 95.39 111 A 1 
+ATOM 892  C CA  . TYR A 1 111 ? 3.949   -20.164 -9.456  1.00 95.30 111 A 1 
+ATOM 893  C C   . TYR A 1 111 ? 3.311   -18.870 -8.943  1.00 95.40 111 A 1 
+ATOM 894  O O   . TYR A 1 111 ? 2.644   -18.165 -9.695  1.00 94.39 111 A 1 
+ATOM 895  C CB  . TYR A 1 111 ? 3.236   -21.390 -8.875  1.00 94.72 111 A 1 
+ATOM 896  C CG  . TYR A 1 111 ? 3.456   -22.720 -9.587  1.00 93.99 111 A 1 
+ATOM 897  C CD1 . TYR A 1 111 ? 4.433   -22.890 -10.591 1.00 89.81 111 A 1 
+ATOM 898  C CD2 . TYR A 1 111 ? 2.632   -23.806 -9.238  1.00 89.96 111 A 1 
+ATOM 899  C CE1 . TYR A 1 111 ? 4.591   -24.129 -11.239 1.00 88.78 111 A 1 
+ATOM 900  C CE2 . TYR A 1 111 ? 2.783   -25.051 -9.882  1.00 89.32 111 A 1 
+ATOM 901  C CZ  . TYR A 1 111 ? 3.765   -25.214 -10.885 1.00 90.03 111 A 1 
+ATOM 902  O OH  . TYR A 1 111 ? 3.908   -26.413 -11.508 1.00 87.38 111 A 1 
+ATOM 903  N N   . THR A 1 112 ? 3.578   -18.494 -7.695  1.00 95.80 112 A 1 
+ATOM 904  C CA  . THR A 1 112 ? 3.056   -17.236 -7.139  1.00 95.71 112 A 1 
+ATOM 905  C C   . THR A 1 112 ? 3.626   -15.998 -7.837  1.00 95.54 112 A 1 
+ATOM 906  O O   . THR A 1 112 ? 2.928   -15.000 -7.986  1.00 94.29 112 A 1 
+ATOM 907  C CB  . THR A 1 112 ? 3.299   -17.138 -5.629  1.00 95.28 112 A 1 
+ATOM 908  O OG1 . THR A 1 112 ? 4.649   -17.319 -5.292  1.00 89.90 112 A 1 
+ATOM 909  C CG2 . THR A 1 112 ? 2.490   -18.180 -4.849  1.00 87.11 112 A 1 
+ATOM 910  N N   . GLN A 1 113 ? 4.869   -16.057 -8.311  1.00 95.37 113 A 1 
+ATOM 911  C CA  . GLN A 1 113 ? 5.452   -14.989 -9.122  1.00 94.67 113 A 1 
+ATOM 912  C C   . GLN A 1 113 ? 4.781   -14.888 -10.495 1.00 94.41 113 A 1 
+ATOM 913  O O   . GLN A 1 113 ? 4.538   -13.773 -10.963 1.00 92.94 113 A 1 
+ATOM 914  C CB  . GLN A 1 113 ? 6.967   -15.219 -9.251  1.00 93.75 113 A 1 
+ATOM 915  C CG  . GLN A 1 113 ? 7.649   -14.075 -10.017 1.00 82.43 113 A 1 
+ATOM 916  C CD  . GLN A 1 113 ? 9.160   -14.239 -10.148 1.00 80.28 113 A 1 
+ATOM 917  O OE1 . GLN A 1 113 ? 9.768   -15.240 -9.820  1.00 72.46 113 A 1 
+ATOM 918  N NE2 . GLN A 1 113 ? 9.843   -13.234 -10.654 1.00 69.37 113 A 1 
+ATOM 919  N N   . TYR A 1 114 ? 4.482   -16.026 -11.124 1.00 93.46 114 A 1 
+ATOM 920  C CA  . TYR A 1 114 ? 3.771   -16.078 -12.403 1.00 91.79 114 A 1 
+ATOM 921  C C   . TYR A 1 114 ? 2.373   -15.454 -12.302 1.00 91.64 114 A 1 
+ATOM 922  O O   . TYR A 1 114 ? 2.022   -14.615 -13.133 1.00 89.85 114 A 1 
+ATOM 923  C CB  . TYR A 1 114 ? 3.733   -17.530 -12.885 1.00 89.89 114 A 1 
+ATOM 924  C CG  . TYR A 1 114 ? 3.103   -17.684 -14.250 1.00 80.12 114 A 1 
+ATOM 925  C CD1 . TYR A 1 114 ? 1.717   -17.873 -14.351 1.00 72.63 114 A 1 
+ATOM 926  C CD2 . TYR A 1 114 ? 3.900   -17.625 -15.412 1.00 70.65 114 A 1 
+ATOM 927  C CE1 . TYR A 1 114 ? 1.121   -18.019 -15.617 1.00 63.67 114 A 1 
+ATOM 928  C CE2 . TYR A 1 114 ? 3.305   -17.777 -16.681 1.00 62.88 114 A 1 
+ATOM 929  C CZ  . TYR A 1 114 ? 1.913   -17.981 -16.781 1.00 63.64 114 A 1 
+ATOM 930  O OH  . TYR A 1 114 ? 1.332   -18.157 -17.997 1.00 61.55 114 A 1 
+ATOM 931  N N   . GLU A 1 115 ? 1.651   -15.744 -11.218 1.00 92.47 115 A 1 
+ATOM 932  C CA  . GLU A 1 115 ? 0.341   -15.141 -10.901 1.00 91.43 115 A 1 
+ATOM 933  C C   . GLU A 1 115 ? 0.419   -13.678 -10.429 1.00 91.35 115 A 1 
+ATOM 934  O O   . GLU A 1 115 ? -0.560  -13.094 -9.964  1.00 87.56 115 A 1 
+ATOM 935  C CB  . GLU A 1 115 ? -0.388  -16.005 -9.857  1.00 89.93 115 A 1 
+ATOM 936  C CG  . GLU A 1 115 ? -0.814  -17.373 -10.406 1.00 84.33 115 A 1 
+ATOM 937  C CD  . GLU A 1 115 ? -1.568  -17.226 -11.729 1.00 85.04 115 A 1 
+ATOM 938  O OE1 . GLU A 1 115 ? -1.139  -17.907 -12.681 1.00 75.64 115 A 1 
+ATOM 939  O OE2 . GLU A 1 115 ? -2.450  -16.343 -11.789 1.00 76.31 115 A 1 
+ATOM 940  N N   . ASN A 1 116 ? 1.582   -13.045 -10.547 1.00 93.80 116 A 1 
+ATOM 941  C CA  . ASN A 1 116 ? 1.817   -11.658 -10.152 1.00 94.40 116 A 1 
+ATOM 942  C C   . ASN A 1 116 ? 1.419   -11.348 -8.700  1.00 95.82 116 A 1 
+ATOM 943  O O   . ASN A 1 116 ? 1.030   -10.212 -8.396  1.00 94.75 116 A 1 
+ATOM 944  C CB  . ASN A 1 116 ? 1.178   -10.694 -11.173 1.00 92.52 116 A 1 
+ATOM 945  C CG  . ASN A 1 116 ? 1.757   -10.864 -12.559 1.00 86.17 116 A 1 
+ATOM 946  O OD1 . ASN A 1 116 ? 2.862   -10.428 -12.846 1.00 78.39 116 A 1 
+ATOM 947  N ND2 . ASN A 1 116 ? 1.032   -11.485 -13.454 1.00 75.46 116 A 1 
+ATOM 948  N N   . LYS A 1 117 ? 1.572   -12.310 -7.793  1.00 96.53 117 A 1 
+ATOM 949  C CA  . LYS A 1 117 ? 1.213   -12.178 -6.372  1.00 97.07 117 A 1 
+ATOM 950  C C   . LYS A 1 117 ? 1.731   -10.878 -5.740  1.00 97.49 117 A 1 
+ATOM 951  O O   . LYS A 1 117 ? 1.013   -10.244 -4.981  1.00 97.04 117 A 1 
+ATOM 952  C CB  . LYS A 1 117 ? 1.733   -13.400 -5.604  1.00 96.69 117 A 1 
+ATOM 953  C CG  . LYS A 1 117 ? 1.271   -13.382 -4.140  1.00 95.74 117 A 1 
+ATOM 954  C CD  . LYS A 1 117 ? 1.859   -14.554 -3.349  1.00 93.98 117 A 1 
+ATOM 955  C CE  . LYS A 1 117 ? 1.369   -14.571 -1.901  1.00 90.33 117 A 1 
+ATOM 956  N NZ  . LYS A 1 117 ? 1.805   -13.364 -1.158  1.00 87.38 117 A 1 
+ATOM 957  N N   . ALA A 1 118 ? 2.938   -10.437 -6.082  1.00 97.25 118 A 1 
+ATOM 958  C CA  . ALA A 1 118 ? 3.494   -9.186  -5.565  1.00 97.25 118 A 1 
+ATOM 959  C C   . ALA A 1 118 ? 2.655   -7.946  -5.928  1.00 97.77 118 A 1 
+ATOM 960  O O   . ALA A 1 118 ? 2.549   -7.015  -5.134  1.00 97.26 118 A 1 
+ATOM 961  C CB  . ALA A 1 118 ? 4.929   -9.046  -6.092  1.00 96.19 118 A 1 
+ATOM 962  N N   . SER A 1 119 ? 2.050   -7.926  -7.120  1.00 97.79 119 A 1 
+ATOM 963  C CA  . SER A 1 119 ? 1.134   -6.857  -7.528  1.00 97.80 119 A 1 
+ATOM 964  C C   . SER A 1 119 ? -0.175  -6.926  -6.750  1.00 98.12 119 A 1 
+ATOM 965  O O   . SER A 1 119 ? -0.651  -5.899  -6.275  1.00 97.60 119 A 1 
+ATOM 966  C CB  . SER A 1 119 ? 0.854   -6.933  -9.032  1.00 96.92 119 A 1 
+ATOM 967  O OG  . SER A 1 119 ? 0.179   -5.766  -9.457  1.00 81.73 119 A 1 
+ATOM 968  N N   . VAL A 1 120 ? -0.713  -8.135  -6.569  1.00 97.83 120 A 1 
+ATOM 969  C CA  . VAL A 1 120 ? -1.921  -8.379  -5.769  1.00 97.96 120 A 1 
+ATOM 970  C C   . VAL A 1 120 ? -1.685  -7.994  -4.307  1.00 98.26 120 A 1 
+ATOM 971  O O   . VAL A 1 120 ? -2.492  -7.276  -3.722  1.00 97.93 120 A 1 
+ATOM 972  C CB  . VAL A 1 120 ? -2.371  -9.849  -5.895  1.00 97.45 120 A 1 
+ATOM 973  C CG1 . VAL A 1 120 ? -3.629  -10.122 -5.069  1.00 95.59 120 A 1 
+ATOM 974  C CG2 . VAL A 1 120 ? -2.670  -10.222 -7.353  1.00 95.37 120 A 1 
+ATOM 975  N N   . ASP A 1 121 ? -0.552  -8.380  -3.720  1.00 98.33 121 A 1 
+ATOM 976  C CA  . ASP A 1 121 ? -0.170  -8.003  -2.354  1.00 98.39 121 A 1 
+ATOM 977  C C   . ASP A 1 121 ? -0.118  -6.486  -2.173  1.00 98.49 121 A 1 
+ATOM 978  O O   . ASP A 1 121 ? -0.599  -5.957  -1.169  1.00 98.21 121 A 1 
+ATOM 979  C CB  . ASP A 1 121 ? 1.213   -8.592  -2.000  1.00 98.11 121 A 1 
+ATOM 980  C CG  . ASP A 1 121 ? 1.200   -10.094 -1.722  1.00 97.52 121 A 1 
+ATOM 981  O OD1 . ASP A 1 121 ? 0.130   -10.633 -1.372  1.00 95.25 121 A 1 
+ATOM 982  O OD2 . ASP A 1 121 ? 2.272   -10.739 -1.786  1.00 95.07 121 A 1 
+ATOM 983  N N   . LYS A 1 122 ? 0.434   -5.774  -3.156  1.00 98.40 122 A 1 
+ATOM 984  C CA  . LYS A 1 122 ? 0.477   -4.311  -3.141  1.00 98.28 122 A 1 
+ATOM 985  C C   . LYS A 1 122 ? -0.930  -3.708  -3.194  1.00 98.43 122 A 1 
+ATOM 986  O O   . LYS A 1 122 ? -1.214  -2.804  -2.413  1.00 98.09 122 A 1 
+ATOM 987  C CB  . LYS A 1 122 ? 1.361   -3.823  -4.288  1.00 97.70 122 A 1 
+ATOM 988  C CG  . LYS A 1 122 ? 1.524   -2.300  -4.235  1.00 95.13 122 A 1 
+ATOM 989  C CD  . LYS A 1 122 ? 2.216   -1.789  -5.492  1.00 90.63 122 A 1 
+ATOM 990  C CE  . LYS A 1 122 ? 2.089   -0.269  -5.479  1.00 83.30 122 A 1 
+ATOM 991  N NZ  . LYS A 1 122 ? 2.340   0.301   -6.817  1.00 75.43 122 A 1 
+ATOM 992  N N   . GLU A 1 123 ? -1.797  -4.211  -4.069  1.00 98.29 123 A 1 
+ATOM 993  C CA  . GLU A 1 123 ? -3.192  -3.761  -4.174  1.00 98.35 123 A 1 
+ATOM 994  C C   . GLU A 1 123 ? -3.960  -4.015  -2.864  1.00 98.53 123 A 1 
+ATOM 995  O O   . GLU A 1 123 ? -4.639  -3.119  -2.355  1.00 98.18 123 A 1 
+ATOM 996  C CB  . GLU A 1 123 ? -3.848  -4.460  -5.377  1.00 98.00 123 A 1 
+ATOM 997  C CG  . GLU A 1 123 ? -5.256  -3.924  -5.670  1.00 93.94 123 A 1 
+ATOM 998  C CD  . GLU A 1 123 ? -5.927  -4.571  -6.898  1.00 94.08 123 A 1 
+ATOM 999  O OE1 . GLU A 1 123 ? -7.061  -4.145  -7.221  1.00 84.76 123 A 1 
+ATOM 1000 O OE2 . GLU A 1 123 ? -5.333  -5.490  -7.510  1.00 87.74 123 A 1 
+ATOM 1001 N N   . LEU A 1 124 ? -3.769  -5.188  -2.241  1.00 98.55 124 A 1 
+ATOM 1002 C CA  . LEU A 1 124 ? -4.304  -5.478  -0.906  1.00 98.58 124 A 1 
+ATOM 1003 C C   . LEU A 1 124 ? -3.790  -4.480  0.135   1.00 98.63 124 A 1 
+ATOM 1004 O O   . LEU A 1 124 ? -4.571  -3.972  0.938   1.00 98.30 124 A 1 
+ATOM 1005 C CB  . LEU A 1 124 ? -3.922  -6.907  -0.478  1.00 98.37 124 A 1 
+ATOM 1006 C CG  . LEU A 1 124 ? -4.577  -8.035  -1.291  1.00 97.33 124 A 1 
+ATOM 1007 C CD1 . LEU A 1 124 ? -3.948  -9.368  -0.885  1.00 95.13 124 A 1 
+ATOM 1008 C CD2 . LEU A 1 124 ? -6.080  -8.131  -1.052  1.00 94.97 124 A 1 
+ATOM 1009 N N   . GLY A 1 125 ? -2.495  -4.167  0.119   1.00 98.54 125 A 1 
+ATOM 1010 C CA  . GLY A 1 125 ? -1.902  -3.169  1.008   1.00 98.48 125 A 1 
+ATOM 1011 C C   . GLY A 1 125 ? -2.480  -1.766  0.809   1.00 98.57 125 A 1 
+ATOM 1012 O O   . GLY A 1 125 ? -2.694  -1.046  1.788   1.00 98.24 125 A 1 
+ATOM 1013 N N   . GLU A 1 126 ? -2.773  -1.375  -0.432  1.00 98.57 126 A 1 
+ATOM 1014 C CA  . GLU A 1 126 ? -3.449  -0.111  -0.747  1.00 98.58 126 A 1 
+ATOM 1015 C C   . GLU A 1 126 ? -4.876  -0.096  -0.179  1.00 98.63 126 A 1 
+ATOM 1016 O O   . GLU A 1 126 ? -5.225  0.834   0.555   1.00 98.34 126 A 1 
+ATOM 1017 C CB  . GLU A 1 126 ? -3.423  0.164   -2.264  1.00 98.31 126 A 1 
+ATOM 1018 C CG  . GLU A 1 126 ? -2.011  0.560   -2.751  1.00 96.46 126 A 1 
+ATOM 1019 C CD  . GLU A 1 126 ? -1.872  0.780   -4.273  1.00 95.62 126 A 1 
+ATOM 1020 O OE1 . GLU A 1 126 ? -0.723  1.077   -4.711  1.00 87.48 126 A 1 
+ATOM 1021 O OE2 . GLU A 1 126 ? -2.876  0.675   -5.004  1.00 89.83 126 A 1 
+ATOM 1022 N N   . TYR A 1 127 ? -5.667  -1.149  -0.395  1.00 98.65 127 A 1 
+ATOM 1023 C CA  . TYR A 1 127 ? -7.000  -1.268  0.205   1.00 98.69 127 A 1 
+ATOM 1024 C C   . TYR A 1 127 ? -6.961  -1.304  1.735   1.00 98.65 127 A 1 
+ATOM 1025 O O   . TYR A 1 127 ? -7.775  -0.636  2.375   1.00 98.26 127 A 1 
+ATOM 1026 C CB  . TYR A 1 127 ? -7.725  -2.505  -0.338  1.00 98.60 127 A 1 
+ATOM 1027 C CG  . TYR A 1 127 ? -8.203  -2.425  -1.776  1.00 98.48 127 A 1 
+ATOM 1028 C CD1 . TYR A 1 127 ? -8.906  -1.293  -2.242  1.00 97.57 127 A 1 
+ATOM 1029 C CD2 . TYR A 1 127 ? -7.980  -3.509  -2.647  1.00 97.60 127 A 1 
+ATOM 1030 C CE1 . TYR A 1 127 ? -9.365  -1.234  -3.574  1.00 97.19 127 A 1 
+ATOM 1031 C CE2 . TYR A 1 127 ? -8.438  -3.459  -3.977  1.00 97.11 127 A 1 
+ATOM 1032 C CZ  . TYR A 1 127 ? -9.127  -2.318  -4.447  1.00 97.38 127 A 1 
+ATOM 1033 O OH  . TYR A 1 127 ? -9.545  -2.262  -5.738  1.00 96.01 127 A 1 
+ATOM 1034 N N   . GLN A 1 128 ? -6.003  -2.010  2.340   1.00 98.40 128 A 1 
+ATOM 1035 C CA  . GLN A 1 128 ? -5.800  -1.988  3.795   1.00 98.20 128 A 1 
+ATOM 1036 C C   . GLN A 1 128 ? -5.547  -0.564  4.302   1.00 98.15 128 A 1 
+ATOM 1037 O O   . GLN A 1 128 ? -6.174  -0.135  5.267   1.00 97.39 128 A 1 
+ATOM 1038 C CB  . GLN A 1 128 ? -4.608  -2.869  4.190   1.00 97.46 128 A 1 
+ATOM 1039 C CG  . GLN A 1 128 ? -4.897  -4.372  4.181   1.00 94.56 128 A 1 
+ATOM 1040 C CD  . GLN A 1 128 ? -3.672  -5.168  4.630   1.00 95.23 128 A 1 
+ATOM 1041 O OE1 . GLN A 1 128 ? -2.532  -4.882  4.285   1.00 88.25 128 A 1 
+ATOM 1042 N NE2 . GLN A 1 128 ? -3.843  -6.175  5.449   1.00 88.40 128 A 1 
+ATOM 1043 N N   . SER A 1 129 ? -4.650  0.170   3.649   1.00 98.57 129 A 1 
+ATOM 1044 C CA  . SER A 1 129 ? -4.280  1.531   4.044   1.00 98.51 129 A 1 
+ATOM 1045 C C   . SER A 1 129 ? -5.435  2.523   3.894   1.00 98.53 129 A 1 
+ATOM 1046 O O   . SER A 1 129 ? -5.620  3.380   4.759   1.00 97.94 129 A 1 
+ATOM 1047 C CB  . SER A 1 129 ? -3.084  1.982   3.206   1.00 98.16 129 A 1 
+ATOM 1048 O OG  . SER A 1 129 ? -2.590  3.222   3.664   1.00 95.46 129 A 1 
+ATOM 1049 N N   . ILE A 1 130 ? -6.221  2.397   2.819   1.00 98.43 130 A 1 
+ATOM 1050 C CA  . ILE A 1 130 ? -7.339  3.298   2.505   1.00 98.52 130 A 1 
+ATOM 1051 C C   . ILE A 1 130 ? -8.589  2.895   3.286   1.00 98.46 130 A 1 
+ATOM 1052 O O   . ILE A 1 130 ? -9.147  3.687   4.044   1.00 98.05 130 A 1 
+ATOM 1053 C CB  . ILE A 1 130 ? -7.603  3.317   0.978   1.00 98.52 130 A 1 
+ATOM 1054 C CG1 . ILE A 1 130 ? -6.367  3.815   0.191   1.00 98.04 130 A 1 
+ATOM 1055 C CG2 . ILE A 1 130 ? -8.817  4.210   0.650   1.00 97.93 130 A 1 
+ATOM 1056 C CD1 . ILE A 1 130 ? -6.424  3.470   -1.302  1.00 96.43 130 A 1 
+ATOM 1057 N N   . CYS A 1 131 ? -9.026  1.646   3.113   1.00 97.79 131 A 1 
+ATOM 1058 C CA  . CYS A 1 131 ? -10.339 1.172   3.544   1.00 97.52 131 A 1 
+ATOM 1059 C C   . CYS A 1 131 ? -10.314 0.500   4.920   1.00 97.78 131 A 1 
+ATOM 1060 O O   . CYS A 1 131 ? -11.366 0.219   5.480   1.00 96.17 131 A 1 
+ATOM 1061 C CB  . CYS A 1 131 ? -10.894 0.208   2.485   1.00 96.03 131 A 1 
+ATOM 1062 S SG  . CYS A 1 131 ? -10.920 1.000   0.848   1.00 93.32 131 A 1 
+ATOM 1063 N N   . GLY A 1 132 ? -9.139  0.205   5.465   1.00 98.08 132 A 1 
+ATOM 1064 C CA  . GLY A 1 132 ? -8.971  -0.527  6.722   1.00 98.17 132 A 1 
+ATOM 1065 C C   . GLY A 1 132 ? -9.159  -2.045  6.619   1.00 98.35 132 A 1 
+ATOM 1066 O O   . GLY A 1 132 ? -8.915  -2.761  7.587   1.00 97.54 132 A 1 
+ATOM 1067 N N   . THR A 1 133 ? -9.575  -2.548  5.453   1.00 98.30 133 A 1 
+ATOM 1068 C CA  . THR A 1 133 ? -9.666  -3.979  5.149   1.00 98.44 133 A 1 
+ATOM 1069 C C   . THR A 1 133 ? -9.484  -4.203  3.654   1.00 98.60 133 A 1 
+ATOM 1070 O O   . THR A 1 133 ? -9.746  -3.305  2.853   1.00 97.93 133 A 1 
+ATOM 1071 C CB  . THR A 1 133 ? -10.989 -4.572  5.663   1.00 97.70 133 A 1 
+ATOM 1072 O OG1 . THR A 1 133 ? -10.932 -5.981  5.640   1.00 93.12 133 A 1 
+ATOM 1073 C CG2 . THR A 1 133 ? -12.235 -4.136  4.882   1.00 92.54 133 A 1 
+ATOM 1074 N N   . ALA A 1 134 ? -9.032  -5.395  3.283   1.00 98.46 134 A 1 
+ATOM 1075 C CA  . ALA A 1 134 ? -8.894  -5.846  1.908   1.00 98.55 134 A 1 
+ATOM 1076 C C   . ALA A 1 134 ? -9.339  -7.306  1.796   1.00 98.63 134 A 1 
+ATOM 1077 O O   . ALA A 1 134 ? -9.419  -8.015  2.801   1.00 98.24 134 A 1 
+ATOM 1078 C CB  . ALA A 1 134 ? -7.438  -5.656  1.473   1.00 98.25 134 A 1 
+ATOM 1079 N N   . TYR A 1 135 ? -9.608  -7.760  0.579   1.00 98.69 135 A 1 
+ATOM 1080 C CA  . TYR A 1 135 ? -10.032 -9.130  0.317   1.00 98.73 135 A 1 
+ATOM 1081 C C   . TYR A 1 135 ? -9.239  -9.719  -0.840  1.00 98.68 135 A 1 
+ATOM 1082 O O   . TYR A 1 135 ? -9.105  -9.100  -1.895  1.00 98.19 135 A 1 
+ATOM 1083 C CB  . TYR A 1 135 ? -11.538 -9.183  0.048   1.00 98.66 135 A 1 
+ATOM 1084 C CG  . TYR A 1 135 ? -12.379 -8.652  1.192   1.00 98.67 135 A 1 
+ATOM 1085 C CD1 . TYR A 1 135 ? -12.710 -9.487  2.277   1.00 98.19 135 A 1 
+ATOM 1086 C CD2 . TYR A 1 135 ? -12.796 -7.305  1.187   1.00 98.20 135 A 1 
+ATOM 1087 C CE1 . TYR A 1 135 ? -13.457 -8.978  3.359   1.00 97.93 135 A 1 
+ATOM 1088 C CE2 . TYR A 1 135 ? -13.539 -6.791  2.269   1.00 97.97 135 A 1 
+ATOM 1089 C CZ  . TYR A 1 135 ? -13.868 -7.629  3.357   1.00 98.10 135 A 1 
+ATOM 1090 O OH  . TYR A 1 135 ? -14.577 -7.127  4.402   1.00 97.25 135 A 1 
+ATOM 1091 N N   . ARG A 1 136 ? -8.739  -10.930 -0.647  1.00 98.46 136 A 1 
+ATOM 1092 C CA  . ARG A 1 136 ? -8.075  -11.738 -1.670  1.00 98.35 136 A 1 
+ATOM 1093 C C   . ARG A 1 136 ? -8.972  -12.908 -2.034  1.00 98.21 136 A 1 
+ATOM 1094 O O   . ARG A 1 136 ? -9.617  -13.474 -1.153  1.00 97.45 136 A 1 
+ATOM 1095 C CB  . ARG A 1 136 ? -6.709  -12.187 -1.141  1.00 97.94 136 A 1 
+ATOM 1096 C CG  . ARG A 1 136 ? -6.042  -13.291 -1.971  1.00 97.47 136 A 1 
+ATOM 1097 C CD  . ARG A 1 136 ? -4.636  -13.602 -1.448  1.00 96.72 136 A 1 
+ATOM 1098 N NE  . ARG A 1 136 ? -3.633  -12.769 -2.116  1.00 94.53 136 A 1 
+ATOM 1099 C CZ  . ARG A 1 136 ? -2.410  -12.517 -1.744  1.00 95.39 136 A 1 
+ATOM 1100 N NH1 . ARG A 1 136 ? -1.911  -12.880 -0.598  1.00 89.40 136 A 1 
+ATOM 1101 N NH2 . ARG A 1 136 ? -1.633  -11.888 -2.554  1.00 89.91 136 A 1 
+ATOM 1102 N N   . ILE A 1 137 ? -8.968  -13.302 -3.291  1.00 96.93 137 A 1 
+ATOM 1103 C CA  . ILE A 1 137 ? -9.540  -14.571 -3.738  1.00 96.35 137 A 1 
+ATOM 1104 C C   . ILE A 1 137 ? -8.461  -15.426 -4.400  1.00 96.01 137 A 1 
+ATOM 1105 O O   . ILE A 1 137 ? -7.711  -14.945 -5.242  1.00 94.90 137 A 1 
+ATOM 1106 C CB  . ILE A 1 137 ? -10.789 -14.365 -4.617  1.00 95.56 137 A 1 
+ATOM 1107 C CG1 . ILE A 1 137 ? -11.484 -15.715 -4.876  1.00 94.02 137 A 1 
+ATOM 1108 C CG2 . ILE A 1 137 ? -10.477 -13.626 -5.932  1.00 92.99 137 A 1 
+ATOM 1109 C CD1 . ILE A 1 137 ? -12.856 -15.595 -5.551  1.00 90.36 137 A 1 
+ATOM 1110 N N   . ILE A 1 138 ? -8.434  -16.712 -4.016  1.00 94.77 138 A 1 
+ATOM 1111 C CA  . ILE A 1 138 ? -7.664  -17.755 -4.693  1.00 93.86 138 A 1 
+ATOM 1112 C C   . ILE A 1 138 ? -8.663  -18.764 -5.250  1.00 92.43 138 A 1 
+ATOM 1113 O O   . ILE A 1 138 ? -9.442  -19.339 -4.493  1.00 89.97 138 A 1 
+ATOM 1114 C CB  . ILE A 1 138 ? -6.672  -18.443 -3.735  1.00 93.49 138 A 1 
+ATOM 1115 C CG1 . ILE A 1 138 ? -5.715  -17.464 -3.025  1.00 89.69 138 A 1 
+ATOM 1116 C CG2 . ILE A 1 138 ? -5.878  -19.531 -4.476  1.00 88.78 138 A 1 
+ATOM 1117 C CD1 . ILE A 1 138 ? -4.788  -16.677 -3.946  1.00 77.75 138 A 1 
+ATOM 1118 N N   . TYR A 1 139 ? -8.634  -19.006 -6.559  1.00 89.25 139 A 1 
+ATOM 1119 C CA  . TYR A 1 139 ? -9.517  -19.974 -7.206  1.00 86.85 139 A 1 
+ATOM 1120 C C   . TYR A 1 139 ? -8.741  -20.823 -8.209  1.00 86.23 139 A 1 
+ATOM 1121 O O   . TYR A 1 139 ? -7.591  -20.533 -8.521  1.00 83.63 139 A 1 
+ATOM 1122 C CB  . TYR A 1 139 ? -10.724 -19.257 -7.824  1.00 84.37 139 A 1 
+ATOM 1123 C CG  . TYR A 1 139 ? -10.384 -18.193 -8.845  1.00 83.67 139 A 1 
+ATOM 1124 C CD1 . TYR A 1 139 ? -10.115 -16.877 -8.416  1.00 79.76 139 A 1 
+ATOM 1125 C CD2 . TYR A 1 139 ? -10.329 -18.514 -10.212 1.00 79.98 139 A 1 
+ATOM 1126 C CE1 . TYR A 1 139 ? -9.788  -15.885 -9.349  1.00 76.06 139 A 1 
+ATOM 1127 C CE2 . TYR A 1 139 ? -9.998  -17.521 -11.152 1.00 76.60 139 A 1 
+ATOM 1128 C CZ  . TYR A 1 139 ? -9.725  -16.204 -10.718 1.00 77.02 139 A 1 
+ATOM 1129 O OH  . TYR A 1 139 ? -9.399  -15.245 -11.616 1.00 74.05 139 A 1 
+ATOM 1130 N N   . ARG A 1 140 ? -9.345  -21.913 -8.670  1.00 83.94 140 A 1 
+ATOM 1131 C CA  . ARG A 1 140 ? -8.691  -22.813 -9.620  1.00 81.64 140 A 1 
+ATOM 1132 C C   . ARG A 1 140 ? -8.838  -22.294 -11.042 1.00 79.86 140 A 1 
+ATOM 1133 O O   . ARG A 1 140 ? -9.863  -21.717 -11.406 1.00 73.00 140 A 1 
+ATOM 1134 C CB  . ARG A 1 140 ? -9.262  -24.225 -9.522  1.00 79.32 140 A 1 
+ATOM 1135 C CG  . ARG A 1 140 ? -8.968  -24.869 -8.169  1.00 73.68 140 A 1 
+ATOM 1136 C CD  . ARG A 1 140 ? -9.627  -26.248 -8.141  1.00 71.95 140 A 1 
+ATOM 1137 N NE  . ARG A 1 140 ? -9.386  -26.934 -6.866  1.00 65.76 140 A 1 
+ATOM 1138 C CZ  . ARG A 1 140 ? -10.021 -28.009 -6.449  1.00 59.18 140 A 1 
+ATOM 1139 N NH1 . ARG A 1 140 ? -10.936 -28.584 -7.176  1.00 55.22 140 A 1 
+ATOM 1140 N NH2 . ARG A 1 140 ? -9.752  -28.524 -5.284  1.00 51.69 140 A 1 
+ATOM 1141 N N   . ASP A 1 141 ? -7.860  -22.607 -11.862 1.00 78.30 141 A 1 
+ATOM 1142 C CA  . ASP A 1 141 ? -7.953  -22.422 -13.301 1.00 74.70 141 A 1 
+ATOM 1143 C C   . ASP A 1 141 ? -9.188  -23.111 -13.886 1.00 73.88 141 A 1 
+ATOM 1144 O O   . ASP A 1 141 ? -9.511  -24.264 -13.580 1.00 64.83 141 A 1 
+ATOM 1145 C CB  . ASP A 1 141 ? -6.694  -22.978 -13.960 1.00 68.64 141 A 1 
+ATOM 1146 C CG  . ASP A 1 141 ? -5.629  -21.910 -14.153 1.00 63.89 141 A 1 
+ATOM 1147 O OD1 . ASP A 1 141 ? -5.793  -20.839 -13.541 1.00 57.97 141 A 1 
+ATOM 1148 O OD2 . ASP A 1 141 ? -4.758  -22.201 -14.997 1.00 59.46 141 A 1 
+ATOM 1149 N N   . GLY A 1 142 ? -9.888  -22.378 -14.748 1.00 69.47 142 A 1 
+ATOM 1150 C CA  . GLY A 1 142 ? -11.116 -22.842 -15.396 1.00 67.17 142 A 1 
+ATOM 1151 C C   . GLY A 1 142 ? -12.391 -22.720 -14.551 1.00 68.42 142 A 1 
+ATOM 1152 O O   . GLY A 1 142 ? -13.469 -23.009 -15.077 1.00 61.96 142 A 1 
+ATOM 1153 N N   . ASP A 1 143 ? -12.329 -22.243 -13.310 1.00 68.33 143 A 1 
+ATOM 1154 C CA  . ASP A 1 143 ? -13.518 -22.015 -12.466 1.00 67.39 143 A 1 
+ATOM 1155 C C   . ASP A 1 143 ? -14.487 -20.963 -13.048 1.00 66.18 143 A 1 
+ATOM 1156 O O   . ASP A 1 143 ? -15.676 -20.968 -12.725 1.00 61.40 143 A 1 
+ATOM 1157 C CB  . ASP A 1 143 ? -13.104 -21.581 -11.043 1.00 63.98 143 A 1 
+ATOM 1158 C CG  . ASP A 1 143 ? -12.693 -22.718 -10.094 1.00 60.61 143 A 1 
+ATOM 1159 O OD1 . ASP A 1 143 ? -12.859 -23.906 -10.446 1.00 58.37 143 A 1 
+ATOM 1160 O OD2 . ASP A 1 143 ? -12.290 -22.387 -8.951  1.00 57.33 143 A 1 
+ATOM 1161 N N   . PHE A 1 144 ? -13.996 -20.070 -13.919 1.00 65.34 144 A 1 
+ATOM 1162 C CA  . PHE A 1 144 ? -14.802 -19.066 -14.605 1.00 64.20 144 A 1 
+ATOM 1163 C C   . PHE A 1 144 ? -14.822 -19.301 -16.118 1.00 62.87 144 A 1 
+ATOM 1164 O O   . PHE A 1 144 ? -13.798 -19.507 -16.768 1.00 57.66 144 A 1 
+ATOM 1165 C CB  . PHE A 1 144 ? -14.320 -17.657 -14.253 1.00 60.94 144 A 1 
+ATOM 1166 C CG  . PHE A 1 144 ? -14.535 -17.291 -12.794 1.00 61.57 144 A 1 
+ATOM 1167 C CD1 . PHE A 1 144 ? -15.776 -16.781 -12.362 1.00 58.39 144 A 1 
+ATOM 1168 C CD2 . PHE A 1 144 ? -13.504 -17.493 -11.858 1.00 58.68 144 A 1 
+ATOM 1169 C CE1 . PHE A 1 144 ? -15.978 -16.470 -11.007 1.00 54.79 144 A 1 
+ATOM 1170 C CE2 . PHE A 1 144 ? -13.709 -17.184 -10.500 1.00 55.98 144 A 1 
+ATOM 1171 C CZ  . PHE A 1 144 ? -14.947 -16.672 -10.076 1.00 57.74 144 A 1 
+ATOM 1172 N N   . THR A 1 145 ? -16.015 -19.214 -16.706 1.00 52.54 145 A 1 
+ATOM 1173 C CA  . THR A 1 145 ? -16.236 -19.438 -18.138 1.00 52.06 145 A 1 
+ATOM 1174 C C   . THR A 1 145 ? -15.393 -18.488 -18.997 1.00 53.91 145 A 1 
+ATOM 1175 O O   . THR A 1 145 ? -15.439 -17.273 -18.828 1.00 49.17 145 A 1 
+ATOM 1176 C CB  . THR A 1 145 ? -17.720 -19.266 -18.497 1.00 45.58 145 A 1 
+ATOM 1177 O OG1 . THR A 1 145 ? -18.531 -19.933 -17.555 1.00 41.55 145 A 1 
+ATOM 1178 C CG2 . THR A 1 145 ? -18.070 -19.854 -19.858 1.00 39.92 145 A 1 
+ATOM 1179 N N   . GLY A 1 146 ? -14.665 -19.050 -19.964 1.00 56.28 146 A 1 
+ATOM 1180 C CA  . GLY A 1 146 ? -13.880 -18.283 -20.944 1.00 57.74 146 A 1 
+ATOM 1181 C C   . GLY A 1 146 ? -12.413 -18.044 -20.573 1.00 60.37 146 A 1 
+ATOM 1182 O O   . GLY A 1 146 ? -11.677 -17.510 -21.410 1.00 56.51 146 A 1 
+ATOM 1183 N N   . ARG A 1 147 ? -11.969 -18.472 -19.395 1.00 61.83 147 A 1 
+ATOM 1184 C CA  . ARG A 1 147 ? -10.537 -18.496 -19.063 1.00 61.43 147 A 1 
+ATOM 1185 C C   . ARG A 1 147 ? -9.838  -19.702 -19.694 1.00 61.24 147 A 1 
+ATOM 1186 O O   . ARG A 1 147 ? -10.430 -20.767 -19.872 1.00 57.58 147 A 1 
+ATOM 1187 C CB  . ARG A 1 147 ? -10.297 -18.424 -17.547 1.00 57.74 147 A 1 
+ATOM 1188 C CG  . ARG A 1 147 ? -10.661 -17.030 -17.017 1.00 53.72 147 A 1 
+ATOM 1189 C CD  . ARG A 1 147 ? -10.005 -16.789 -15.656 1.00 50.80 147 A 1 
+ATOM 1190 N NE  . ARG A 1 147 ? -10.228 -15.404 -15.179 1.00 48.19 147 A 1 
+ATOM 1191 C CZ  . ARG A 1 147 ? -9.411  -14.739 -14.380 1.00 43.35 147 A 1 
+ATOM 1192 N NH1 . ARG A 1 147 ? -8.299  -15.237 -13.936 1.00 42.18 147 A 1 
+ATOM 1193 N NH2 . ARG A 1 147 ? -9.697  -13.534 -13.990 1.00 40.62 147 A 1 
+ATOM 1194 N N   . LYS A 1 148 ? -8.585  -19.505 -20.090 1.00 65.98 148 A 1 
+ATOM 1195 C CA  . LYS A 1 148 ? -7.712  -20.575 -20.582 1.00 65.56 148 A 1 
+ATOM 1196 C C   . LYS A 1 148 ? -6.918  -21.113 -19.402 1.00 67.20 148 A 1 
+ATOM 1197 O O   . LYS A 1 148 ? -6.312  -20.315 -18.701 1.00 60.95 148 A 1 
+ATOM 1198 C CB  . LYS A 1 148 ? -6.749  -20.064 -21.660 1.00 58.85 148 A 1 
+ATOM 1199 C CG  . LYS A 1 148 ? -7.462  -19.722 -22.971 1.00 52.74 148 A 1 
+ATOM 1200 C CD  . LYS A 1 148 ? -6.412  -19.308 -24.005 1.00 48.29 148 A 1 
+ATOM 1201 C CE  . LYS A 1 148 ? -7.071  -18.973 -25.341 1.00 43.11 148 A 1 
+ATOM 1202 N NZ  . LYS A 1 148 ? -6.043  -18.556 -26.321 1.00 36.67 148 A 1 
+ATOM 1203 N N   . ASN A 1 149 ? -6.891  -22.431 -19.261 1.00 71.99 149 A 1 
+ATOM 1204 C CA  . ASN A 1 149 ? -6.002  -23.076 -18.306 1.00 72.22 149 A 1 
+ATOM 1205 C C   . ASN A 1 149 ? -4.558  -22.856 -18.758 1.00 73.76 149 A 1 
+ATOM 1206 O O   . ASN A 1 149 ? -4.257  -23.004 -19.951 1.00 67.86 149 A 1 
+ATOM 1207 C CB  . ASN A 1 149 ? -6.314  -24.577 -18.200 1.00 67.29 149 A 1 
+ATOM 1208 C CG  . ASN A 1 149 ? -7.720  -24.915 -17.738 1.00 61.45 149 A 1 
+ATOM 1209 O OD1 . ASN A 1 149 ? -8.603  -24.096 -17.576 1.00 56.34 149 A 1 
+ATOM 1210 N ND2 . ASN A 1 149 ? -8.006  -26.179 -17.565 1.00 55.17 149 A 1 
+ATOM 1211 N N   . ASP A 1 150 ? -3.693  -22.551 -17.826 1.00 77.41 150 A 1 
+ATOM 1212 C CA  . ASP A 1 150 ? -2.267  -22.426 -18.073 1.00 78.69 150 A 1 
+ATOM 1213 C C   . ASP A 1 150 ? -1.442  -23.428 -17.239 1.00 80.95 150 A 1 
+ATOM 1214 O O   . ASP A 1 150 ? -1.903  -24.549 -16.955 1.00 76.45 150 A 1 
+ATOM 1215 C CB  . ASP A 1 150 ? -1.875  -20.943 -18.025 1.00 73.24 150 A 1 
+ATOM 1216 C CG  . ASP A 1 150 ? -1.802  -20.315 -16.637 1.00 68.59 150 A 1 
+ATOM 1217 O OD1 . ASP A 1 150 ? -1.648  -21.104 -15.684 1.00 62.85 150 A 1 
+ATOM 1218 O OD2 . ASP A 1 150 ? -1.637  -19.079 -16.639 1.00 66.30 150 A 1 
+ATOM 1219 N N   . THR A 1 151 ? -0.184  -23.117 -16.964 1.00 80.12 151 A 1 
+ATOM 1220 C CA  . THR A 1 151 ? 0.717   -24.036 -16.254 1.00 81.34 151 A 1 
+ATOM 1221 C C   . THR A 1 151 ? 0.525   -23.991 -14.738 1.00 83.58 151 A 1 
+ATOM 1222 O O   . THR A 1 151 ? 0.885   -24.943 -14.047 1.00 79.84 151 A 1 
+ATOM 1223 C CB  . THR A 1 151 ? 2.175   -23.720 -16.616 1.00 77.48 151 A 1 
+ATOM 1224 O OG1 . THR A 1 151 ? 2.319   -23.715 -18.024 1.00 69.85 151 A 1 
+ATOM 1225 C CG2 . THR A 1 151 ? 3.183   -24.738 -16.091 1.00 68.54 151 A 1 
+ATOM 1226 N N   . VAL A 1 152 ? -0.017  -22.883 -14.219 1.00 84.66 152 A 1 
+ATOM 1227 C CA  . VAL A 1 152 ? -0.236  -22.687 -12.784 1.00 86.10 152 A 1 
+ATOM 1228 C C   . VAL A 1 152 ? -1.668  -23.113 -12.443 1.00 87.28 152 A 1 
+ATOM 1229 O O   . VAL A 1 152 ? -2.602  -22.695 -13.110 1.00 85.10 152 A 1 
+ATOM 1230 C CB  . VAL A 1 152 ? 0.051   -21.236 -12.370 1.00 84.36 152 A 1 
+ATOM 1231 C CG1 . VAL A 1 152 ? -0.137  -21.047 -10.864 1.00 79.07 152 A 1 
+ATOM 1232 C CG2 . VAL A 1 152 ? 1.506   -20.864 -12.704 1.00 79.99 152 A 1 
+ATOM 1233 N N   . PRO A 1 153 ? -1.889  -23.945 -11.420 1.00 85.08 153 A 1 
+ATOM 1234 C CA  . PRO A 1 153 ? -3.215  -24.523 -11.168 1.00 84.55 153 A 1 
+ATOM 1235 C C   . PRO A 1 153 ? -4.187  -23.596 -10.412 1.00 85.99 153 A 1 
+ATOM 1236 O O   . PRO A 1 153 ? -5.258  -24.048 -9.991  1.00 83.12 153 A 1 
+ATOM 1237 C CB  . PRO A 1 153 ? -2.912  -25.807 -10.387 1.00 82.12 153 A 1 
+ATOM 1238 C CG  . PRO A 1 153 ? -1.651  -25.440 -9.596  1.00 82.17 153 A 1 
+ATOM 1239 C CD  . PRO A 1 153 ? -0.885  -24.554 -10.571 1.00 85.97 153 A 1 
+ATOM 1240 N N   . PHE A 1 154 ? -3.812  -22.353 -10.161 1.00 87.69 154 A 1 
+ATOM 1241 C CA  . PHE A 1 154 ? -4.599  -21.375 -9.411  1.00 88.58 154 A 1 
+ATOM 1242 C C   . PHE A 1 154 ? -4.396  -19.956 -9.940  1.00 89.47 154 A 1 
+ATOM 1243 O O   . PHE A 1 154 ? -3.378  -19.637 -10.535 1.00 87.51 154 A 1 
+ATOM 1244 C CB  . PHE A 1 154 ? -4.247  -21.433 -7.916  1.00 87.79 154 A 1 
+ATOM 1245 C CG  . PHE A 1 154 ? -2.803  -21.104 -7.564  1.00 90.38 154 A 1 
+ATOM 1246 C CD1 . PHE A 1 154 ? -1.895  -22.144 -7.285  1.00 87.09 154 A 1 
+ATOM 1247 C CD2 . PHE A 1 154 ? -2.353  -19.770 -7.526  1.00 88.69 154 A 1 
+ATOM 1248 C CE1 . PHE A 1 154 ? -0.552  -21.851 -6.987  1.00 87.51 154 A 1 
+ATOM 1249 C CE2 . PHE A 1 154 ? -1.005  -19.478 -7.236  1.00 88.03 154 A 1 
+ATOM 1250 C CZ  . PHE A 1 154 ? -0.103  -20.519 -6.969  1.00 89.09 154 A 1 
+ATOM 1251 N N   . GLU A 1 155 ? -5.343  -19.112 -9.616  1.00 88.95 155 A 1 
+ATOM 1252 C CA  . GLU A 1 155 ? -5.350  -17.678 -9.917  1.00 89.57 155 A 1 
+ATOM 1253 C C   . GLU A 1 155 ? -5.422  -16.892 -8.600  1.00 90.91 155 A 1 
+ATOM 1254 O O   . GLU A 1 155 ? -6.121  -17.294 -7.660  1.00 89.06 155 A 1 
+ATOM 1255 C CB  . GLU A 1 155 ? -6.587  -17.398 -10.759 1.00 87.46 155 A 1 
+ATOM 1256 C CG  . GLU A 1 155 ? -6.516  -18.006 -12.187 1.00 80.68 155 A 1 
+ATOM 1257 C CD  . GLU A 1 155 ? -6.151  -16.986 -13.253 1.00 77.41 155 A 1 
+ATOM 1258 O OE1 . GLU A 1 155 ? -6.540  -17.230 -14.427 1.00 68.00 155 A 1 
+ATOM 1259 O OE2 . GLU A 1 155 ? -5.861  -15.806 -12.920 1.00 66.79 155 A 1 
+ATOM 1260 N N   . ASP A 1 156 ? -4.732  -15.756 -8.544  1.00 91.84 156 A 1 
+ATOM 1261 C CA  . ASP A 1 156 ? -4.664  -14.861 -7.385  1.00 92.95 156 A 1 
+ATOM 1262 C C   . ASP A 1 156 ? -5.168  -13.461 -7.749  1.00 93.26 156 A 1 
+ATOM 1263 O O   . ASP A 1 156 ? -4.708  -12.846 -8.709  1.00 90.96 156 A 1 
+ATOM 1264 C CB  . ASP A 1 156 ? -3.222  -14.817 -6.843  1.00 91.80 156 A 1 
+ATOM 1265 C CG  . ASP A 1 156 ? -3.069  -13.988 -5.556  1.00 92.53 156 A 1 
+ATOM 1266 O OD1 . ASP A 1 156 ? -4.089  -13.604 -4.936  1.00 87.03 156 A 1 
+ATOM 1267 O OD2 . ASP A 1 156 ? -1.930  -13.763 -5.086  1.00 87.68 156 A 1 
+ATOM 1268 N N   . ARG A 1 157 ? -6.119  -12.928 -6.967  1.00 95.12 157 A 1 
+ATOM 1269 C CA  . ARG A 1 157 ? -6.687  -11.605 -7.237  1.00 95.19 157 A 1 
+ATOM 1270 C C   . ARG A 1 157 ? -7.104  -10.868 -5.963  1.00 96.38 157 A 1 
+ATOM 1271 O O   . ARG A 1 157 ? -7.731  -11.442 -5.073  1.00 95.75 157 A 1 
+ATOM 1272 C CB  . ARG A 1 157 ? -7.849  -11.772 -8.225  1.00 93.18 157 A 1 
+ATOM 1273 C CG  . ARG A 1 157 ? -8.360  -10.423 -8.727  1.00 82.58 157 A 1 
+ATOM 1274 C CD  . ARG A 1 157 ? -9.432  -10.596 -9.792  1.00 76.78 157 A 1 
+ATOM 1275 N NE  . ARG A 1 157 ? -9.971  -9.278  -10.163 1.00 67.14 157 A 1 
+ATOM 1276 C CZ  . ARG A 1 157 ? -10.914 -9.036  -11.051 1.00 58.25 157 A 1 
+ATOM 1277 N NH1 . ARG A 1 157 ? -11.473 -9.997  -11.730 1.00 52.60 157 A 1 
+ATOM 1278 N NH2 . ARG A 1 157 ? -11.309 -7.812  -11.261 1.00 49.86 157 A 1 
+ATOM 1279 N N   . ALA A 1 158 ? -6.843  -9.567  -5.917  1.00 97.01 158 A 1 
+ATOM 1280 C CA  . ALA A 1 158 ? -7.465  -8.660  -4.958  1.00 97.52 158 A 1 
+ATOM 1281 C C   . ALA A 1 158 ? -8.907  -8.335  -5.386  1.00 97.45 158 A 1 
+ATOM 1282 O O   . ALA A 1 158 ? -9.198  -8.127  -6.564  1.00 96.38 158 A 1 
+ATOM 1283 C CB  . ALA A 1 158 ? -6.611  -7.397  -4.812  1.00 97.37 158 A 1 
+ATOM 1284 N N   . LEU A 1 159 ? -9.812  -8.308  -4.421  1.00 98.02 159 A 1 
+ATOM 1285 C CA  . LEU A 1 159 ? -11.215 -7.958  -4.612  1.00 98.08 159 A 1 
+ATOM 1286 C C   . LEU A 1 159 ? -11.494 -6.568  -4.042  1.00 98.19 159 A 1 
+ATOM 1287 O O   . LEU A 1 159 ? -10.946 -6.189  -3.005  1.00 97.46 159 A 1 
+ATOM 1288 C CB  . LEU A 1 159 ? -12.113 -9.017  -3.954  1.00 97.63 159 A 1 
+ATOM 1289 C CG  . LEU A 1 159 ? -12.025 -10.425 -4.564  1.00 97.01 159 A 1 
+ATOM 1290 C CD1 . LEU A 1 159 ? -12.915 -11.371 -3.757  1.00 95.14 159 A 1 
+ATOM 1291 C CD2 . LEU A 1 159 ? -12.491 -10.457 -6.022  1.00 95.00 159 A 1 
+ATOM 1292 N N   . ASP A 1 160 ? -12.391 -5.837  -4.696  1.00 98.23 160 A 1 
+ATOM 1293 C CA  . ASP A 1 160 ? -12.831 -4.522  -4.238  1.00 98.19 160 A 1 
+ATOM 1294 C C   . ASP A 1 160 ? -13.581 -4.643  -2.897  1.00 98.38 160 A 1 
+ATOM 1295 O O   . ASP A 1 160 ? -14.624 -5.309  -2.838  1.00 97.85 160 A 1 
+ATOM 1296 C CB  . ASP A 1 160 ? -13.693 -3.861  -5.324  1.00 97.40 160 A 1 
+ATOM 1297 C CG  . ASP A 1 160 ? -14.139 -2.426  -4.986  1.00 96.05 160 A 1 
+ATOM 1298 O OD1 . ASP A 1 160 ? -14.011 -2.006  -3.811  1.00 92.81 160 A 1 
+ATOM 1299 O OD2 . ASP A 1 160 ? -14.641 -1.750  -5.907  1.00 91.29 160 A 1 
+ATOM 1300 N N   . PRO A 1 161 ? -13.110 -3.992  -1.820  1.00 98.34 161 A 1 
+ATOM 1301 C CA  . PRO A 1 161 ? -13.786 -4.009  -0.525  1.00 98.26 161 A 1 
+ATOM 1302 C C   . PRO A 1 161 ? -15.196 -3.411  -0.542  1.00 98.13 161 A 1 
+ATOM 1303 O O   . PRO A 1 161 ? -15.997 -3.703  0.346   1.00 97.20 161 A 1 
+ATOM 1304 C CB  . PRO A 1 161 ? -12.875 -3.218  0.418   1.00 97.85 161 A 1 
+ATOM 1305 C CG  . PRO A 1 161 ? -11.499 -3.322  -0.228  1.00 96.48 161 A 1 
+ATOM 1306 C CD  . PRO A 1 161 ? -11.830 -3.308  -1.709  1.00 97.94 161 A 1 
+ATOM 1307 N N   . SER A 1 162 ? -15.530 -2.587  -1.540  1.00 98.12 162 A 1 
+ATOM 1308 C CA  . SER A 1 162 ? -16.877 -2.025  -1.702  1.00 97.77 162 A 1 
+ATOM 1309 C C   . SER A 1 162 ? -17.906 -3.060  -2.156  1.00 97.64 162 A 1 
+ATOM 1310 O O   . SER A 1 162 ? -19.105 -2.843  -1.977  1.00 96.29 162 A 1 
+ATOM 1311 C CB  . SER A 1 162 ? -16.868 -0.891  -2.729  1.00 96.72 162 A 1 
+ATOM 1312 O OG  . SER A 1 162 ? -16.060 0.180   -2.304  1.00 84.96 162 A 1 
+ATOM 1313 N N   . THR A 1 163 ? -17.465 -4.161  -2.753  1.00 97.52 163 A 1 
+ATOM 1314 C CA  . THR A 1 163 ? -18.339 -5.212  -3.304  1.00 97.41 163 A 1 
+ATOM 1315 C C   . THR A 1 163 ? -18.053 -6.585  -2.710  1.00 97.60 163 A 1 
+ATOM 1316 O O   . THR A 1 163 ? -18.658 -7.572  -3.119  1.00 96.83 163 A 1 
+ATOM 1317 C CB  . THR A 1 163 ? -18.259 -5.260  -4.835  1.00 96.64 163 A 1 
+ATOM 1318 O OG1 . THR A 1 163 ? -16.949 -5.521  -5.260  1.00 94.67 163 A 1 
+ATOM 1319 C CG2 . THR A 1 163 ? -18.702 -3.946  -5.478  1.00 92.70 163 A 1 
+ATOM 1320 N N   . THR A 1 164 ? -17.160 -6.661  -1.730  1.00 97.63 164 A 1 
+ATOM 1321 C CA  . THR A 1 164 ? -16.749 -7.920  -1.107  1.00 98.16 164 A 1 
+ATOM 1322 C C   . THR A 1 164 ? -16.867 -7.842  0.408   1.00 98.20 164 A 1 
+ATOM 1323 O O   . THR A 1 164 ? -16.540 -6.828  1.018   1.00 97.77 164 A 1 
+ATOM 1324 C CB  . THR A 1 164 ? -15.322 -8.297  -1.525  1.00 98.03 164 A 1 
+ATOM 1325 O OG1 . THR A 1 164 ? -15.232 -8.319  -2.933  1.00 94.59 164 A 1 
+ATOM 1326 C CG2 . THR A 1 164 ? -14.912 -9.683  -1.031  1.00 95.13 164 A 1 
+ATOM 1327 N N   . PHE A 1 165 ? -17.313 -8.920  1.031   1.00 98.23 165 A 1 
+ATOM 1328 C CA  . PHE A 1 165 ? -17.359 -9.035  2.486   1.00 98.21 165 A 1 
+ATOM 1329 C C   . PHE A 1 165 ? -17.205 -10.480 2.959   1.00 98.21 165 A 1 
+ATOM 1330 O O   . PHE A 1 165 ? -17.510 -11.435 2.249   1.00 97.80 165 A 1 
+ATOM 1331 C CB  . PHE A 1 165 ? -18.645 -8.399  3.030   1.00 98.04 165 A 1 
+ATOM 1332 C CG  . PHE A 1 165 ? -19.941 -9.040  2.578   1.00 98.10 165 A 1 
+ATOM 1333 C CD1 . PHE A 1 165 ? -20.569 -8.607  1.389   1.00 97.42 165 A 1 
+ATOM 1334 C CD2 . PHE A 1 165 ? -20.550 -10.037 3.362   1.00 97.31 165 A 1 
+ATOM 1335 C CE1 . PHE A 1 165 ? -21.798 -9.161  0.999   1.00 96.87 165 A 1 
+ATOM 1336 C CE2 . PHE A 1 165 ? -21.782 -10.590 2.971   1.00 96.90 165 A 1 
+ATOM 1337 C CZ  . PHE A 1 165 ? -22.411 -10.149 1.790   1.00 96.87 165 A 1 
+ATOM 1338 N N   . MET A 1 166 ? -16.763 -10.621 4.200   1.00 98.52 166 A 1 
+ATOM 1339 C CA  . MET A 1 166 ? -16.641 -11.902 4.891   1.00 98.53 166 A 1 
+ATOM 1340 C C   . MET A 1 166 ? -17.629 -11.959 6.056   1.00 98.64 166 A 1 
+ATOM 1341 O O   . MET A 1 166 ? -17.770 -10.996 6.817   1.00 98.19 166 A 1 
+ATOM 1342 C CB  . MET A 1 166 ? -15.189 -12.097 5.351   1.00 97.89 166 A 1 
+ATOM 1343 C CG  . MET A 1 166 ? -14.945 -13.476 5.975   1.00 90.25 166 A 1 
+ATOM 1344 S SD  . MET A 1 166 ? -15.151 -14.882 4.855   1.00 88.44 166 A 1 
+ATOM 1345 C CE  . MET A 1 166 ? -13.672 -14.692 3.834   1.00 77.08 166 A 1 
+ATOM 1346 N N   . VAL A 1 167 ? -18.288 -13.100 6.204   1.00 98.31 167 A 1 
+ATOM 1347 C CA  . VAL A 1 167 ? -19.195 -13.401 7.314   1.00 98.33 167 A 1 
+ATOM 1348 C C   . VAL A 1 167 ? -18.511 -14.373 8.268   1.00 98.22 167 A 1 
+ATOM 1349 O O   . VAL A 1 167 ? -17.975 -15.393 7.840   1.00 97.57 167 A 1 
+ATOM 1350 C CB  . VAL A 1 167 ? -20.541 -13.959 6.821   1.00 98.09 167 A 1 
+ATOM 1351 C CG1 . VAL A 1 167 ? -21.516 -14.095 7.988   1.00 96.83 167 A 1 
+ATOM 1352 C CG2 . VAL A 1 167 ? -21.196 -13.052 5.768   1.00 96.73 167 A 1 
+ATOM 1353 N N   . TYR A 1 168 ? -18.570 -14.067 9.548   1.00 97.99 168 A 1 
+ATOM 1354 C CA  . TYR A 1 168 ? -17.947 -14.834 10.617  1.00 97.98 168 A 1 
+ATOM 1355 C C   . TYR A 1 168 ? -18.984 -15.430 11.568  1.00 97.85 168 A 1 
+ATOM 1356 O O   . TYR A 1 168 ? -20.059 -14.865 11.787  1.00 97.00 168 A 1 
+ATOM 1357 C CB  . TYR A 1 168 ? -16.966 -13.943 11.383  1.00 97.85 168 A 1 
+ATOM 1358 C CG  . TYR A 1 168 ? -15.798 -13.454 10.550  1.00 97.96 168 A 1 
+ATOM 1359 C CD1 . TYR A 1 168 ? -14.669 -14.277 10.397  1.00 97.05 168 A 1 
+ATOM 1360 C CD2 . TYR A 1 168 ? -15.840 -12.194 9.919   1.00 97.11 168 A 1 
+ATOM 1361 C CE1 . TYR A 1 168 ? -13.576 -13.845 9.619   1.00 96.75 168 A 1 
+ATOM 1362 C CE2 . TYR A 1 168 ? -14.749 -11.759 9.138   1.00 96.88 168 A 1 
+ATOM 1363 C CZ  . TYR A 1 168 ? -13.614 -12.588 8.991   1.00 97.10 168 A 1 
+ATOM 1364 O OH  . TYR A 1 168 ? -12.550 -12.190 8.249   1.00 96.10 168 A 1 
+ATOM 1365 N N   . GLU A 1 169 ? -18.624 -16.544 12.182  1.00 97.14 169 A 1 
+ATOM 1366 C CA  . GLU A 1 169 ? -19.422 -17.166 13.235  1.00 96.69 169 A 1 
+ATOM 1367 C C   . GLU A 1 169 ? -19.459 -16.280 14.493  1.00 96.77 169 A 1 
+ATOM 1368 O O   . GLU A 1 169 ? -18.445 -15.722 14.934  1.00 95.46 169 A 1 
+ATOM 1369 C CB  . GLU A 1 169 ? -18.849 -18.559 13.516  1.00 94.73 169 A 1 
+ATOM 1370 C CG  . GLU A 1 169 ? -19.840 -19.463 14.253  1.00 87.75 169 A 1 
+ATOM 1371 C CD  . GLU A 1 169 ? -19.270 -20.867 14.534  1.00 87.21 169 A 1 
+ATOM 1372 O OE1 . GLU A 1 169 ? -20.051 -21.741 14.951  1.00 78.52 169 A 1 
+ATOM 1373 O OE2 . GLU A 1 169 ? -18.026 -21.040 14.471  1.00 80.00 169 A 1 
+ATOM 1374 N N   . SER A 1 170 ? -20.645 -16.145 15.091  1.00 96.62 170 A 1 
+ATOM 1375 C CA  . SER A 1 170 ? -20.870 -15.346 16.301  1.00 95.97 170 A 1 
+ATOM 1376 C C   . SER A 1 170 ? -20.511 -16.104 17.583  1.00 95.36 170 A 1 
+ATOM 1377 O O   . SER A 1 170 ? -21.299 -16.166 18.531  1.00 90.99 170 A 1 
+ATOM 1378 C CB  . SER A 1 170 ? -22.306 -14.807 16.328  1.00 94.23 170 A 1 
+ATOM 1379 O OG  . SER A 1 170 ? -22.452 -13.860 17.371  1.00 82.50 170 A 1 
+ATOM 1380 N N   . ASN A 1 171 ? -19.316 -16.686 17.638  1.00 95.28 171 A 1 
+ATOM 1381 C CA  . ASN A 1 171 ? -18.797 -17.392 18.807  1.00 94.47 171 A 1 
+ATOM 1382 C C   . ASN A 1 171 ? -17.374 -16.917 19.166  1.00 95.13 171 A 1 
+ATOM 1383 O O   . ASN A 1 171 ? -16.853 -15.946 18.609  1.00 92.69 171 A 1 
+ATOM 1384 C CB  . ASN A 1 171 ? -18.946 -18.913 18.575  1.00 91.49 171 A 1 
+ATOM 1385 C CG  . ASN A 1 171 ? -17.999 -19.488 17.542  1.00 89.00 171 A 1 
+ATOM 1386 O OD1 . ASN A 1 171 ? -17.034 -18.866 17.132  1.00 79.97 171 A 1 
+ATOM 1387 N ND2 . ASN A 1 171 ? -18.213 -20.720 17.144  1.00 81.91 171 A 1 
+ATOM 1388 N N   . ILE A 1 172 ? -16.750 -17.589 20.131  1.00 94.44 172 A 1 
+ATOM 1389 C CA  . ILE A 1 172 ? -15.394 -17.251 20.598  1.00 94.22 172 A 1 
+ATOM 1390 C C   . ILE A 1 172 ? -14.347 -17.453 19.492  1.00 93.78 172 A 1 
+ATOM 1391 O O   . ILE A 1 172 ? -13.376 -16.705 19.439  1.00 90.79 172 A 1 
+ATOM 1392 C CB  . ILE A 1 172 ? -15.045 -18.075 21.863  1.00 93.41 172 A 1 
+ATOM 1393 C CG1 . ILE A 1 172 ? -16.017 -17.731 23.017  1.00 87.39 172 A 1 
+ATOM 1394 C CG2 . ILE A 1 172 ? -13.587 -17.841 22.310  1.00 86.66 172 A 1 
+ATOM 1395 C CD1 . ILE A 1 172 ? -15.888 -18.642 24.248  1.00 80.94 172 A 1 
+ATOM 1396 N N   . SER A 1 173 ? -14.539 -18.445 18.622  1.00 93.55 173 A 1 
+ATOM 1397 C CA  . SER A 1 173 ? -13.590 -18.742 17.545  1.00 92.60 173 A 1 
+ATOM 1398 C C   . SER A 1 173 ? -13.612 -17.677 16.450  1.00 93.43 173 A 1 
+ATOM 1399 O O   . SER A 1 173 ? -12.570 -17.397 15.864  1.00 91.37 173 A 1 
+ATOM 1400 C CB  . SER A 1 173 ? -13.852 -20.129 16.949  1.00 90.23 173 A 1 
+ATOM 1401 O OG  . SER A 1 173 ? -14.999 -20.150 16.132  1.00 79.92 173 A 1 
+ATOM 1402 N N   . GLY A 1 174 ? -14.789 -17.067 16.191  1.00 93.59 174 A 1 
+ATOM 1403 C CA  . GLY A 1 174 ? -14.953 -16.110 15.105  1.00 94.03 174 A 1 
+ATOM 1404 C C   . GLY A 1 174 ? -14.532 -16.685 13.751  1.00 94.94 174 A 1 
+ATOM 1405 O O   . GLY A 1 174 ? -13.890 -15.983 12.973  1.00 92.84 174 A 1 
+ATOM 1406 N N   . TYR A 1 175 ? -14.824 -17.963 13.507  1.00 94.79 175 A 1 
+ATOM 1407 C CA  . TYR A 1 175 ? -14.375 -18.658 12.300  1.00 94.78 175 A 1 
+ATOM 1408 C C   . TYR A 1 175 ? -15.051 -18.071 11.047  1.00 95.90 175 A 1 
+ATOM 1409 O O   . TYR A 1 175 ? -16.234 -17.726 11.111  1.00 95.46 175 A 1 
+ATOM 1410 C CB  . TYR A 1 175 ? -14.629 -20.166 12.440  1.00 92.65 175 A 1 
+ATOM 1411 C CG  . TYR A 1 175 ? -13.599 -21.023 11.724  1.00 85.91 175 A 1 
+ATOM 1412 C CD1 . TYR A 1 175 ? -13.847 -21.507 10.424  1.00 79.50 175 A 1 
+ATOM 1413 C CD2 . TYR A 1 175 ? -12.375 -21.320 12.359  1.00 78.33 175 A 1 
+ATOM 1414 C CE1 . TYR A 1 175 ? -12.876 -22.286 9.763   1.00 70.65 175 A 1 
+ATOM 1415 C CE2 . TYR A 1 175 ? -11.398 -22.097 11.701  1.00 71.30 175 A 1 
+ATOM 1416 C CZ  . TYR A 1 175 ? -11.650 -22.582 10.401  1.00 70.14 175 A 1 
+ATOM 1417 O OH  . TYR A 1 175 ? -10.711 -23.332 9.763   1.00 67.33 175 A 1 
+ATOM 1418 N N   . PRO A 1 176 ? -14.350 -17.932 9.914   1.00 96.25 176 A 1 
+ATOM 1419 C CA  . PRO A 1 176 ? -14.978 -17.502 8.671   1.00 96.10 176 A 1 
+ATOM 1420 C C   . PRO A 1 176 ? -15.989 -18.557 8.198   1.00 96.15 176 A 1 
+ATOM 1421 O O   . PRO A 1 176 ? -15.688 -19.749 8.198   1.00 94.68 176 A 1 
+ATOM 1422 C CB  . PRO A 1 176 ? -13.826 -17.305 7.683   1.00 94.99 176 A 1 
+ATOM 1423 C CG  . PRO A 1 176 ? -12.752 -18.272 8.182   1.00 92.28 176 A 1 
+ATOM 1424 C CD  . PRO A 1 176 ? -12.940 -18.246 9.696   1.00 94.86 176 A 1 
+ATOM 1425 N N   . LEU A 1 177 ? -17.182 -18.115 7.813   1.00 96.90 177 A 1 
+ATOM 1426 C CA  . LEU A 1 177 ? -18.284 -18.968 7.359   1.00 96.63 177 A 1 
+ATOM 1427 C C   . LEU A 1 177 ? -18.552 -18.827 5.865   1.00 96.43 177 A 1 
+ATOM 1428 O O   . LEU A 1 177 ? -18.802 -19.818 5.182   1.00 94.36 177 A 1 
+ATOM 1429 C CB  . LEU A 1 177 ? -19.558 -18.596 8.140   1.00 95.84 177 A 1 
+ATOM 1430 C CG  . LEU A 1 177 ? -19.583 -19.013 9.615   1.00 94.62 177 A 1 
+ATOM 1431 C CD1 . LEU A 1 177 ? -20.930 -18.581 10.204  1.00 91.83 177 A 1 
+ATOM 1432 C CD2 . LEU A 1 177 ? -19.437 -20.528 9.785   1.00 92.27 177 A 1 
+ATOM 1433 N N   . LEU A 1 178 ? -18.553 -17.595 5.367   1.00 97.05 178 A 1 
+ATOM 1434 C CA  . LEU A 1 178 ? -18.978 -17.280 4.012   1.00 97.29 178 A 1 
+ATOM 1435 C C   . LEU A 1 178 ? -18.222 -16.050 3.504   1.00 97.76 178 A 1 
+ATOM 1436 O O   . LEU A 1 178 ? -18.272 -14.986 4.122   1.00 96.97 178 A 1 
+ATOM 1437 C CB  . LEU A 1 178 ? -20.505 -17.048 4.031   1.00 96.17 178 A 1 
+ATOM 1438 C CG  . LEU A 1 178 ? -21.173 -17.091 2.649   1.00 93.54 178 A 1 
+ATOM 1439 C CD1 . LEU A 1 178 ? -21.262 -18.525 2.121   1.00 87.89 178 A 1 
+ATOM 1440 C CD2 . LEU A 1 178 ? -22.595 -16.542 2.754   1.00 88.74 178 A 1 
+ATOM 1441 N N   . GLY A 1 179 ? -17.550 -16.197 2.368   1.00 97.37 179 A 1 
+ATOM 1442 C CA  . GLY A 1 179 ? -16.967 -15.093 1.614   1.00 97.36 179 A 1 
+ATOM 1443 C C   . GLY A 1 179 ? -17.879 -14.720 0.456   1.00 97.29 179 A 1 
+ATOM 1444 O O   . GLY A 1 179 ? -18.246 -15.590 -0.325  1.00 96.28 179 A 1 
+ATOM 1445 N N   . VAL A 1 180 ? -18.261 -13.456 0.337   1.00 97.63 180 A 1 
+ATOM 1446 C CA  . VAL A 1 180 ? -19.207 -12.980 -0.676  1.00 97.71 180 A 1 
+ATOM 1447 C C   . VAL A 1 180 ? -18.572 -11.863 -1.489  1.00 97.79 180 A 1 
+ATOM 1448 O O   . VAL A 1 180 ? -18.014 -10.924 -0.925  1.00 97.30 180 A 1 
+ATOM 1449 C CB  . VAL A 1 180 ? -20.530 -12.521 -0.037  1.00 97.28 180 A 1 
+ATOM 1450 C CG1 . VAL A 1 180 ? -21.541 -12.094 -1.105  1.00 95.86 180 A 1 
+ATOM 1451 C CG2 . VAL A 1 180 ? -21.174 -13.641 0.797   1.00 95.70 180 A 1 
+ATOM 1452 N N   . THR A 1 181 ? -18.704 -11.950 -2.810  1.00 97.10 181 A 1 
+ATOM 1453 C CA  . THR A 1 181 ? -18.372 -10.858 -3.733  1.00 96.85 181 A 1 
+ATOM 1454 C C   . THR A 1 181 ? -19.466 -10.720 -4.782  1.00 96.51 181 A 1 
+ATOM 1455 O O   . THR A 1 181 ? -20.101 -11.710 -5.150  1.00 95.24 181 A 1 
+ATOM 1456 C CB  . THR A 1 181 ? -16.982 -11.044 -4.359  1.00 96.13 181 A 1 
+ATOM 1457 O OG1 . THR A 1 181 ? -16.615 -9.884  -5.069  1.00 89.07 181 A 1 
+ATOM 1458 C CG2 . THR A 1 181 ? -16.885 -12.234 -5.318  1.00 88.79 181 A 1 
+ATOM 1459 N N   . TYR A 1 182 ? -19.717 -9.496  -5.257  1.00 97.11 182 A 1 
+ATOM 1460 C CA  . TYR A 1 182 ? -20.770 -9.239  -6.234  1.00 96.72 182 A 1 
+ATOM 1461 C C   . TYR A 1 182 ? -20.357 -8.200  -7.276  1.00 96.41 182 A 1 
+ATOM 1462 O O   . TYR A 1 182 ? -19.481 -7.372  -7.046  1.00 95.20 182 A 1 
+ATOM 1463 C CB  . TYR A 1 182 ? -22.078 -8.869  -5.521  1.00 96.30 182 A 1 
+ATOM 1464 C CG  . TYR A 1 182 ? -22.028 -7.573  -4.735  1.00 96.50 182 A 1 
+ATOM 1465 C CD1 . TYR A 1 182 ? -21.681 -7.589  -3.366  1.00 95.03 182 A 1 
+ATOM 1466 C CD2 . TYR A 1 182 ? -22.328 -6.352  -5.365  1.00 95.26 182 A 1 
+ATOM 1467 C CE1 . TYR A 1 182 ? -21.637 -6.388  -2.635  1.00 94.67 182 A 1 
+ATOM 1468 C CE2 . TYR A 1 182 ? -22.281 -5.146  -4.639  1.00 94.90 182 A 1 
+ATOM 1469 C CZ  . TYR A 1 182 ? -21.936 -5.161  -3.271  1.00 94.97 182 A 1 
+ATOM 1470 O OH  . TYR A 1 182 ? -21.894 -3.996  -2.574  1.00 93.53 182 A 1 
+ATOM 1471 N N   . TYR A 1 183 ? -21.018 -8.262  -8.419  1.00 94.62 183 A 1 
+ATOM 1472 C CA  . TYR A 1 183 ? -20.744 -7.402  -9.565  1.00 93.56 183 A 1 
+ATOM 1473 C C   . TYR A 1 183 ? -22.052 -6.986  -10.231 1.00 94.05 183 A 1 
+ATOM 1474 O O   . TYR A 1 183 ? -22.974 -7.796  -10.367 1.00 92.10 183 A 1 
+ATOM 1475 C CB  . TYR A 1 183 ? -19.861 -8.135  -10.583 1.00 90.15 183 A 1 
+ATOM 1476 C CG  . TYR A 1 183 ? -18.573 -8.700  -10.010 1.00 83.90 183 A 1 
+ATOM 1477 C CD1 . TYR A 1 183 ? -17.434 -7.881  -9.888  1.00 73.15 183 A 1 
+ATOM 1478 C CD2 . TYR A 1 183 ? -18.530 -10.036 -9.562  1.00 74.85 183 A 1 
+ATOM 1479 C CE1 . TYR A 1 183 ? -16.252 -8.395  -9.318  1.00 61.53 183 A 1 
+ATOM 1480 C CE2 . TYR A 1 183 ? -17.351 -10.552 -8.988  1.00 64.50 183 A 1 
+ATOM 1481 C CZ  . TYR A 1 183 ? -16.211 -9.731  -8.866  1.00 61.38 183 A 1 
+ATOM 1482 O OH  . TYR A 1 183 ? -15.075 -10.232 -8.307  1.00 57.37 183 A 1 
+ATOM 1483 N N   . ASP A 1 184 ? -22.097 -5.751  -10.714 1.00 92.46 184 A 1 
+ATOM 1484 C CA  . ASP A 1 184 ? -23.190 -5.284  -11.553 1.00 92.27 184 A 1 
+ATOM 1485 C C   . ASP A 1 184 ? -23.125 -5.959  -12.928 1.00 92.90 184 A 1 
+ATOM 1486 O O   . ASP A 1 184 ? -22.075 -6.011  -13.579 1.00 91.49 184 A 1 
+ATOM 1487 C CB  . ASP A 1 184 ? -23.143 -3.757  -11.686 1.00 90.84 184 A 1 
+ATOM 1488 C CG  . ASP A 1 184 ? -23.448 -3.009  -10.381 1.00 88.82 184 A 1 
+ATOM 1489 O OD1 . ASP A 1 184 ? -23.987 -3.639  -9.438  1.00 84.02 184 A 1 
+ATOM 1490 O OD2 . ASP A 1 184 ? -23.161 -1.793  -10.356 1.00 84.45 184 A 1 
+ATOM 1491 N N   . VAL A 1 185 ? -24.262 -6.474  -13.387 1.00 91.72 185 A 1 
+ATOM 1492 C CA  . VAL A 1 185 ? -24.408 -7.117  -14.692 1.00 91.60 185 A 1 
+ATOM 1493 C C   . VAL A 1 185 ? -25.156 -6.179  -15.624 1.00 92.19 185 A 1 
+ATOM 1494 O O   . VAL A 1 185 ? -26.278 -5.754  -15.344 1.00 90.28 185 A 1 
+ATOM 1495 C CB  . VAL A 1 185 ? -25.098 -8.489  -14.593 1.00 89.61 185 A 1 
+ATOM 1496 C CG1 . VAL A 1 185 ? -25.139 -9.186  -15.962 1.00 82.90 185 A 1 
+ATOM 1497 C CG2 . VAL A 1 185 ? -24.348 -9.422  -13.630 1.00 83.30 185 A 1 
+ATOM 1498 N N   . TYR A 1 186 ? -24.533 -5.910  -16.766 1.00 90.16 186 A 1 
+ATOM 1499 C CA  . TYR A 1 186 ? -25.107 -5.123  -17.849 1.00 90.07 186 A 1 
+ATOM 1500 C C   . TYR A 1 186 ? -25.330 -6.008  -19.078 1.00 90.46 186 A 1 
+ATOM 1501 O O   . TYR A 1 186 ? -24.622 -6.997  -19.294 1.00 87.99 186 A 1 
+ATOM 1502 C CB  . TYR A 1 186 ? -24.213 -3.910  -18.133 1.00 89.30 186 A 1 
+ATOM 1503 C CG  . TYR A 1 186 ? -24.033 -2.985  -16.932 1.00 89.95 186 A 1 
+ATOM 1504 C CD1 . TYR A 1 186 ? -24.914 -1.904  -16.727 1.00 85.73 186 A 1 
+ATOM 1505 C CD2 . TYR A 1 186 ? -23.006 -3.229  -15.995 1.00 87.29 186 A 1 
+ATOM 1506 C CE1 . TYR A 1 186 ? -24.777 -1.074  -15.590 1.00 85.97 186 A 1 
+ATOM 1507 C CE2 . TYR A 1 186 ? -22.873 -2.410  -14.852 1.00 86.87 186 A 1 
+ATOM 1508 C CZ  . TYR A 1 186 ? -23.761 -1.333  -14.649 1.00 87.70 186 A 1 
+ATOM 1509 O OH  . TYR A 1 186 ? -23.649 -0.555  -13.540 1.00 85.00 186 A 1 
+ATOM 1510 N N   . ASP A 1 187 ? -26.346 -5.698  -19.877 1.00 88.82 187 A 1 
+ATOM 1511 C CA  . ASP A 1 187 ? -26.512 -6.324  -21.185 1.00 88.17 187 A 1 
+ATOM 1512 C C   . ASP A 1 187 ? -25.604 -5.697  -22.254 1.00 89.49 187 A 1 
+ATOM 1513 O O   . ASP A 1 187 ? -24.834 -4.776  -21.988 1.00 87.14 187 A 1 
+ATOM 1514 C CB  . ASP A 1 187 ? -27.988 -6.382  -21.594 1.00 84.36 187 A 1 
+ATOM 1515 C CG  . ASP A 1 187 ? -28.668 -5.032  -21.826 1.00 77.74 187 A 1 
+ATOM 1516 O OD1 . ASP A 1 187 ? -27.955 -4.035  -22.049 1.00 71.71 187 A 1 
+ATOM 1517 O OD2 . ASP A 1 187 ? -29.922 -5.053  -21.747 1.00 74.06 187 A 1 
+ATOM 1518 N N   . ALA A 1 188 ? -25.679 -6.229  -23.477 1.00 89.25 188 A 1 
+ATOM 1519 C CA  . ALA A 1 188 ? -24.884 -5.740  -24.601 1.00 90.32 188 A 1 
+ATOM 1520 C C   . ALA A 1 188 ? -25.204 -4.284  -24.993 1.00 91.54 188 A 1 
+ATOM 1521 O O   . ALA A 1 188 ? -24.370 -3.626  -25.611 1.00 89.00 188 A 1 
+ATOM 1522 C CB  . ALA A 1 188 ? -25.103 -6.693  -25.784 1.00 89.56 188 A 1 
+ATOM 1523 N N   . ASP A 1 189 ? -26.376 -3.791  -24.607 1.00 90.23 189 A 1 
+ATOM 1524 C CA  . ASP A 1 189 ? -26.833 -2.422  -24.850 1.00 90.90 189 A 1 
+ATOM 1525 C C   . ASP A 1 189 ? -26.491 -1.478  -23.675 1.00 91.42 189 A 1 
+ATOM 1526 O O   . ASP A 1 189 ? -26.837 -0.296  -23.691 1.00 88.41 189 A 1 
+ATOM 1527 C CB  . ASP A 1 189 ? -28.340 -2.448  -25.167 1.00 90.38 189 A 1 
+ATOM 1528 C CG  . ASP A 1 189 ? -28.699 -3.274  -26.411 1.00 85.82 189 A 1 
+ATOM 1529 O OD1 . ASP A 1 189 ? -28.013 -3.119  -27.446 1.00 79.16 189 A 1 
+ATOM 1530 O OD2 . ASP A 1 189 ? -29.680 -4.052  -26.335 1.00 81.25 189 A 1 
+ATOM 1531 N N   . GLY A 1 190 ? -25.791 -1.985  -22.653 1.00 89.62 190 A 1 
+ATOM 1532 C CA  . GLY A 1 190 ? -25.388 -1.226  -21.466 1.00 89.46 190 A 1 
+ATOM 1533 C C   . GLY A 1 190 ? -26.500 -1.037  -20.428 1.00 90.44 190 A 1 
+ATOM 1534 O O   . GLY A 1 190 ? -26.351 -0.222  -19.517 1.00 87.96 190 A 1 
+ATOM 1535 N N   . LYS A 1 191 ? -27.602 -1.774  -20.533 1.00 90.10 191 A 1 
+ATOM 1536 C CA  . LYS A 1 191 ? -28.699 -1.706  -19.570 1.00 89.04 191 A 1 
+ATOM 1537 C C   . LYS A 1 191 ? -28.414 -2.612  -18.376 1.00 89.13 191 A 1 
+ATOM 1538 O O   . LYS A 1 191 ? -28.078 -3.782  -18.538 1.00 87.56 191 A 1 
+ATOM 1539 C CB  . LYS A 1 191 ? -30.017 -2.053  -20.271 1.00 87.89 191 A 1 
+ATOM 1540 C CG  . LYS A 1 191 ? -31.228 -1.833  -19.368 1.00 79.59 191 A 1 
+ATOM 1541 C CD  . LYS A 1 191 ? -32.499 -2.286  -20.085 1.00 74.39 191 A 1 
+ATOM 1542 C CE  . LYS A 1 191 ? -33.685 -2.129  -19.141 1.00 67.18 191 A 1 
+ATOM 1543 N NZ  . LYS A 1 191 ? -34.925 -2.653  -19.751 1.00 56.96 191 A 1 
+ATOM 1544 N N   . PHE A 1 192 ? -28.595 -2.080  -17.174 1.00 88.68 192 A 1 
+ATOM 1545 C CA  . PHE A 1 192 ? -28.460 -2.843  -15.939 1.00 88.00 192 A 1 
+ATOM 1546 C C   . PHE A 1 192 ? -29.467 -4.003  -15.895 1.00 88.43 192 A 1 
+ATOM 1547 O O   . PHE A 1 192 ? -30.674 -3.790  -16.027 1.00 86.75 192 A 1 
+ATOM 1548 C CB  . PHE A 1 192 ? -28.641 -1.897  -14.745 1.00 87.00 192 A 1 
+ATOM 1549 C CG  . PHE A 1 192 ? -28.480 -2.568  -13.395 1.00 87.20 192 A 1 
+ATOM 1550 C CD1 . PHE A 1 192 ? -29.609 -2.821  -12.587 1.00 83.22 192 A 1 
+ATOM 1551 C CD2 . PHE A 1 192 ? -27.201 -2.928  -12.935 1.00 84.53 192 A 1 
+ATOM 1552 C CE1 . PHE A 1 192 ? -29.452 -3.411  -11.321 1.00 83.53 192 A 1 
+ATOM 1553 C CE2 . PHE A 1 192 ? -27.046 -3.521  -11.669 1.00 84.02 192 A 1 
+ATOM 1554 C CZ  . PHE A 1 192 ? -28.170 -3.755  -10.856 1.00 86.04 192 A 1 
+ATOM 1555 N N   . LYS A 1 193 ? -28.952 -5.218  -15.725 1.00 89.05 193 A 1 
+ATOM 1556 C CA  . LYS A 1 193 ? -29.745 -6.451  -15.596 1.00 87.37 193 A 1 
+ATOM 1557 C C   . LYS A 1 193 ? -29.929 -6.909  -14.155 1.00 88.22 193 A 1 
+ATOM 1558 O O   . LYS A 1 193 ? -30.848 -7.673  -13.891 1.00 84.32 193 A 1 
+ATOM 1559 C CB  . LYS A 1 193 ? -29.105 -7.585  -16.407 1.00 84.72 193 A 1 
+ATOM 1560 C CG  . LYS A 1 193 ? -29.454 -7.498  -17.896 1.00 76.54 193 A 1 
+ATOM 1561 C CD  . LYS A 1 193 ? -29.031 -8.788  -18.604 1.00 73.53 193 A 1 
+ATOM 1562 C CE  . LYS A 1 193 ? -29.586 -8.795  -20.025 1.00 66.16 193 A 1 
+ATOM 1563 N NZ  . LYS A 1 193 ? -29.147 -9.990  -20.776 1.00 58.68 193 A 1 
+ATOM 1564 N N   . GLY A 1 194 ? -29.037 -6.494  -13.266 1.00 90.25 194 A 1 
+ATOM 1565 C CA  . GLY A 1 194 ? -29.023 -6.938  -11.883 1.00 90.91 194 A 1 
+ATOM 1566 C C   . GLY A 1 194 ? -27.609 -7.132  -11.356 1.00 92.46 194 A 1 
+ATOM 1567 O O   . GLY A 1 194 ? -26.622 -6.745  -11.992 1.00 90.97 194 A 1 
+ATOM 1568 N N   . ILE A 1 195 ? -27.529 -7.741  -10.196 1.00 93.22 195 A 1 
+ATOM 1569 C CA  . ILE A 1 195 ? -26.286 -8.028  -9.489  1.00 93.51 195 A 1 
+ATOM 1570 C C   . ILE A 1 195 ? -26.025 -9.531  -9.576  1.00 94.12 195 A 1 
+ATOM 1571 O O   . ILE A 1 195 ? -26.881 -10.337 -9.204  1.00 92.68 195 A 1 
+ATOM 1572 C CB  . ILE A 1 195 ? -26.378 -7.521  -8.034  1.00 91.71 195 A 1 
+ATOM 1573 C CG1 . ILE A 1 195 ? -26.661 -5.999  -7.999  1.00 82.92 195 A 1 
+ATOM 1574 C CG2 . ILE A 1 195 ? -25.075 -7.846  -7.286  1.00 82.28 195 A 1 
+ATOM 1575 C CD1 . ILE A 1 195 ? -26.937 -5.447  -6.594  1.00 76.99 195 A 1 
+ATOM 1576 N N   . ARG A 1 196 ? -24.835 -9.908  -10.035 1.00 94.88 196 A 1 
+ATOM 1577 C CA  . ARG A 1 196 ? -24.324 -11.273 -9.923  1.00 94.74 196 A 1 
+ATOM 1578 C C   . ARG A 1 196 ? -23.502 -11.387 -8.649  1.00 95.10 196 A 1 
+ATOM 1579 O O   . ARG A 1 196 ? -22.554 -10.628 -8.457  1.00 94.09 196 A 1 
+ATOM 1580 C CB  . ARG A 1 196 ? -23.525 -11.653 -11.169 1.00 93.44 196 A 1 
+ATOM 1581 C CG  . ARG A 1 196 ? -22.983 -13.090 -11.065 1.00 89.96 196 A 1 
+ATOM 1582 C CD  . ARG A 1 196 ? -22.327 -13.538 -12.372 1.00 87.30 196 A 1 
+ATOM 1583 N NE  . ARG A 1 196 ? -23.326 -13.839 -13.405 1.00 81.52 196 A 1 
+ATOM 1584 C CZ  . ARG A 1 196 ? -23.088 -14.063 -14.682 1.00 76.93 196 A 1 
+ATOM 1585 N NH1 . ARG A 1 196 ? -21.892 -13.981 -15.190 1.00 69.02 196 A 1 
+ATOM 1586 N NH2 . ARG A 1 196 ? -24.066 -14.387 -15.478 1.00 70.04 196 A 1 
+ATOM 1587 N N   . LEU A 1 197 ? -23.842 -12.339 -7.815  1.00 95.76 197 A 1 
+ATOM 1588 C CA  . LEU A 1 197 ? -23.245 -12.558 -6.507  1.00 95.78 197 A 1 
+ATOM 1589 C C   . LEU A 1 197 ? -22.644 -13.963 -6.432  1.00 95.75 197 A 1 
+ATOM 1590 O O   . LEU A 1 197 ? -23.315 -14.952 -6.731  1.00 94.80 197 A 1 
+ATOM 1591 C CB  . LEU A 1 197 ? -24.316 -12.253 -5.444  1.00 95.06 197 A 1 
+ATOM 1592 C CG  . LEU A 1 197 ? -23.844 -12.381 -3.985  1.00 90.36 197 A 1 
+ATOM 1593 C CD1 . LEU A 1 197 ? -24.702 -11.481 -3.089  1.00 82.55 197 A 1 
+ATOM 1594 C CD2 . LEU A 1 197 ? -23.985 -13.817 -3.459  1.00 82.73 197 A 1 
+ATOM 1595 N N   . TYR A 1 198 ? -21.399 -14.041 -6.013  1.00 95.23 198 A 1 
+ATOM 1596 C CA  . TYR A 1 198 ? -20.692 -15.277 -5.708  1.00 95.19 198 A 1 
+ATOM 1597 C C   . TYR A 1 198 ? -20.508 -15.387 -4.201  1.00 95.83 198 A 1 
+ATOM 1598 O O   . TYR A 1 198 ? -19.896 -14.515 -3.582  1.00 95.55 198 A 1 
+ATOM 1599 C CB  . TYR A 1 198 ? -19.346 -15.313 -6.431  1.00 94.26 198 A 1 
+ATOM 1600 C CG  . TYR A 1 198 ? -19.461 -15.294 -7.943  1.00 93.12 198 A 1 
+ATOM 1601 C CD1 . TYR A 1 198 ? -19.850 -16.458 -8.629  1.00 90.28 198 A 1 
+ATOM 1602 C CD2 . TYR A 1 198 ? -19.180 -14.115 -8.662  1.00 90.24 198 A 1 
+ATOM 1603 C CE1 . TYR A 1 198 ? -19.960 -16.448 -10.033 1.00 88.84 198 A 1 
+ATOM 1604 C CE2 . TYR A 1 198 ? -19.289 -14.100 -10.067 1.00 89.10 198 A 1 
+ATOM 1605 C CZ  . TYR A 1 198 ? -19.679 -15.270 -10.754 1.00 89.29 198 A 1 
+ATOM 1606 O OH  . TYR A 1 198 ? -19.785 -15.259 -12.108 1.00 86.73 198 A 1 
+ATOM 1607 N N   . ALA A 1 199 ? -21.012 -16.463 -3.624  1.00 95.81 199 A 1 
+ATOM 1608 C CA  . ALA A 1 199 ? -20.830 -16.791 -2.222  1.00 95.88 199 A 1 
+ATOM 1609 C C   . ALA A 1 199 ? -20.047 -18.101 -2.095  1.00 95.48 199 A 1 
+ATOM 1610 O O   . ALA A 1 199 ? -20.398 -19.107 -2.708  1.00 94.51 199 A 1 
+ATOM 1611 C CB  . ALA A 1 199 ? -22.199 -16.836 -1.535  1.00 95.91 199 A 1 
+ATOM 1612 N N   . TYR A 1 200 ? -18.999 -18.082 -1.308  1.00 95.89 200 A 1 
+ATOM 1613 C CA  . TYR A 1 200 ? -18.093 -19.199 -1.102  1.00 95.74 200 A 1 
+ATOM 1614 C C   . TYR A 1 200 ? -18.157 -19.667 0.347   1.00 95.86 200 A 1 
+ATOM 1615 O O   . TYR A 1 200 ? -17.910 -18.885 1.266   1.00 95.08 200 A 1 
+ATOM 1616 C CB  . TYR A 1 200 ? -16.671 -18.794 -1.481  1.00 95.06 200 A 1 
+ATOM 1617 C CG  . TYR A 1 200 ? -16.485 -18.440 -2.943  1.00 94.55 200 A 1 
+ATOM 1618 C CD1 . TYR A 1 200 ? -16.080 -19.427 -3.858  1.00 92.68 200 A 1 
+ATOM 1619 C CD2 . TYR A 1 200 ? -16.693 -17.119 -3.387  1.00 92.90 200 A 1 
+ATOM 1620 C CE1 . TYR A 1 200 ? -15.858 -19.093 -5.206  1.00 91.89 200 A 1 
+ATOM 1621 C CE2 . TYR A 1 200 ? -16.479 -16.782 -4.736  1.00 92.16 200 A 1 
+ATOM 1622 C CZ  . TYR A 1 200 ? -16.047 -17.769 -5.645  1.00 92.02 200 A 1 
+ATOM 1623 O OH  . TYR A 1 200 ? -15.803 -17.442 -6.941  1.00 90.12 200 A 1 
+ATOM 1624 N N   . SER A 1 201 ? -18.455 -20.942 0.536   1.00 95.07 201 A 1 
+ATOM 1625 C CA  . SER A 1 201 ? -18.364 -21.652 1.808   1.00 94.45 201 A 1 
+ATOM 1626 C C   . SER A 1 201 ? -17.341 -22.786 1.707   1.00 93.77 201 A 1 
+ATOM 1627 O O   . SER A 1 201 ? -16.777 -23.047 0.647   1.00 91.76 201 A 1 
+ATOM 1628 C CB  . SER A 1 201 ? -19.748 -22.171 2.221   1.00 93.86 201 A 1 
+ATOM 1629 O OG  . SER A 1 201 ? -20.118 -23.308 1.466   1.00 90.60 201 A 1 
+ATOM 1630 N N   . ASP A 1 202 ? -17.135 -23.516 2.793   1.00 92.58 202 A 1 
+ATOM 1631 C CA  . ASP A 1 202 ? -16.302 -24.724 2.774   1.00 91.36 202 A 1 
+ATOM 1632 C C   . ASP A 1 202 ? -16.874 -25.863 1.903   1.00 91.25 202 A 1 
+ATOM 1633 O O   . ASP A 1 202 ? -16.152 -26.801 1.566   1.00 88.16 202 A 1 
+ATOM 1634 C CB  . ASP A 1 202 ? -16.142 -25.237 4.200   1.00 89.35 202 A 1 
+ATOM 1635 C CG  . ASP A 1 202 ? -15.221 -24.391 5.075   1.00 86.25 202 A 1 
+ATOM 1636 O OD1 . ASP A 1 202 ? -14.196 -23.899 4.580   1.00 80.85 202 A 1 
+ATOM 1637 O OD2 . ASP A 1 202 ? -15.476 -24.385 6.295   1.00 81.53 202 A 1 
+ATOM 1638 N N   . PHE A 1 203 ? -18.170 -25.794 1.545   1.00 91.01 203 A 1 
+ATOM 1639 C CA  . PHE A 1 203 ? -18.851 -26.808 0.736   1.00 90.15 203 A 1 
+ATOM 1640 C C   . PHE A 1 203 ? -18.765 -26.532 -0.760  1.00 89.37 203 A 1 
+ATOM 1641 O O   . PHE A 1 203 ? -18.842 -27.461 -1.566  1.00 84.86 203 A 1 
+ATOM 1642 C CB  . PHE A 1 203 ? -20.311 -26.925 1.193   1.00 89.15 203 A 1 
+ATOM 1643 C CG  . PHE A 1 203 ? -20.443 -27.275 2.659   1.00 89.24 203 A 1 
+ATOM 1644 C CD1 . PHE A 1 203 ? -20.105 -28.569 3.102   1.00 85.47 203 A 1 
+ATOM 1645 C CD2 . PHE A 1 203 ? -20.848 -26.300 3.585   1.00 86.42 203 A 1 
+ATOM 1646 C CE1 . PHE A 1 203 ? -20.165 -28.885 4.467   1.00 84.16 203 A 1 
+ATOM 1647 C CE2 . PHE A 1 203 ? -20.910 -26.617 4.955   1.00 84.88 203 A 1 
+ATOM 1648 C CZ  . PHE A 1 203 ? -20.564 -27.909 5.395   1.00 85.11 203 A 1 
+ATOM 1649 N N   . GLY A 1 204 ? -18.608 -25.270 -1.138  1.00 89.59 204 A 1 
+ATOM 1650 C CA  . GLY A 1 204 ? -18.552 -24.895 -2.539  1.00 89.57 204 A 1 
+ATOM 1651 C C   . GLY A 1 204 ? -18.888 -23.442 -2.822  1.00 91.39 204 A 1 
+ATOM 1652 O O   . GLY A 1 204 ? -18.978 -22.608 -1.919  1.00 90.53 204 A 1 
+ATOM 1653 N N   . ARG A 1 205 ? -19.073 -23.166 -4.114  1.00 91.76 205 A 1 
+ATOM 1654 C CA  . ARG A 1 205 ? -19.463 -21.870 -4.662  1.00 92.04 205 A 1 
+ATOM 1655 C C   . ARG A 1 205 ? -20.954 -21.855 -4.967  1.00 92.53 205 A 1 
+ATOM 1656 O O   . ARG A 1 205 ? -21.445 -22.726 -5.678  1.00 91.86 205 A 1 
+ATOM 1657 C CB  . ARG A 1 205 ? -18.643 -21.589 -5.932  1.00 90.63 205 A 1 
+ATOM 1658 C CG  . ARG A 1 205 ? -18.909 -20.198 -6.521  1.00 88.96 205 A 1 
+ATOM 1659 C CD  . ARG A 1 205 ? -18.138 -19.983 -7.830  1.00 86.61 205 A 1 
+ATOM 1660 N NE  . ARG A 1 205 ? -18.780 -20.640 -8.984  1.00 80.34 205 A 1 
+ATOM 1661 C CZ  . ARG A 1 205 ? -18.248 -20.804 -10.185 1.00 77.94 205 A 1 
+ATOM 1662 N NH1 . ARG A 1 205 ? -17.017 -20.473 -10.453 1.00 70.50 205 A 1 
+ATOM 1663 N NH2 . ARG A 1 205 ? -18.953 -21.295 -11.161 1.00 69.39 205 A 1 
+ATOM 1664 N N   . TYR A 1 206 ? -21.631 -20.826 -4.497  1.00 94.35 206 A 1 
+ATOM 1665 C CA  . TYR A 1 206 ? -23.012 -20.493 -4.830  1.00 94.65 206 A 1 
+ATOM 1666 C C   . TYR A 1 206 ? -23.002 -19.262 -5.735  1.00 94.84 206 A 1 
+ATOM 1667 O O   . TYR A 1 206 ? -22.432 -18.235 -5.366  1.00 94.18 206 A 1 
+ATOM 1668 C CB  . TYR A 1 206 ? -23.813 -20.221 -3.553  1.00 94.62 206 A 1 
+ATOM 1669 C CG  . TYR A 1 206 ? -23.780 -21.335 -2.524  1.00 94.45 206 A 1 
+ATOM 1670 C CD1 . TYR A 1 206 ? -24.845 -22.250 -2.432  1.00 92.29 206 A 1 
+ATOM 1671 C CD2 . TYR A 1 206 ? -22.676 -21.460 -1.656  1.00 92.72 206 A 1 
+ATOM 1672 C CE1 . TYR A 1 206 ? -24.804 -23.296 -1.493  1.00 91.79 206 A 1 
+ATOM 1673 C CE2 . TYR A 1 206 ? -22.624 -22.513 -0.722  1.00 92.15 206 A 1 
+ATOM 1674 C CZ  . TYR A 1 206 ? -23.687 -23.432 -0.645  1.00 92.27 206 A 1 
+ATOM 1675 O OH  . TYR A 1 206 ? -23.624 -24.459 0.241   1.00 90.42 206 A 1 
+ATOM 1676 N N   . GLU A 1 207 ? -23.626 -19.354 -6.898  1.00 93.42 207 A 1 
+ATOM 1677 C CA  . GLU A 1 207 ? -23.814 -18.229 -7.810  1.00 93.51 207 A 1 
+ATOM 1678 C C   . GLU A 1 207 ? -25.282 -17.804 -7.796  1.00 94.11 207 A 1 
+ATOM 1679 O O   . GLU A 1 207 ? -26.165 -18.608 -8.084  1.00 92.91 207 A 1 
+ATOM 1680 C CB  . GLU A 1 207 ? -23.321 -18.596 -9.218  1.00 91.89 207 A 1 
+ATOM 1681 C CG  . GLU A 1 207 ? -23.442 -17.411 -10.193 1.00 86.86 207 A 1 
+ATOM 1682 C CD  . GLU A 1 207 ? -22.791 -17.644 -11.562 1.00 86.32 207 A 1 
+ATOM 1683 O OE1 . GLU A 1 207 ? -23.084 -16.841 -12.480 1.00 77.84 207 A 1 
+ATOM 1684 O OE2 . GLU A 1 207 ? -21.919 -18.525 -11.685 1.00 79.39 207 A 1 
+ATOM 1685 N N   . PHE A 1 208 ? -25.530 -16.534 -7.493  1.00 94.94 208 A 1 
+ATOM 1686 C CA  . PHE A 1 208 ? -26.862 -15.943 -7.484  1.00 95.16 208 A 1 
+ATOM 1687 C C   . PHE A 1 208 ? -26.955 -14.788 -8.479  1.00 95.11 208 A 1 
+ATOM 1688 O O   . PHE A 1 208 ? -25.989 -14.053 -8.698  1.00 94.09 208 A 1 
+ATOM 1689 C CB  . PHE A 1 208 ? -27.230 -15.464 -6.072  1.00 95.17 208 A 1 
+ATOM 1690 C CG  . PHE A 1 208 ? -27.202 -16.529 -4.993  1.00 95.46 208 A 1 
+ATOM 1691 C CD1 . PHE A 1 208 ? -28.350 -17.303 -4.735  1.00 93.87 208 A 1 
+ATOM 1692 C CD2 . PHE A 1 208 ? -26.043 -16.725 -4.223  1.00 94.31 208 A 1 
+ATOM 1693 C CE1 . PHE A 1 208 ? -28.340 -18.260 -3.706  1.00 93.71 208 A 1 
+ATOM 1694 C CE2 . PHE A 1 208 ? -26.032 -17.687 -3.195  1.00 94.04 208 A 1 
+ATOM 1695 C CZ  . PHE A 1 208 ? -27.182 -18.453 -2.935  1.00 94.34 208 A 1 
+ATOM 1696 N N   . ILE A 1 209 ? -28.154 -14.582 -9.031  1.00 93.69 209 A 1 
+ATOM 1697 C CA  . ILE A 1 209 ? -28.516 -13.361 -9.756  1.00 93.23 209 A 1 
+ATOM 1698 C C   . ILE A 1 209 ? -29.723 -12.731 -9.064  1.00 93.43 209 A 1 
+ATOM 1699 O O   . ILE A 1 209 ? -30.739 -13.385 -8.858  1.00 91.58 209 A 1 
+ATOM 1700 C CB  . ILE A 1 209 ? -28.751 -13.628 -11.258 1.00 91.12 209 A 1 
+ATOM 1701 C CG1 . ILE A 1 209 ? -27.421 -14.042 -11.924 1.00 81.41 209 A 1 
+ATOM 1702 C CG2 . ILE A 1 209 ? -29.332 -12.377 -11.950 1.00 80.53 209 A 1 
+ATOM 1703 C CD1 . ILE A 1 209 ? -27.532 -14.409 -13.415 1.00 72.64 209 A 1 
+ATOM 1704 N N   . SER A 1 210 ? -29.608 -11.445 -8.738  1.00 92.37 210 A 1 
+ATOM 1705 C CA  . SER A 1 210 ? -30.674 -10.656 -8.119  1.00 91.56 210 A 1 
+ATOM 1706 C C   . SER A 1 210 ? -30.795 -9.304  -8.811  1.00 91.40 210 A 1 
+ATOM 1707 O O   . SER A 1 210 ? -29.815 -8.773  -9.331  1.00 87.82 210 A 1 
+ATOM 1708 C CB  . SER A 1 210 ? -30.378 -10.475 -6.629  1.00 89.01 210 A 1 
+ATOM 1709 O OG  . SER A 1 210 ? -31.402 -9.736  -5.991  1.00 79.08 210 A 1 
+ATOM 1710 N N   . ASP A 1 211 ? -31.985 -8.722  -8.808  1.00 89.17 211 A 1 
+ATOM 1711 C CA  . ASP A 1 211 ? -32.204 -7.332  -9.229  1.00 86.78 211 A 1 
+ATOM 1712 C C   . ASP A 1 211 ? -31.729 -6.302  -8.184  1.00 86.53 211 A 1 
+ATOM 1713 O O   . ASP A 1 211 ? -31.686 -5.104  -8.460  1.00 78.77 211 A 1 
+ATOM 1714 C CB  . ASP A 1 211 ? -33.682 -7.153  -9.605  1.00 82.71 211 A 1 
+ATOM 1715 C CG  . ASP A 1 211 ? -34.666 -7.317  -8.437  1.00 75.92 211 A 1 
+ATOM 1716 O OD1 . ASP A 1 211 ? -34.206 -7.543  -7.292  1.00 67.72 211 A 1 
+ATOM 1717 O OD2 . ASP A 1 211 ? -35.870 -7.173  -8.720  1.00 70.66 211 A 1 
+ATOM 1718 N N   . GLY A 1 212 ? -31.340 -6.778  -6.994  1.00 80.13 212 A 1 
+ATOM 1719 C CA  . GLY A 1 212 ? -30.870 -5.960  -5.880  1.00 76.82 212 A 1 
+ATOM 1720 C C   . GLY A 1 212 ? -31.981 -5.271  -5.083  1.00 77.59 212 A 1 
+ATOM 1721 O O   . GLY A 1 212 ? -31.674 -4.531  -4.146  1.00 71.71 212 A 1 
+ATOM 1722 N N   . LEU A 1 213 ? -33.243 -5.498  -5.432  1.00 73.36 213 A 1 
+ATOM 1723 C CA  . LEU A 1 213 ? -34.404 -4.888  -4.777  1.00 70.62 213 A 1 
+ATOM 1724 C C   . LEU A 1 213 ? -35.042 -5.814  -3.739  1.00 72.21 213 A 1 
+ATOM 1725 O O   . LEU A 1 213 ? -35.517 -5.345  -2.703  1.00 66.67 213 A 1 
+ATOM 1726 C CB  . LEU A 1 213 ? -35.438 -4.498  -5.846  1.00 65.09 213 A 1 
+ATOM 1727 C CG  . LEU A 1 213 ? -34.959 -3.454  -6.870  1.00 60.01 213 A 1 
+ATOM 1728 C CD1 . LEU A 1 213 ? -36.023 -3.271  -7.953  1.00 54.68 213 A 1 
+ATOM 1729 C CD2 . LEU A 1 213 ? -34.705 -2.091  -6.220  1.00 57.88 213 A 1 
+ATOM 1730 N N   . GLU A 1 214 ? -35.043 -7.114  -4.021  1.00 78.61 214 A 1 
+ATOM 1731 C CA  . GLU A 1 214 ? -35.632 -8.122  -3.146  1.00 80.90 214 A 1 
+ATOM 1732 C C   . GLU A 1 214 ? -34.557 -8.942  -2.410  1.00 84.42 214 A 1 
+ATOM 1733 O O   . GLU A 1 214 ? -33.447 -9.128  -2.921  1.00 80.95 214 A 1 
+ATOM 1734 C CB  . GLU A 1 214 ? -36.610 -9.018  -3.922  1.00 75.79 214 A 1 
+ATOM 1735 C CG  . GLU A 1 214 ? -37.816 -8.218  -4.456  1.00 68.36 214 A 1 
+ATOM 1736 C CD  . GLU A 1 214 ? -38.978 -9.090  -4.956  1.00 60.96 214 A 1 
+ATOM 1737 O OE1 . GLU A 1 214 ? -40.070 -8.508  -5.159  1.00 53.63 214 A 1 
+ATOM 1738 O OE2 . GLU A 1 214 ? -38.810 -10.321 -5.073  1.00 55.88 214 A 1 
+ATOM 1739 N N   . PRO A 1 215 ? -34.866 -9.443  -1.200  1.00 87.08 215 A 1 
+ATOM 1740 C CA  . PRO A 1 215 ? -34.009 -10.397 -0.510  1.00 88.59 215 A 1 
+ATOM 1741 C C   . PRO A 1 215 ? -33.769 -11.656 -1.351  1.00 89.89 215 A 1 
+ATOM 1742 O O   . PRO A 1 215 ? -34.676 -12.141 -2.024  1.00 86.78 215 A 1 
+ATOM 1743 C CB  . PRO A 1 215 ? -34.725 -10.734 0.803   1.00 85.71 215 A 1 
+ATOM 1744 C CG  . PRO A 1 215 ? -35.635 -9.539  1.039   1.00 82.83 215 A 1 
+ATOM 1745 C CD  . PRO A 1 215 ? -36.027 -9.128  -0.377  1.00 86.82 215 A 1 
+ATOM 1746 N N   . LEU A 1 216 ? -32.559 -12.213 -1.257  1.00 90.57 216 A 1 
+ATOM 1747 C CA  . LEU A 1 216 ? -32.206 -13.456 -1.936  1.00 91.40 216 A 1 
+ATOM 1748 C C   . LEU A 1 216 ? -33.054 -14.626 -1.423  1.00 92.72 216 A 1 
+ATOM 1749 O O   . LEU A 1 216 ? -33.243 -14.797 -0.216  1.00 90.72 216 A 1 
+ATOM 1750 C CB  . LEU A 1 216 ? -30.708 -13.763 -1.750  1.00 89.44 216 A 1 
+ATOM 1751 C CG  . LEU A 1 216 ? -29.762 -12.825 -2.517  1.00 87.21 216 A 1 
+ATOM 1752 C CD1 . LEU A 1 216 ? -28.325 -13.073 -2.060  1.00 81.18 216 A 1 
+ATOM 1753 C CD2 . LEU A 1 216 ? -29.816 -13.062 -4.028  1.00 83.12 216 A 1 
+ATOM 1754 N N   . SER A 1 217 ? -33.491 -15.447 -2.360  1.00 91.37 217 A 1 
+ATOM 1755 C CA  . SER A 1 217 ? -34.193 -16.716 -2.159  1.00 90.89 217 A 1 
+ATOM 1756 C C   . SER A 1 217 ? -33.528 -17.825 -2.980  1.00 91.22 217 A 1 
+ATOM 1757 O O   . SER A 1 217 ? -32.643 -17.560 -3.795  1.00 87.98 217 A 1 
+ATOM 1758 C CB  . SER A 1 217 ? -35.669 -16.547 -2.543  1.00 88.81 217 A 1 
+ATOM 1759 O OG  . SER A 1 217 ? -35.800 -16.371 -3.939  1.00 83.29 217 A 1 
+ATOM 1760 N N   . GLU A 1 218 ? -33.961 -19.072 -2.789  1.00 91.09 218 A 1 
+ATOM 1761 C CA  . GLU A 1 218 ? -33.482 -20.198 -3.611  1.00 90.55 218 A 1 
+ATOM 1762 C C   . GLU A 1 218 ? -33.733 -19.990 -5.115  1.00 90.89 218 A 1 
+ATOM 1763 O O   . GLU A 1 218 ? -32.933 -20.444 -5.926  1.00 86.35 218 A 1 
+ATOM 1764 C CB  . GLU A 1 218 ? -34.151 -21.511 -3.177  1.00 87.78 218 A 1 
+ATOM 1765 C CG  . GLU A 1 218 ? -33.637 -22.004 -1.818  1.00 77.12 218 A 1 
+ATOM 1766 C CD  . GLU A 1 218 ? -34.141 -23.404 -1.431  1.00 75.84 218 A 1 
+ATOM 1767 O OE1 . GLU A 1 218 ? -33.536 -24.007 -0.509  1.00 68.30 218 A 1 
+ATOM 1768 O OE2 . GLU A 1 218 ? -35.173 -23.861 -1.965  1.00 70.63 218 A 1 
+ATOM 1769 N N   . ASP A 1 219 ? -34.782 -19.256 -5.493  1.00 90.99 219 A 1 
+ATOM 1770 C CA  . ASP A 1 219 ? -35.110 -18.965 -6.895  1.00 90.73 219 A 1 
+ATOM 1771 C C   . ASP A 1 219 ? -34.046 -18.086 -7.581  1.00 91.51 219 A 1 
+ATOM 1772 O O   . ASP A 1 219 ? -33.963 -18.046 -8.809  1.00 88.30 219 A 1 
+ATOM 1773 C CB  . ASP A 1 219 ? -36.479 -18.264 -6.968  1.00 89.63 219 A 1 
+ATOM 1774 C CG  . ASP A 1 219 ? -37.655 -19.118 -6.478  1.00 84.76 219 A 1 
+ATOM 1775 O OD1 . ASP A 1 219 ? -37.615 -20.356 -6.659  1.00 77.66 219 A 1 
+ATOM 1776 O OD2 . ASP A 1 219 ? -38.615 -18.513 -5.952  1.00 80.23 219 A 1 
+ATOM 1777 N N   . ASN A 1 220 ? -33.229 -17.380 -6.800  1.00 92.07 220 A 1 
+ATOM 1778 C CA  . ASN A 1 220 ? -32.121 -16.575 -7.310  1.00 91.88 220 A 1 
+ATOM 1779 C C   . ASN A 1 220 ? -30.852 -17.396 -7.578  1.00 92.96 220 A 1 
+ATOM 1780 O O   . ASN A 1 220 ? -29.909 -16.860 -8.169  1.00 91.08 220 A 1 
+ATOM 1781 C CB  . ASN A 1 220 ? -31.832 -15.429 -6.327  1.00 90.75 220 A 1 
+ATOM 1782 C CG  . ASN A 1 220 ? -32.996 -14.479 -6.151  1.00 89.59 220 A 1 
+ATOM 1783 O OD1 . ASN A 1 220 ? -33.631 -14.433 -5.113  1.00 80.32 220 A 1 
+ATOM 1784 N ND2 . ASN A 1 220 ? -33.289 -13.676 -7.138  1.00 82.92 220 A 1 
+ATOM 1785 N N   . LEU A 1 221 ? -30.800 -18.653 -7.134  1.00 93.02 221 A 1 
+ATOM 1786 C CA  . LEU A 1 221 ? -29.648 -19.522 -7.344  1.00 93.30 221 A 1 
+ATOM 1787 C C   . LEU A 1 221 ? -29.554 -19.913 -8.823  1.00 93.44 221 A 1 
+ATOM 1788 O O   . LEU A 1 221 ? -30.454 -20.539 -9.375  1.00 91.76 221 A 1 
+ATOM 1789 C CB  . LEU A 1 221 ? -29.744 -20.763 -6.437  1.00 92.63 221 A 1 
+ATOM 1790 C CG  . LEU A 1 221 ? -28.508 -21.680 -6.513  1.00 91.26 221 A 1 
+ATOM 1791 C CD1 . LEU A 1 221 ? -27.302 -21.075 -5.785  1.00 85.87 221 A 1 
+ATOM 1792 C CD2 . LEU A 1 221 ? -28.814 -23.029 -5.862  1.00 87.95 221 A 1 
+ATOM 1793 N N   . VAL A 1 222 ? -28.430 -19.580 -9.439  1.00 92.63 222 A 1 
+ATOM 1794 C CA  . VAL A 1 222 ? -28.102 -19.967 -10.818 1.00 91.88 222 A 1 
+ATOM 1795 C C   . VAL A 1 222 ? -27.374 -21.303 -10.828 1.00 92.00 222 A 1 
+ATOM 1796 O O   . VAL A 1 222 ? -27.726 -22.199 -11.590 1.00 88.92 222 A 1 
+ATOM 1797 C CB  . VAL A 1 222 ? -27.242 -18.885 -11.497 1.00 90.07 222 A 1 
+ATOM 1798 C CG1 . VAL A 1 222 ? -26.891 -19.244 -12.946 1.00 84.18 222 A 1 
+ATOM 1799 C CG2 . VAL A 1 222 ? -27.976 -17.543 -11.511 1.00 84.98 222 A 1 
+ATOM 1800 N N   . GLU A 1 223 ? -26.363 -21.434 -9.983  1.00 91.30 223 A 1 
+ATOM 1801 C CA  . GLU A 1 223 ? -25.496 -22.607 -9.948  1.00 90.96 223 A 1 
+ATOM 1802 C C   . GLU A 1 223 ? -24.903 -22.809 -8.550  1.00 91.92 223 A 1 
+ATOM 1803 O O   . GLU A 1 223 ? -24.541 -21.853 -7.857  1.00 90.70 223 A 1 
+ATOM 1804 C CB  . GLU A 1 223 ? -24.392 -22.455 -11.014 1.00 87.69 223 A 1 
+ATOM 1805 C CG  . GLU A 1 223 ? -23.595 -23.747 -11.226 1.00 80.94 223 A 1 
+ATOM 1806 C CD  . GLU A 1 223 ? -22.502 -23.616 -12.301 1.00 80.89 223 A 1 
+ATOM 1807 O OE1 . GLU A 1 223 ? -22.305 -24.609 -13.039 1.00 71.74 223 A 1 
+ATOM 1808 O OE2 . GLU A 1 223 ? -21.810 -22.575 -12.337 1.00 73.18 223 A 1 
+ATOM 1809 N N   . PHE A 1 224 ? -24.763 -24.080 -8.161  1.00 90.97 224 A 1 
+ATOM 1810 C CA  . PHE A 1 224 ? -23.961 -24.495 -7.018  1.00 90.91 224 A 1 
+ATOM 1811 C C   . PHE A 1 224 ? -22.904 -25.499 -7.479  1.00 90.89 224 A 1 
+ATOM 1812 O O   . PHE A 1 224 ? -23.236 -26.537 -8.054  1.00 89.52 224 A 1 
+ATOM 1813 C CB  . PHE A 1 224 ? -24.850 -25.089 -5.919  1.00 90.41 224 A 1 
+ATOM 1814 C CG  . PHE A 1 224 ? -24.054 -25.732 -4.792  1.00 89.94 224 A 1 
+ATOM 1815 C CD1 . PHE A 1 224 ? -24.088 -27.128 -4.598  1.00 85.72 224 A 1 
+ATOM 1816 C CD2 . PHE A 1 224 ? -23.237 -24.942 -3.960  1.00 87.00 224 A 1 
+ATOM 1817 C CE1 . PHE A 1 224 ? -23.334 -27.717 -3.565  1.00 85.72 224 A 1 
+ATOM 1818 C CE2 . PHE A 1 224 ? -22.478 -25.532 -2.931  1.00 85.85 224 A 1 
+ATOM 1819 C CZ  . PHE A 1 224 ? -22.534 -26.920 -2.726  1.00 86.91 224 A 1 
+ATOM 1820 N N   . ILE A 1 225 ? -21.639 -25.200 -7.210  1.00 89.13 225 A 1 
+ATOM 1821 C CA  . ILE A 1 225 ? -20.508 -26.059 -7.568  1.00 88.19 225 A 1 
+ATOM 1822 C C   . ILE A 1 225 ? -19.827 -26.535 -6.282  1.00 89.04 225 A 1 
+ATOM 1823 O O   . ILE A 1 225 ? -19.137 -25.739 -5.635  1.00 87.94 225 A 1 
+ATOM 1824 C CB  . ILE A 1 225 ? -19.530 -25.337 -8.521  1.00 85.60 225 A 1 
+ATOM 1825 C CG1 . ILE A 1 225 ? -20.270 -24.897 -9.804  1.00 80.01 225 A 1 
+ATOM 1826 C CG2 . ILE A 1 225 ? -18.343 -26.262 -8.858  1.00 79.46 225 A 1 
+ATOM 1827 C CD1 . ILE A 1 225 ? -19.385 -24.156 -10.815 1.00 72.35 225 A 1 
+ATOM 1828 N N   . PRO A 1 226 ? -19.986 -27.818 -5.896  1.00 86.65 226 A 1 
+ATOM 1829 C CA  . PRO A 1 226 ? -19.258 -28.372 -4.768  1.00 84.90 226 A 1 
+ATOM 1830 C C   . PRO A 1 226 ? -17.774 -28.533 -5.126  1.00 84.11 226 A 1 
+ATOM 1831 O O   . PRO A 1 226 ? -17.424 -29.186 -6.112  1.00 81.11 226 A 1 
+ATOM 1832 C CB  . PRO A 1 226 ? -19.934 -29.710 -4.459  1.00 83.77 226 A 1 
+ATOM 1833 C CG  . PRO A 1 226 ? -20.502 -30.149 -5.810  1.00 81.33 226 A 1 
+ATOM 1834 C CD  . PRO A 1 226 ? -20.848 -28.828 -6.497  1.00 85.12 226 A 1 
+ATOM 1835 N N   . TYR A 1 227 ? -16.904 -27.969 -4.317  1.00 79.27 227 A 1 
+ATOM 1836 C CA  . TYR A 1 227 ? -15.459 -28.130 -4.453  1.00 78.40 227 A 1 
+ATOM 1837 C C   . TYR A 1 227 ? -14.755 -27.896 -3.115  1.00 80.36 227 A 1 
+ATOM 1838 O O   . TYR A 1 227 ? -15.263 -27.211 -2.233  1.00 76.44 227 A 1 
+ATOM 1839 C CB  . TYR A 1 227 ? -14.900 -27.219 -5.558  1.00 72.74 227 A 1 
+ATOM 1840 C CG  . TYR A 1 227 ? -14.783 -25.744 -5.220  1.00 68.60 227 A 1 
+ATOM 1841 C CD1 . TYR A 1 227 ? -15.931 -24.988 -4.934  1.00 63.94 227 A 1 
+ATOM 1842 C CD2 . TYR A 1 227 ? -13.521 -25.127 -5.204  1.00 62.46 227 A 1 
+ATOM 1843 C CE1 . TYR A 1 227 ? -15.820 -23.624 -4.613  1.00 57.48 227 A 1 
+ATOM 1844 C CE2 . TYR A 1 227 ? -13.405 -23.759 -4.888  1.00 58.79 227 A 1 
+ATOM 1845 C CZ  . TYR A 1 227 ? -14.557 -23.009 -4.583  1.00 58.53 227 A 1 
+ATOM 1846 O OH  . TYR A 1 227 ? -14.447 -21.701 -4.252  1.00 55.70 227 A 1 
+ATOM 1847 N N   . ASN A 1 228 ? -13.570 -28.473 -2.973  1.00 82.34 228 A 1 
+ATOM 1848 C CA  . ASN A 1 228 ? -12.753 -28.299 -1.780  1.00 82.43 228 A 1 
+ATOM 1849 C C   . ASN A 1 228 ? -11.398 -27.711 -2.178  1.00 83.83 228 A 1 
+ATOM 1850 O O   . ASN A 1 228 ? -10.617 -28.368 -2.870  1.00 80.77 228 A 1 
+ATOM 1851 C CB  . ASN A 1 228 ? -12.643 -29.646 -1.040  1.00 77.88 228 A 1 
+ATOM 1852 C CG  . ASN A 1 228 ? -11.895 -29.535 0.280   1.00 71.55 228 A 1 
+ATOM 1853 O OD1 . ASN A 1 228 ? -11.289 -28.540 0.617   1.00 64.72 228 A 1 
+ATOM 1854 N ND2 . ASN A 1 228 ? -11.903 -30.575 1.079   1.00 64.32 228 A 1 
+ATOM 1855 N N   . VAL A 1 229 ? -11.140 -26.504 -1.718  1.00 86.79 229 A 1 
+ATOM 1856 C CA  . VAL A 1 229 ? -9.865  -25.790 -1.894  1.00 86.73 229 A 1 
+ATOM 1857 C C   . VAL A 1 229 ? -9.100  -25.629 -0.573  1.00 88.23 229 A 1 
+ATOM 1858 O O   . VAL A 1 229 ? -8.204  -24.809 -0.470  1.00 85.32 229 A 1 
+ATOM 1859 C CB  . VAL A 1 229 ? -10.053 -24.447 -2.629  1.00 83.89 229 A 1 
+ATOM 1860 C CG1 . VAL A 1 229 ? -10.417 -24.680 -4.100  1.00 77.66 229 A 1 
+ATOM 1861 C CG2 . VAL A 1 229 ? -11.127 -23.569 -1.975  1.00 78.45 229 A 1 
+ATOM 1862 N N   . GLY A 1 230 ? -9.450  -26.414 0.447   1.00 88.92 230 A 1 
+ATOM 1863 C CA  . GLY A 1 230 ? -8.786  -26.350 1.753   1.00 88.86 230 A 1 
+ATOM 1864 C C   . GLY A 1 230 ? -9.267  -25.210 2.660   1.00 90.10 230 A 1 
+ATOM 1865 O O   . GLY A 1 230 ? -8.617  -24.924 3.663   1.00 86.23 230 A 1 
+ATOM 1866 N N   . GLY A 1 231 ? -10.394 -24.582 2.330   1.00 90.74 231 A 1 
+ATOM 1867 C CA  . GLY A 1 231 ? -11.027 -23.491 3.066   1.00 91.18 231 A 1 
+ATOM 1868 C C   . GLY A 1 231 ? -11.876 -22.602 2.160   1.00 92.79 231 A 1 
+ATOM 1869 O O   . GLY A 1 231 ? -12.120 -22.935 1.001   1.00 91.36 231 A 1 
+ATOM 1870 N N   . ILE A 1 232 ? -12.313 -21.455 2.681   1.00 94.89 232 A 1 
+ATOM 1871 C CA  . ILE A 1 232 ? -13.046 -20.445 1.909   1.00 95.92 232 A 1 
+ATOM 1872 C C   . ILE A 1 232 ? -12.043 -19.664 1.043   1.00 96.26 232 A 1 
+ATOM 1873 O O   . ILE A 1 232 ? -11.099 -19.101 1.594   1.00 95.31 232 A 1 
+ATOM 1874 C CB  . ILE A 1 232 ? -13.839 -19.513 2.845   1.00 95.67 232 A 1 
+ATOM 1875 C CG1 . ILE A 1 232 ? -14.862 -20.332 3.661   1.00 93.91 232 A 1 
+ATOM 1876 C CG2 . ILE A 1 232 ? -14.549 -18.411 2.033   1.00 93.77 232 A 1 
+ATOM 1877 C CD1 . ILE A 1 232 ? -15.544 -19.523 4.764   1.00 85.80 232 A 1 
+ATOM 1878 N N   . PRO A 1 233 ? -12.226 -19.604 -0.293  1.00 95.86 233 A 1 
+ATOM 1879 C CA  . PRO A 1 233 ? -11.248 -19.009 -1.205  1.00 95.74 233 A 1 
+ATOM 1880 C C   . PRO A 1 233 ? -11.130 -17.487 -1.099  1.00 96.37 233 A 1 
+ATOM 1881 O O   . PRO A 1 233 ? -10.128 -16.938 -1.552  1.00 95.82 233 A 1 
+ATOM 1882 C CB  . PRO A 1 233 ? -11.706 -19.428 -2.601  1.00 94.45 233 A 1 
+ATOM 1883 C CG  . PRO A 1 233 ? -13.211 -19.572 -2.438  1.00 92.83 233 A 1 
+ATOM 1884 C CD  . PRO A 1 233 ? -13.336 -20.157 -1.039  1.00 94.42 233 A 1 
+ATOM 1885 N N   . ILE A 1 234 ? -12.124 -16.814 -0.516  1.00 96.95 234 A 1 
+ATOM 1886 C CA  . ILE A 1 234 ? -12.035 -15.388 -0.191  1.00 97.47 234 A 1 
+ATOM 1887 C C   . ILE A 1 234 ? -11.450 -15.253 1.217   1.00 97.56 234 A 1 
+ATOM 1888 O O   . ILE A 1 234 ? -11.980 -15.822 2.172   1.00 97.19 234 A 1 
+ATOM 1889 C CB  . ILE A 1 234 ? -13.393 -14.665 -0.346  1.00 97.46 234 A 1 
+ATOM 1890 C CG1 . ILE A 1 234 ? -13.879 -14.759 -1.813  1.00 96.62 234 A 1 
+ATOM 1891 C CG2 . ILE A 1 234 ? -13.265 -13.188 0.085   1.00 96.65 234 A 1 
+ATOM 1892 C CD1 . ILE A 1 234 ? -15.248 -14.116 -2.076  1.00 94.45 234 A 1 
+ATOM 1893 N N   . ILE A 1 235 ? -10.382 -14.490 1.344   1.00 98.10 235 A 1 
+ATOM 1894 C CA  . ILE A 1 235 ? -9.689  -14.234 2.605   1.00 98.25 235 A 1 
+ATOM 1895 C C   . ILE A 1 235 ? -9.725  -12.737 2.893   1.00 98.47 235 A 1 
+ATOM 1896 O O   . ILE A 1 235 ? -9.377  -11.922 2.044   1.00 98.22 235 A 1 
+ATOM 1897 C CB  . ILE A 1 235 ? -8.241  -14.775 2.583   1.00 97.77 235 A 1 
+ATOM 1898 C CG1 . ILE A 1 235 ? -8.148  -16.268 2.203   1.00 95.28 235 A 1 
+ATOM 1899 C CG2 . ILE A 1 235 ? -7.588  -14.579 3.966   1.00 95.33 235 A 1 
+ATOM 1900 C CD1 . ILE A 1 235 ? -7.942  -16.495 0.696   1.00 84.86 235 A 1 
+ATOM 1901 N N   . GLU A 1 236 ? -10.119 -12.369 4.109   1.00 98.45 236 A 1 
+ATOM 1902 C CA  . GLU A 1 236 ? -10.022 -10.988 4.582   1.00 98.52 236 A 1 
+ATOM 1903 C C   . GLU A 1 236 ? -8.599  -10.683 5.068   1.00 98.55 236 A 1 
+ATOM 1904 O O   . GLU A 1 236 ? -8.008  -11.436 5.844   1.00 98.11 236 A 1 
+ATOM 1905 C CB  . GLU A 1 236 ? -11.065 -10.723 5.685   1.00 98.25 236 A 1 
+ATOM 1906 C CG  . GLU A 1 236 ? -11.177 -9.224  6.015   1.00 97.56 236 A 1 
+ATOM 1907 C CD  . GLU A 1 236 ? -12.072 -8.906  7.219   1.00 97.56 236 A 1 
+ATOM 1908 O OE1 . GLU A 1 236 ? -12.375 -7.708  7.446   1.00 93.74 236 A 1 
+ATOM 1909 O OE2 . GLU A 1 236 ? -12.389 -9.798  8.033   1.00 94.99 236 A 1 
+ATOM 1910 N N   . TYR A 1 237 ? -8.089  -9.530  4.651   1.00 98.66 237 A 1 
+ATOM 1911 C CA  . TYR A 1 237 ? -6.830  -8.933  5.084   1.00 98.66 237 A 1 
+ATOM 1912 C C   . TYR A 1 237 ? -7.128  -7.618  5.825   1.00 98.64 237 A 1 
+ATOM 1913 O O   . TYR A 1 237 ? -7.119  -6.552  5.208   1.00 98.07 237 A 1 
+ATOM 1914 C CB  . TYR A 1 237 ? -5.925  -8.716  3.869   1.00 98.53 237 A 1 
+ATOM 1915 C CG  . TYR A 1 237 ? -5.229  -9.962  3.361   1.00 98.55 237 A 1 
+ATOM 1916 C CD1 . TYR A 1 237 ? -3.842  -10.116 3.561   1.00 97.96 237 A 1 
+ATOM 1917 C CD2 . TYR A 1 237 ? -5.957  -10.957 2.680   1.00 98.02 237 A 1 
+ATOM 1918 C CE1 . TYR A 1 237 ? -3.180  -11.255 3.079   1.00 97.68 237 A 1 
+ATOM 1919 C CE2 . TYR A 1 237 ? -5.298  -12.106 2.208   1.00 97.73 237 A 1 
+ATOM 1920 C CZ  . TYR A 1 237 ? -3.905  -12.253 2.403   1.00 97.98 237 A 1 
+ATOM 1921 O OH  . TYR A 1 237 ? -3.269  -13.355 1.949   1.00 97.20 237 A 1 
+ATOM 1922 N N   . PRO A 1 238 ? -7.432  -7.650  7.127   1.00 98.59 238 A 1 
+ATOM 1923 C CA  . PRO A 1 238 ? -7.636  -6.428  7.895   1.00 98.52 238 A 1 
+ATOM 1924 C C   . PRO A 1 238 ? -6.324  -5.640  8.036   1.00 98.52 238 A 1 
+ATOM 1925 O O   . PRO A 1 238 ? -5.244  -6.217  8.119   1.00 97.83 238 A 1 
+ATOM 1926 C CB  . PRO A 1 238 ? -8.193  -6.891  9.243   1.00 97.94 238 A 1 
+ATOM 1927 C CG  . PRO A 1 238 ? -7.599  -8.289  9.409   1.00 96.31 238 A 1 
+ATOM 1928 C CD  . PRO A 1 238 ? -7.549  -8.825  7.982   1.00 98.01 238 A 1 
+ATOM 1929 N N   . ASN A 1 239 ? -6.416  -4.314  8.087   1.00 98.36 239 A 1 
+ATOM 1930 C CA  . ASN A 1 239 ? -5.267  -3.432  8.330   1.00 98.24 239 A 1 
+ATOM 1931 C C   . ASN A 1 239 ? -4.788  -3.496  9.789   1.00 98.13 239 A 1 
+ATOM 1932 O O   . ASN A 1 239 ? -3.598  -3.440  10.082  1.00 97.03 239 A 1 
+ATOM 1933 C CB  . ASN A 1 239 ? -5.688  -1.997  7.977   1.00 97.91 239 A 1 
+ATOM 1934 C CG  . ASN A 1 239 ? -4.509  -1.050  7.941   1.00 97.71 239 A 1 
+ATOM 1935 O OD1 . ASN A 1 239 ? -3.456  -1.387  7.431   1.00 93.29 239 A 1 
+ATOM 1936 N ND2 . ASN A 1 239 ? -4.644  0.157   8.434   1.00 93.64 239 A 1 
+ATOM 1937 N N   . ASN A 1 240 ? -5.757  -3.583  10.694  1.00 97.90 240 A 1 
+ATOM 1938 C CA  . ASN A 1 240 ? -5.593  -3.716  12.136  1.00 97.77 240 A 1 
+ATOM 1939 C C   . ASN A 1 240 ? -6.865  -4.354  12.722  1.00 97.94 240 A 1 
+ATOM 1940 O O   . ASN A 1 240 ? -7.865  -4.531  12.019  1.00 97.31 240 A 1 
+ATOM 1941 C CB  . ASN A 1 240 ? -5.291  -2.326  12.742  1.00 97.30 240 A 1 
+ATOM 1942 C CG  . ASN A 1 240 ? -6.301  -1.273  12.352  1.00 97.27 240 A 1 
+ATOM 1943 O OD1 . ASN A 1 240 ? -7.479  -1.371  12.658  1.00 93.33 240 A 1 
+ATOM 1944 N ND2 . ASN A 1 240 ? -5.880  -0.253  11.637  1.00 93.66 240 A 1 
+ATOM 1945 N N   . SER A 1 241 ? -6.854  -4.655  14.019  1.00 97.26 241 A 1 
+ATOM 1946 C CA  . SER A 1 241 ? -7.986  -5.305  14.704  1.00 96.91 241 A 1 
+ATOM 1947 C C   . SER A 1 241 ? -9.314  -4.535  14.606  1.00 97.25 241 A 1 
+ATOM 1948 O O   . SER A 1 241 ? -10.383 -5.132  14.739  1.00 96.06 241 A 1 
+ATOM 1949 C CB  . SER A 1 241 ? -7.651  -5.500  16.183  1.00 95.58 241 A 1 
+ATOM 1950 O OG  . SER A 1 241 ? -6.389  -6.123  16.332  1.00 86.84 241 A 1 
+ATOM 1951 N N   . TRP A 1 242 ? -9.265  -3.219  14.369  1.00 97.51 242 A 1 
+ATOM 1952 C CA  . TRP A 1 242 ? -10.442 -2.353  14.236  1.00 97.45 242 A 1 
+ATOM 1953 C C   . TRP A 1 242 ? -10.849 -2.086  12.782  1.00 97.75 242 A 1 
+ATOM 1954 O O   . TRP A 1 242 ? -11.858 -1.416  12.561  1.00 96.76 242 A 1 
+ATOM 1955 C CB  . TRP A 1 242 ? -10.193 -1.045  14.989  1.00 96.78 242 A 1 
+ATOM 1956 C CG  . TRP A 1 242 ? -9.841  -1.219  16.434  1.00 95.83 242 A 1 
+ATOM 1957 C CD1 . TRP A 1 242 ? -10.715 -1.487  17.434  1.00 91.62 242 A 1 
+ATOM 1958 C CD2 . TRP A 1 242 ? -8.523  -1.190  17.058  1.00 93.56 242 A 1 
+ATOM 1959 N NE1 . TRP A 1 242 ? -10.036 -1.629  18.630  1.00 91.15 242 A 1 
+ATOM 1960 C CE2 . TRP A 1 242 ? -8.676  -1.450  18.456  1.00 92.75 242 A 1 
+ATOM 1961 C CE3 . TRP A 1 242 ? -7.209  -0.974  16.584  1.00 90.50 242 A 1 
+ATOM 1962 C CZ2 . TRP A 1 242 ? -7.584  -1.494  19.338  1.00 89.58 242 A 1 
+ATOM 1963 C CZ3 . TRP A 1 242 ? -6.110  -1.019  17.462  1.00 85.80 242 A 1 
+ATOM 1964 C CH2 . TRP A 1 242 ? -6.294  -1.275  18.835  1.00 85.59 242 A 1 
+ATOM 1965 N N   . ARG A 1 243 ? -10.086 -2.602  11.788  1.00 97.88 243 A 1 
+ATOM 1966 C CA  . ARG A 1 243 ? -10.323 -2.345  10.356  1.00 98.20 243 A 1 
+ATOM 1967 C C   . ARG A 1 243 ? -10.367 -0.845  10.038  1.00 98.36 243 A 1 
+ATOM 1968 O O   . ARG A 1 243 ? -11.280 -0.362  9.370   1.00 97.40 243 A 1 
+ATOM 1969 C CB  . ARG A 1 243 ? -11.573 -3.097  9.884   1.00 97.79 243 A 1 
+ATOM 1970 C CG  . ARG A 1 243 ? -11.443 -4.617  9.996   1.00 96.14 243 A 1 
+ATOM 1971 C CD  . ARG A 1 243 ? -12.823 -5.260  9.936   1.00 95.05 243 A 1 
+ATOM 1972 N NE  . ARG A 1 243 ? -12.739 -6.717  9.882   1.00 92.56 243 A 1 
+ATOM 1973 C CZ  . ARG A 1 243 ? -12.327 -7.552  10.815  1.00 93.03 243 A 1 
+ATOM 1974 N NH1 . ARG A 1 243 ? -11.991 -7.164  12.015  1.00 86.54 243 A 1 
+ATOM 1975 N NH2 . ARG A 1 243 ? -12.229 -8.817  10.535  1.00 88.47 243 A 1 
+ATOM 1976 N N   . ILE A 1 244 ? -9.420  -0.100  10.584  1.00 98.08 244 A 1 
+ATOM 1977 C CA  . ILE A 1 244 ? -9.259  1.341   10.361  1.00 98.22 244 A 1 
+ATOM 1978 C C   . ILE A 1 244 ? -8.124  1.542   9.351   1.00 98.34 244 A 1 
+ATOM 1979 O O   . ILE A 1 244 ? -7.085  0.884   9.457   1.00 97.83 244 A 1 
+ATOM 1980 C CB  . ILE A 1 244 ? -9.015  2.077   11.699  1.00 97.79 244 A 1 
+ATOM 1981 C CG1 . ILE A 1 244 ? -10.241 1.943   12.636  1.00 95.96 244 A 1 
+ATOM 1982 C CG2 . ILE A 1 244 ? -8.704  3.565   11.472  1.00 95.38 244 A 1 
+ATOM 1983 C CD1 . ILE A 1 244 ? -10.017 2.460   14.061  1.00 91.36 244 A 1 
+ATOM 1984 N N   . GLY A 1 245 ? -8.326  2.441   8.389   1.00 98.09 245 A 1 
+ATOM 1985 C CA  . GLY A 1 245 ? -7.306  2.848   7.425   1.00 98.12 245 A 1 
+ATOM 1986 C C   . GLY A 1 245 ? -6.174  3.650   8.071   1.00 98.10 245 A 1 
+ATOM 1987 O O   . GLY A 1 245 ? -6.363  4.266   9.122   1.00 97.42 245 A 1 
+ATOM 1988 N N   . ASP A 1 246 ? -5.000  3.682   7.442   1.00 98.19 246 A 1 
+ATOM 1989 C CA  . ASP A 1 246 ? -3.782  4.258   8.036   1.00 98.06 246 A 1 
+ATOM 1990 C C   . ASP A 1 246 ? -3.887  5.773   8.299   1.00 97.95 246 A 1 
+ATOM 1991 O O   . ASP A 1 246 ? -3.271  6.290   9.227   1.00 96.97 246 A 1 
+ATOM 1992 C CB  . ASP A 1 246 ? -2.577  3.968   7.122   1.00 97.81 246 A 1 
+ATOM 1993 C CG  . ASP A 1 246 ? -2.174  2.487   7.052   1.00 97.43 246 A 1 
+ATOM 1994 O OD1 . ASP A 1 246 ? -2.363  1.722   8.027   1.00 95.61 246 A 1 
+ATOM 1995 O OD2 . ASP A 1 246 ? -1.625  2.065   6.009   1.00 95.41 246 A 1 
+ATOM 1996 N N   . TRP A 1 247 ? -4.692  6.493   7.514   1.00 98.13 247 A 1 
+ATOM 1997 C CA  . TRP A 1 247 ? -4.888  7.943   7.632   1.00 98.10 247 A 1 
+ATOM 1998 C C   . TRP A 1 247 ? -6.318  8.335   8.016   1.00 97.96 247 A 1 
+ATOM 1999 O O   . TRP A 1 247 ? -6.626  9.518   8.152   1.00 97.21 247 A 1 
+ATOM 2000 C CB  . TRP A 1 247 ? -4.438  8.591   6.322   1.00 98.08 247 A 1 
+ATOM 2001 C CG  . TRP A 1 247 ? -5.028  7.999   5.080   1.00 98.27 247 A 1 
+ATOM 2002 C CD1 . TRP A 1 247 ? -4.418  7.095   4.283   1.00 97.73 247 A 1 
+ATOM 2003 C CD2 . TRP A 1 247 ? -6.341  8.233   4.486   1.00 98.15 247 A 1 
+ATOM 2004 N NE1 . TRP A 1 247 ? -5.253  6.759   3.238   1.00 97.76 247 A 1 
+ATOM 2005 C CE2 . TRP A 1 247 ? -6.452  7.430   3.315   1.00 98.05 247 A 1 
+ATOM 2006 C CE3 . TRP A 1 247 ? -7.446  9.046   4.814   1.00 98.05 247 A 1 
+ATOM 2007 C CZ2 . TRP A 1 247 ? -7.603  7.429   2.516   1.00 97.64 247 A 1 
+ATOM 2008 C CZ3 . TRP A 1 247 ? -8.610  9.050   4.018   1.00 97.42 247 A 1 
+ATOM 2009 C CH2 . TRP A 1 247 ? -8.686  8.243   2.876   1.00 97.18 247 A 1 
+ATOM 2010 N N   . GLU A 1 248 ? -7.196  7.375   8.235   1.00 97.75 248 A 1 
+ATOM 2011 C CA  . GLU A 1 248 ? -8.623  7.601   8.497   1.00 97.73 248 A 1 
+ATOM 2012 C C   . GLU A 1 248 ? -8.866  8.458   9.753   1.00 97.80 248 A 1 
+ATOM 2013 O O   . GLU A 1 248 ? -9.737  9.328   9.759   1.00 97.06 248 A 1 
+ATOM 2014 C CB  . GLU A 1 248 ? -9.291  6.221   8.623   1.00 97.27 248 A 1 
+ATOM 2015 C CG  . GLU A 1 248 ? -10.804 6.294   8.866   1.00 96.37 248 A 1 
+ATOM 2016 C CD  . GLU A 1 248 ? -11.441 4.901   8.980   1.00 97.05 248 A 1 
+ATOM 2017 O OE1 . GLU A 1 248 ? -12.626 4.794   9.382   1.00 93.60 248 A 1 
+ATOM 2018 O OE2 . GLU A 1 248 ? -10.804 3.884   8.634   1.00 95.35 248 A 1 
+ATOM 2019 N N   . LEU A 1 249 ? -8.068  8.253   10.803  1.00 97.40 249 A 1 
+ATOM 2020 C CA  . LEU A 1 249 ? -8.210  8.979   12.075  1.00 97.25 249 A 1 
+ATOM 2021 C C   . LEU A 1 249 ? -7.723  10.435  12.016  1.00 97.42 249 A 1 
+ATOM 2022 O O   . LEU A 1 249 ? -8.034  11.212  12.915  1.00 96.68 249 A 1 
+ATOM 2023 C CB  . LEU A 1 249 ? -7.470  8.209   13.182  1.00 96.74 249 A 1 
+ATOM 2024 C CG  . LEU A 1 249 ? -8.000  6.789   13.453  1.00 95.94 249 A 1 
+ATOM 2025 C CD1 . LEU A 1 249 ? -7.201  6.163   14.597  1.00 93.96 249 A 1 
+ATOM 2026 C CD2 . LEU A 1 249 ? -9.483  6.785   13.844  1.00 93.59 249 A 1 
+ATOM 2027 N N   . VAL A 1 250 ? -6.983  10.804  10.981  1.00 97.61 250 A 1 
+ATOM 2028 C CA  . VAL A 1 250 ? -6.398  12.145  10.817  1.00 97.77 250 A 1 
+ATOM 2029 C C   . VAL A 1 250 ? -7.050  12.949  9.692   1.00 97.97 250 A 1 
+ATOM 2030 O O   . VAL A 1 250 ? -6.553  14.016  9.340   1.00 97.70 250 A 1 
+ATOM 2031 C CB  . VAL A 1 250 ? -4.864  12.091  10.690  1.00 97.46 250 A 1 
+ATOM 2032 C CG1 . VAL A 1 250 ? -4.215  11.515  11.961  1.00 96.44 250 A 1 
+ATOM 2033 C CG2 . VAL A 1 250 ? -4.413  11.254  9.489   1.00 95.34 250 A 1 
+ATOM 2034 N N   . ILE A 1 251 ? -8.187  12.499  9.154   1.00 97.77 251 A 1 
+ATOM 2035 C CA  . ILE A 1 251 ? -8.950  13.215  8.115   1.00 97.83 251 A 1 
+ATOM 2036 C C   . ILE A 1 251 ? -9.216  14.668  8.525   1.00 97.91 251 A 1 
+ATOM 2037 O O   . ILE A 1 251 ? -8.953  15.577  7.746   1.00 97.70 251 A 1 
+ATOM 2038 C CB  . ILE A 1 251 ? -10.265 12.460  7.790   1.00 97.69 251 A 1 
+ATOM 2039 C CG1 . ILE A 1 251 ? -9.942  11.185  6.979   1.00 97.08 251 A 1 
+ATOM 2040 C CG2 . ILE A 1 251 ? -11.254 13.337  6.999   1.00 96.77 251 A 1 
+ATOM 2041 C CD1 . ILE A 1 251 ? -11.133 10.228  6.809   1.00 94.95 251 A 1 
+ATOM 2042 N N   . GLY A 1 252 ? -9.660  14.897  9.764   1.00 97.49 252 A 1 
+ATOM 2043 C CA  . GLY A 1 252 ? -9.926  16.260  10.243  1.00 97.43 252 A 1 
+ATOM 2044 C C   . GLY A 1 252 ? -8.699  17.178  10.222  1.00 97.81 252 A 1 
+ATOM 2045 O O   . GLY A 1 252 ? -8.835  18.375  9.978   1.00 97.48 252 A 1 
+ATOM 2046 N N   . LEU A 1 253 ? -7.503  16.636  10.435  1.00 97.73 253 A 1 
+ATOM 2047 C CA  . LEU A 1 253 ? -6.255  17.397  10.348  1.00 97.86 253 A 1 
+ATOM 2048 C C   . LEU A 1 253 ? -5.890  17.701  8.888   1.00 98.05 253 A 1 
+ATOM 2049 O O   . LEU A 1 253 ? -5.515  18.828  8.576   1.00 97.66 253 A 1 
+ATOM 2050 C CB  . LEU A 1 253 ? -5.154  16.614  11.086  1.00 97.42 253 A 1 
+ATOM 2051 C CG  . LEU A 1 253 ? -3.785  17.316  11.128  1.00 94.39 253 A 1 
+ATOM 2052 C CD1 . LEU A 1 253 ? -3.852  18.683  11.801  1.00 92.16 253 A 1 
+ATOM 2053 C CD2 . LEU A 1 253 ? -2.809  16.450  11.928  1.00 92.68 253 A 1 
+ATOM 2054 N N   . MET A 1 254 ? -6.060  16.739  7.981   1.00 98.14 254 A 1 
+ATOM 2055 C CA  . MET A 1 254 ? -5.861  16.958  6.542   1.00 98.22 254 A 1 
+ATOM 2056 C C   . MET A 1 254 ? -6.840  18.000  5.987   1.00 98.27 254 A 1 
+ATOM 2057 O O   . MET A 1 254 ? -6.439  18.869  5.211   1.00 97.97 254 A 1 
+ATOM 2058 C CB  . MET A 1 254 ? -5.996  15.633  5.773   1.00 98.00 254 A 1 
+ATOM 2059 C CG  . MET A 1 254 ? -4.894  14.623  6.134   1.00 97.15 254 A 1 
+ATOM 2060 S SD  . MET A 1 254 ? -4.850  13.122  5.111   1.00 96.47 254 A 1 
+ATOM 2061 C CE  . MET A 1 254 ? -6.367  12.302  5.655   1.00 90.23 254 A 1 
+ATOM 2062 N N   . ASP A 1 255 ? -8.099  17.968  6.430   1.00 98.20 255 A 1 
+ATOM 2063 C CA  . ASP A 1 255 ? -9.105  18.969  6.066   1.00 98.12 255 A 1 
+ATOM 2064 C C   . ASP A 1 255 ? -8.720  20.365  6.577   1.00 98.11 255 A 1 
+ATOM 2065 O O   . ASP A 1 255 ? -8.799  21.334  5.819   1.00 97.62 255 A 1 
+ATOM 2066 C CB  . ASP A 1 255 ? -10.490 18.554  6.597   1.00 97.89 255 A 1 
+ATOM 2067 C CG  . ASP A 1 255 ? -11.118 17.356  5.869   1.00 97.23 255 A 1 
+ATOM 2068 O OD1 . ASP A 1 255 ? -10.699 17.054  4.724   1.00 94.70 255 A 1 
+ATOM 2069 O OD2 . ASP A 1 255 ? -12.085 16.784  6.427   1.00 94.54 255 A 1 
+ATOM 2070 N N   . ALA A 1 256 ? -8.217  20.475  7.809   1.00 98.09 256 A 1 
+ATOM 2071 C CA  . ALA A 1 256 ? -7.734  21.741  8.365   1.00 97.94 256 A 1 
+ATOM 2072 C C   . ALA A 1 256 ? -6.535  22.307  7.581   1.00 97.88 256 A 1 
+ATOM 2073 O O   . ALA A 1 256 ? -6.478  23.509  7.321   1.00 97.35 256 A 1 
+ATOM 2074 C CB  . ALA A 1 256 ? -7.388  21.529  9.845   1.00 97.74 256 A 1 
+ATOM 2075 N N   . ILE A 1 257 ? -5.605  21.453  7.145   1.00 97.80 257 A 1 
+ATOM 2076 C CA  . ILE A 1 257 ? -4.476  21.859  6.290   1.00 97.60 257 A 1 
+ATOM 2077 C C   . ILE A 1 257 ? -4.982  22.387  4.940   1.00 97.41 257 A 1 
+ATOM 2078 O O   . ILE A 1 257 ? -4.523  23.431  4.465   1.00 96.77 257 A 1 
+ATOM 2079 C CB  . ILE A 1 257 ? -3.479  20.683  6.114   1.00 97.43 257 A 1 
+ATOM 2080 C CG1 . ILE A 1 257 ? -2.768  20.357  7.450   1.00 96.85 257 A 1 
+ATOM 2081 C CG2 . ILE A 1 257 ? -2.416  21.008  5.043   1.00 96.53 257 A 1 
+ATOM 2082 C CD1 . ILE A 1 257 ? -2.057  18.993  7.462   1.00 94.92 257 A 1 
+ATOM 2083 N N   . ASN A 1 258 ? -5.955  21.708  4.326   1.00 97.98 258 A 1 
+ATOM 2084 C CA  . ASN A 1 258 ? -6.563  22.155  3.072   1.00 98.00 258 A 1 
+ATOM 2085 C C   . ASN A 1 258 ? -7.288  23.495  3.232   1.00 97.71 258 A 1 
+ATOM 2086 O O   . ASN A 1 258 ? -7.144  24.383  2.386   1.00 96.90 258 A 1 
+ATOM 2087 C CB  . ASN A 1 258 ? -7.543  21.084  2.571   1.00 97.91 258 A 1 
+ATOM 2088 C CG  . ASN A 1 258 ? -6.873  19.858  1.986   1.00 97.51 258 A 1 
+ATOM 2089 O OD1 . ASN A 1 258 ? -5.715  19.854  1.603   1.00 92.44 258 A 1 
+ATOM 2090 N ND2 . ASN A 1 258 ? -7.626  18.793  1.829   1.00 92.75 258 A 1 
+ATOM 2091 N N   . GLU A 1 259 ? -8.047  23.661  4.319   1.00 97.51 259 A 1 
+ATOM 2092 C CA  . GLU A 1 259 ? -8.772  24.894  4.615   1.00 97.07 259 A 1 
+ATOM 2093 C C   . GLU A 1 259 ? -7.816  26.063  4.853   1.00 96.78 259 A 1 
+ATOM 2094 O O   . GLU A 1 259 ? -7.991  27.124  4.246   1.00 95.63 259 A 1 
+ATOM 2095 C CB  . GLU A 1 259 ? -9.716  24.660  5.803   1.00 96.46 259 A 1 
+ATOM 2096 C CG  . GLU A 1 259 ? -10.635 25.872  6.032   1.00 87.18 259 A 1 
+ATOM 2097 C CD  . GLU A 1 259 ? -11.734 25.632  7.083   1.00 82.17 259 A 1 
+ATOM 2098 O OE1 . GLU A 1 259 ? -12.609 26.527  7.188   1.00 71.24 259 A 1 
+ATOM 2099 O OE2 . GLU A 1 259 ? -11.716 24.578  7.752   1.00 72.04 259 A 1 
+ATOM 2100 N N   . LEU A 1 260 ? -6.764  25.859  5.646   1.00 96.38 260 A 1 
+ATOM 2101 C CA  . LEU A 1 260 ? -5.735  26.861  5.909   1.00 95.86 260 A 1 
+ATOM 2102 C C   . LEU A 1 260 ? -5.061  27.329  4.616   1.00 95.44 260 A 1 
+ATOM 2103 O O   . LEU A 1 260 ? -5.008  28.529  4.347   1.00 94.49 260 A 1 
+ATOM 2104 C CB  . LEU A 1 260 ? -4.711  26.273  6.897   1.00 95.53 260 A 1 
+ATOM 2105 C CG  . LEU A 1 260 ? -3.542  27.221  7.228   1.00 94.02 260 A 1 
+ATOM 2106 C CD1 . LEU A 1 260 ? -4.010  28.488  7.944   1.00 89.92 260 A 1 
+ATOM 2107 C CD2 . LEU A 1 260 ? -2.547  26.500  8.133   1.00 89.89 260 A 1 
+ATOM 2108 N N   . ASN A 1 261 ? -4.589  26.399  3.787   1.00 95.78 261 A 1 
+ATOM 2109 C CA  . ASN A 1 261 ? -3.906  26.750  2.542   1.00 95.26 261 A 1 
+ATOM 2110 C C   . ASN A 1 261 ? -4.850  27.393  1.514   1.00 95.07 261 A 1 
+ATOM 2111 O O   . ASN A 1 261 ? -4.465  28.343  0.830   1.00 93.92 261 A 1 
+ATOM 2112 C CB  . ASN A 1 261 ? -3.194  25.510  1.989   1.00 94.95 261 A 1 
+ATOM 2113 C CG  . ASN A 1 261 ? -1.916  25.222  2.757   1.00 93.87 261 A 1 
+ATOM 2114 O OD1 . ASN A 1 261 ? -0.931  25.930  2.623   1.00 87.32 261 A 1 
+ATOM 2115 N ND2 . ASN A 1 261 ? -1.899  24.220  3.598   1.00 87.08 261 A 1 
+ATOM 2116 N N   . SER A 1 262 ? -6.104  26.952  1.454   1.00 95.84 262 A 1 
+ATOM 2117 C CA  . SER A 1 262 ? -7.130  27.600  0.624   1.00 95.69 262 A 1 
+ATOM 2118 C C   . SER A 1 262 ? -7.442  29.019  1.116   1.00 94.84 262 A 1 
+ATOM 2119 O O   . SER A 1 262 ? -7.600  29.934  0.313   1.00 93.81 262 A 1 
+ATOM 2120 C CB  . SER A 1 262 ? -8.418  26.773  0.610   1.00 95.97 262 A 1 
+ATOM 2121 O OG  . SER A 1 262 ? -8.172  25.463  0.135   1.00 92.19 262 A 1 
+ATOM 2122 N N   . GLY A 1 263 ? -7.487  29.222  2.441   1.00 94.27 263 A 1 
+ATOM 2123 C CA  . GLY A 1 263 ? -7.669  30.536  3.059   1.00 93.07 263 A 1 
+ATOM 2124 C C   . GLY A 1 263 ? -6.504  31.491  2.808   1.00 92.83 263 A 1 
+ATOM 2125 O O   . GLY A 1 263 ? -6.732  32.671  2.551   1.00 91.56 263 A 1 
+ATOM 2126 N N   . ARG A 1 264 ? -5.270  30.989  2.809   1.00 92.87 264 A 1 
+ATOM 2127 C CA  . ARG A 1 264 ? -4.071  31.774  2.454   1.00 92.28 264 A 1 
+ATOM 2128 C C   . ARG A 1 264 ? -4.118  32.263  1.007   1.00 92.16 264 A 1 
+ATOM 2129 O O   . ARG A 1 264 ? -3.791  33.420  0.756   1.00 91.04 264 A 1 
+ATOM 2130 C CB  . ARG A 1 264 ? -2.798  30.940  2.682   1.00 91.44 264 A 1 
+ATOM 2131 C CG  . ARG A 1 264 ? -2.480  30.735  4.171   1.00 85.15 264 A 1 
+ATOM 2132 C CD  . ARG A 1 264 ? -1.278  29.794  4.356   1.00 85.62 264 A 1 
+ATOM 2133 N NE  . ARG A 1 264 ? -0.010  30.426  3.950   1.00 78.25 264 A 1 
+ATOM 2134 C CZ  . ARG A 1 264 ? 1.161   29.817  3.806   1.00 75.50 264 A 1 
+ATOM 2135 N NH1 . ARG A 1 264 ? 1.307   28.531  3.942   1.00 69.96 264 A 1 
+ATOM 2136 N NH2 . ARG A 1 264 ? 2.228   30.511  3.535   1.00 64.41 264 A 1 
+ATOM 2137 N N   . LEU A 1 265 ? -4.554  31.417  0.075   1.00 92.61 265 A 1 
+ATOM 2138 C CA  . LEU A 1 265 ? -4.751  31.835  -1.318  1.00 92.47 265 A 1 
+ATOM 2139 C C   . LEU A 1 265 ? -5.864  32.883  -1.444  1.00 92.15 265 A 1 
+ATOM 2140 O O   . LEU A 1 265 ? -5.678  33.880  -2.139  1.00 90.79 265 A 1 
+ATOM 2141 C CB  . LEU A 1 265 ? -5.055  30.615  -2.202  1.00 92.23 265 A 1 
+ATOM 2142 C CG  . LEU A 1 265 ? -3.862  29.671  -2.443  1.00 86.40 265 A 1 
+ATOM 2143 C CD1 . LEU A 1 265 ? -4.329  28.494  -3.302  1.00 81.79 265 A 1 
+ATOM 2144 C CD2 . LEU A 1 265 ? -2.704  30.355  -3.175  1.00 82.18 265 A 1 
+ATOM 2145 N N   . ASP A 1 266 ? -6.969  32.704  -0.720  1.00 91.46 266 A 1 
+ATOM 2146 C CA  . ASP A 1 266 ? -8.040  33.706  -0.677  1.00 90.85 266 A 1 
+ATOM 2147 C C   . ASP A 1 266 ? -7.541  35.056  -0.147  1.00 90.43 266 A 1 
+ATOM 2148 O O   . ASP A 1 266 ? -7.973  36.097  -0.640  1.00 89.31 266 A 1 
+ATOM 2149 C CB  . ASP A 1 266 ? -9.196  33.249  0.231   1.00 91.05 266 A 1 
+ATOM 2150 C CG  . ASP A 1 266 ? -10.073 32.113  -0.287  1.00 91.12 266 A 1 
+ATOM 2151 O OD1 . ASP A 1 266 ? -10.033 31.753  -1.478  1.00 87.40 266 A 1 
+ATOM 2152 O OD2 . ASP A 1 266 ? -10.894 31.629  0.536   1.00 88.51 266 A 1 
+ATOM 2153 N N   . ASP A 1 267 ? -6.669  35.071  0.862   1.00 90.07 267 A 1 
+ATOM 2154 C CA  . ASP A 1 267 ? -6.098  36.301  1.422   1.00 88.43 267 A 1 
+ATOM 2155 C C   . ASP A 1 267 ? -5.198  37.015  0.406   1.00 88.35 267 A 1 
+ATOM 2156 O O   . ASP A 1 267 ? -5.357  38.213  0.174   1.00 87.10 267 A 1 
+ATOM 2157 C CB  . ASP A 1 267 ? -5.336  35.979  2.711   1.00 87.00 267 A 1 
+ATOM 2158 C CG  . ASP A 1 267 ? -4.815  37.245  3.403   1.00 77.99 267 A 1 
+ATOM 2159 O OD1 . ASP A 1 267 ? -5.647  38.120  3.717   1.00 73.14 267 A 1 
+ATOM 2160 O OD2 . ASP A 1 267 ? -3.587  37.317  3.646   1.00 71.74 267 A 1 
+ATOM 2161 N N   . ILE A 1 268 ? -4.321  36.272  -0.272  1.00 87.54 268 A 1 
+ATOM 2162 C CA  . ILE A 1 268 ? -3.459  36.822  -1.329  1.00 86.95 268 A 1 
+ATOM 2163 C C   . ILE A 1 268 ? -4.307  37.472  -2.431  1.00 87.02 268 A 1 
+ATOM 2164 O O   . ILE A 1 268 ? -4.049  38.609  -2.829  1.00 85.79 268 A 1 
+ATOM 2165 C CB  . ILE A 1 268 ? -2.525  35.722  -1.888  1.00 87.02 268 A 1 
+ATOM 2166 C CG1 . ILE A 1 268 ? -1.496  35.293  -0.814  1.00 84.95 268 A 1 
+ATOM 2167 C CG2 . ILE A 1 268 ? -1.786  36.202  -3.155  1.00 84.93 268 A 1 
+ATOM 2168 C CD1 . ILE A 1 268 ? -0.771  33.979  -1.142  1.00 79.97 268 A 1 
+ATOM 2169 N N   . GLU A 1 269 ? -5.348  36.789  -2.903  1.00 86.73 269 A 1 
+ATOM 2170 C CA  . GLU A 1 269 ? -6.244  37.346  -3.920  1.00 86.67 269 A 1 
+ATOM 2171 C C   . GLU A 1 269 ? -7.043  38.549  -3.406  1.00 85.86 269 A 1 
+ATOM 2172 O O   . GLU A 1 269 ? -7.233  39.522  -4.139  1.00 83.04 269 A 1 
+ATOM 2173 C CB  . GLU A 1 269 ? -7.211  36.285  -4.431  1.00 86.73 269 A 1 
+ATOM 2174 C CG  . GLU A 1 269 ? -6.539  35.313  -5.406  1.00 80.66 269 A 1 
+ATOM 2175 C CD  . GLU A 1 269 ? -7.539  34.329  -6.025  1.00 81.46 269 A 1 
+ATOM 2176 O OE1 . GLU A 1 269 ? -7.068  33.319  -6.581  1.00 71.97 269 A 1 
+ATOM 2177 O OE2 . GLU A 1 269 ? -8.762  34.560  -5.927  1.00 74.80 269 A 1 
+ATOM 2178 N N   . GLN A 1 270 ? -7.477  38.531  -2.151  1.00 85.92 270 A 1 
+ATOM 2179 C CA  . GLN A 1 270 ? -8.163  39.669  -1.530  1.00 83.73 270 A 1 
+ATOM 2180 C C   . GLN A 1 270 ? -7.271  40.904  -1.427  1.00 82.76 270 A 1 
+ATOM 2181 O O   . GLN A 1 270 ? -7.765  42.019  -1.602  1.00 80.57 270 A 1 
+ATOM 2182 C CB  . GLN A 1 270 ? -8.678  39.281  -0.139  1.00 82.56 270 A 1 
+ATOM 2183 C CG  . GLN A 1 270 ? -9.999  38.530  -0.235  1.00 77.38 270 A 1 
+ATOM 2184 C CD  . GLN A 1 270 ? -10.414 37.944  1.100   1.00 76.68 270 A 1 
+ATOM 2185 O OE1 . GLN A 1 270 ? -11.063 38.561  1.919   1.00 70.04 270 A 1 
+ATOM 2186 N NE2 . GLN A 1 270 ? -10.110 36.689  1.344   1.00 67.56 270 A 1 
+ATOM 2187 N N   . VAL A 1 271 ? -5.976  40.720  -1.163  1.00 82.68 271 A 1 
+ATOM 2188 C CA  . VAL A 1 271 ? -4.994  41.813  -1.164  1.00 80.90 271 A 1 
+ATOM 2189 C C   . VAL A 1 271 ? -4.820  42.377  -2.576  1.00 80.97 271 A 1 
+ATOM 2190 O O   . VAL A 1 271 ? -4.866  43.595  -2.757  1.00 79.01 271 A 1 
+ATOM 2191 C CB  . VAL A 1 271 ? -3.657  41.344  -0.564  1.00 80.13 271 A 1 
+ATOM 2192 C CG1 . VAL A 1 271 ? -2.547  42.397  -0.733  1.00 75.96 271 A 1 
+ATOM 2193 C CG2 . VAL A 1 271 ? -3.804  41.067  0.937   1.00 77.87 271 A 1 
+ATOM 2194 N N   . ILE A 1 272 ? -4.675  41.517  -3.576  1.00 80.87 272 A 1 
+ATOM 2195 C CA  . ILE A 1 272 ? -4.540  41.928  -4.984  1.00 80.11 272 A 1 
+ATOM 2196 C C   . ILE A 1 272 ? -5.808  42.650  -5.464  1.00 81.04 272 A 1 
+ATOM 2197 O O   . ILE A 1 272 ? -5.732  43.685  -6.127  1.00 78.76 272 A 1 
+ATOM 2198 C CB  . ILE A 1 272 ? -4.202  40.703  -5.867  1.00 79.12 272 A 1 
+ATOM 2199 C CG1 . ILE A 1 272 ? -2.803  40.146  -5.512  1.00 76.38 272 A 1 
+ATOM 2200 C CG2 . ILE A 1 272 ? -4.248  41.063  -7.367  1.00 76.69 272 A 1 
+ATOM 2201 C CD1 . ILE A 1 272 ? -2.531  38.749  -6.092  1.00 69.54 272 A 1 
+ATOM 2202 N N   . GLN A 1 273 ? -6.979  42.131  -5.104  1.00 80.19 273 A 1 
+ATOM 2203 C CA  . GLN A 1 273 ? -8.292  42.688  -5.442  1.00 78.49 273 A 1 
+ATOM 2204 C C   . GLN A 1 273 ? -8.869  43.532  -4.290  1.00 78.65 273 A 1 
+ATOM 2205 O O   . GLN A 1 273 ? -10.045 43.409  -3.936  1.00 74.92 273 A 1 
+ATOM 2206 C CB  . GLN A 1 273 ? -9.244  41.559  -5.863  1.00 77.44 273 A 1 
+ATOM 2207 C CG  . GLN A 1 273 ? -8.751  40.704  -7.038  1.00 75.40 273 A 1 
+ATOM 2208 C CD  . GLN A 1 273 ? -9.749  39.594  -7.378  1.00 72.39 273 A 1 
+ATOM 2209 O OE1 . GLN A 1 273 ? -10.885 39.578  -6.933  1.00 65.75 273 A 1 
+ATOM 2210 N NE2 . GLN A 1 273 ? -9.366  38.621  -8.177  1.00 63.35 273 A 1 
+ATOM 2211 N N   . SER A 1 274 ? -8.030  44.360  -3.649  1.00 78.68 274 A 1 
+ATOM 2212 C CA  . SER A 1 274 ? -8.433  45.165  -2.494  1.00 76.85 274 A 1 
+ATOM 2213 C C   . SER A 1 274 ? -9.534  46.180  -2.833  1.00 77.74 274 A 1 
+ATOM 2214 O O   . SER A 1 274 ? -9.603  46.717  -3.940  1.00 73.68 274 A 1 
+ATOM 2215 C CB  . SER A 1 274 ? -7.222  45.852  -1.864  1.00 72.55 274 A 1 
+ATOM 2216 O OG  . SER A 1 274 ? -6.582  46.727  -2.773  1.00 65.01 274 A 1 
+ATOM 2217 N N   . LEU A 1 275 ? -10.394 46.457  -1.853  1.00 75.13 275 A 1 
+ATOM 2218 C CA  . LEU A 1 275 ? -11.442 47.466  -1.998  1.00 74.68 275 A 1 
+ATOM 2219 C C   . LEU A 1 275 ? -10.829 48.860  -1.878  1.00 76.68 275 A 1 
+ATOM 2220 O O   . LEU A 1 275 ? -10.167 49.180  -0.886  1.00 75.54 275 A 1 
+ATOM 2221 C CB  . LEU A 1 275 ? -12.549 47.250  -0.956  1.00 70.95 275 A 1 
+ATOM 2222 C CG  . LEU A 1 275 ? -13.369 45.957  -1.146  1.00 65.45 275 A 1 
+ATOM 2223 C CD1 . LEU A 1 275 ? -14.325 45.775  0.033   1.00 61.40 275 A 1 
+ATOM 2224 C CD2 . LEU A 1 275 ? -14.199 45.977  -2.433  1.00 61.05 275 A 1 
+ATOM 2225 N N   . ILE A 1 276 ? -11.086 49.692  -2.877  1.00 74.75 276 A 1 
+ATOM 2226 C CA  . ILE A 1 276 ? -10.676 51.094  -2.889  1.00 75.87 276 A 1 
+ATOM 2227 C C   . ILE A 1 276 ? -11.823 51.933  -2.323  1.00 78.70 276 A 1 
+ATOM 2228 O O   . ILE A 1 276 ? -12.955 51.859  -2.798  1.00 77.49 276 A 1 
+ATOM 2229 C CB  . ILE A 1 276 ? -10.248 51.536  -4.306  1.00 73.10 276 A 1 
+ATOM 2230 C CG1 . ILE A 1 276 ? -9.099  50.638  -4.835  1.00 68.31 276 A 1 
+ATOM 2231 C CG2 . ILE A 1 276 ? -9.818  53.011  -4.275  1.00 67.80 276 A 1 
+ATOM 2232 C CD1 . ILE A 1 276 ? -8.645  50.961  -6.266  1.00 62.87 276 A 1 
+ATOM 2233 N N   . VAL A 1 277 ? -11.517 52.740  -1.298  1.00 79.13 277 A 1 
+ATOM 2234 C CA  . VAL A 1 277 ? -12.453 53.674  -0.672  1.00 79.76 277 A 1 
+ATOM 2235 C C   . VAL A 1 277 ? -12.036 55.092  -1.024  1.00 80.98 277 A 1 
+ATOM 2236 O O   . VAL A 1 277 ? -10.933 55.524  -0.694  1.00 79.96 277 A 1 
+ATOM 2237 C CB  . VAL A 1 277 ? -12.506 53.476  0.853   1.00 77.53 277 A 1 
+ATOM 2238 C CG1 . VAL A 1 277 ? -13.505 54.435  1.520   1.00 69.92 277 A 1 
+ATOM 2239 C CG2 . VAL A 1 277 ? -12.948 52.050  1.187   1.00 72.42 277 A 1 
+ATOM 2240 N N   . PHE A 1 278 ? -12.950 55.812  -1.645  1.00 80.63 278 A 1 
+ATOM 2241 C CA  . PHE A 1 278 ? -12.802 57.237  -1.911  1.00 80.47 278 A 1 
+ATOM 2242 C C   . PHE A 1 278 ? -13.440 58.031  -0.766  1.00 82.41 278 A 1 
+ATOM 2243 O O   . PHE A 1 278 ? -14.625 57.875  -0.474  1.00 80.89 278 A 1 
+ATOM 2244 C CB  . PHE A 1 278 ? -13.431 57.559  -3.269  1.00 78.98 278 A 1 
+ATOM 2245 C CG  . PHE A 1 278 ? -12.747 56.855  -4.433  1.00 78.79 278 A 1 
+ATOM 2246 C CD1 . PHE A 1 278 ? -11.593 57.414  -5.008  1.00 75.01 278 A 1 
+ATOM 2247 C CD2 . PHE A 1 278 ? -13.254 55.638  -4.928  1.00 76.49 278 A 1 
+ATOM 2248 C CE1 . PHE A 1 278 ? -10.951 56.767  -6.082  1.00 73.57 278 A 1 
+ATOM 2249 C CE2 . PHE A 1 278 ? -12.609 54.988  -5.998  1.00 74.71 278 A 1 
+ATOM 2250 C CZ  . PHE A 1 278 ? -11.459 55.554  -6.579  1.00 76.40 278 A 1 
+ATOM 2251 N N   . LEU A 1 279 ? -12.649 58.879  -0.102  1.00 81.73 279 A 1 
+ATOM 2252 C CA  . LEU A 1 279 ? -13.116 59.768  0.956   1.00 82.23 279 A 1 
+ATOM 2253 C C   . LEU A 1 279 ? -13.342 61.169  0.379   1.00 82.35 279 A 1 
+ATOM 2254 O O   . LEU A 1 279 ? -12.433 61.754  -0.202  1.00 80.58 279 A 1 
+ATOM 2255 C CB  . LEU A 1 279 ? -12.101 59.792  2.112   1.00 81.58 279 A 1 
+ATOM 2256 C CG  . LEU A 1 279 ? -11.903 58.445  2.837   1.00 77.83 279 A 1 
+ATOM 2257 C CD1 . LEU A 1 279 ? -10.788 58.586  3.880   1.00 71.52 279 A 1 
+ATOM 2258 C CD2 . LEU A 1 279 ? -13.166 57.983  3.563   1.00 72.72 279 A 1 
+ATOM 2259 N N   . ASN A 1 280 ? -14.550 61.714  0.587   1.00 83.17 280 A 1 
+ATOM 2260 C CA  . ASN A 1 280 ? -14.947 63.044  0.111   1.00 82.44 280 A 1 
+ATOM 2261 C C   . ASN A 1 280 ? -14.740 63.261  -1.401  1.00 82.82 280 A 1 
+ATOM 2262 O O   . ASN A 1 280 ? -14.430 64.370  -1.834  1.00 78.94 280 A 1 
+ATOM 2263 C CB  . ASN A 1 280 ? -14.266 64.133  0.961   1.00 81.05 280 A 1 
+ATOM 2264 C CG  . ASN A 1 280 ? -14.520 63.997  2.446   1.00 79.39 280 A 1 
+ATOM 2265 O OD1 . ASN A 1 280 ? -15.593 63.642  2.900   1.00 73.04 280 A 1 
+ATOM 2266 N ND2 . ASN A 1 280 ? -13.533 64.291  3.259   1.00 73.76 280 A 1 
+ATOM 2267 N N   . ALA A 1 281 ? -14.895 62.202  -2.196  1.00 81.77 281 A 1 
+ATOM 2268 C CA  . ALA A 1 281 ? -14.823 62.268  -3.646  1.00 80.77 281 A 1 
+ATOM 2269 C C   . ALA A 1 281 ? -15.999 61.501  -4.263  1.00 82.12 281 A 1 
+ATOM 2270 O O   . ALA A 1 281 ? -16.218 60.336  -3.943  1.00 78.96 281 A 1 
+ATOM 2271 C CB  . ALA A 1 281 ? -13.468 61.715  -4.102  1.00 78.18 281 A 1 
+ATOM 2272 N N   . GLU A 1 282 ? -16.742 62.177  -5.143  1.00 83.73 282 A 1 
+ATOM 2273 C CA  . GLU A 1 282 ? -17.745 61.544  -5.997  1.00 83.12 282 A 1 
+ATOM 2274 C C   . GLU A 1 282 ? -17.114 61.309  -7.370  1.00 83.44 282 A 1 
+ATOM 2275 O O   . GLU A 1 282 ? -16.584 62.239  -7.981  1.00 79.57 282 A 1 
+ATOM 2276 C CB  . GLU A 1 282 ? -19.013 62.402  -6.093  1.00 79.89 282 A 1 
+ATOM 2277 C CG  . GLU A 1 282 ? -19.782 62.449  -4.757  1.00 71.95 282 A 1 
+ATOM 2278 C CD  . GLU A 1 282 ? -21.095 63.252  -4.816  1.00 69.70 282 A 1 
+ATOM 2279 O OE1 . GLU A 1 282 ? -21.789 63.285  -3.770  1.00 63.60 282 A 1 
+ATOM 2280 O OE2 . GLU A 1 282 ? -21.399 63.842  -5.876  1.00 64.30 282 A 1 
+ATOM 2281 N N   . ILE A 1 283 ? -17.120 60.063  -7.817  1.00 80.99 283 A 1 
+ATOM 2282 C CA  . ILE A 1 283 ? -16.542 59.650  -9.095  1.00 81.84 283 A 1 
+ATOM 2283 C C   . ILE A 1 283 ? -17.640 58.936  -9.876  1.00 83.30 283 A 1 
+ATOM 2284 O O   . ILE A 1 283 ? -18.242 57.985  -9.375  1.00 81.19 283 A 1 
+ATOM 2285 C CB  . ILE A 1 283 ? -15.285 58.766  -8.890  1.00 79.61 283 A 1 
+ATOM 2286 C CG1 . ILE A 1 283 ? -14.224 59.504  -8.040  1.00 73.34 283 A 1 
+ATOM 2287 C CG2 . ILE A 1 283 ? -14.683 58.354  -10.244 1.00 72.02 283 A 1 
+ATOM 2288 C CD1 . ILE A 1 283 ? -12.972 58.672  -7.740  1.00 67.69 283 A 1 
+ATOM 2289 N N   . ASP A 1 284 ? -17.913 59.414  -11.084 1.00 85.64 284 A 1 
+ATOM 2290 C CA  . ASP A 1 284 ? -18.828 58.733  -11.996 1.00 85.98 284 A 1 
+ATOM 2291 C C   . ASP A 1 284 ? -18.180 57.483  -12.618 1.00 86.91 284 A 1 
+ATOM 2292 O O   . ASP A 1 284 ? -16.956 57.304  -12.590 1.00 84.91 284 A 1 
+ATOM 2293 C CB  . ASP A 1 284 ? -19.353 59.718  -13.048 1.00 85.00 284 A 1 
+ATOM 2294 C CG  . ASP A 1 284 ? -18.220 60.188  -13.949 1.00 82.22 284 A 1 
+ATOM 2295 O OD1 . ASP A 1 284 ? -17.858 59.413  -14.859 1.00 73.88 284 A 1 
+ATOM 2296 O OD2 . ASP A 1 284 ? -17.650 61.263  -13.669 1.00 76.89 284 A 1 
+ATOM 2297 N N   . SER A 1 285 ? -18.999 56.622  -13.167 1.00 86.81 285 A 1 
+ATOM 2298 C CA  . SER A 1 285 ? -18.546 55.345  -13.724 1.00 86.40 285 A 1 
+ATOM 2299 C C   . SER A 1 285 ? -17.578 55.494  -14.898 1.00 87.23 285 A 1 
+ATOM 2300 O O   . SER A 1 285 ? -16.651 54.694  -15.017 1.00 85.54 285 A 1 
+ATOM 2301 C CB  . SER A 1 285 ? -19.750 54.500  -14.155 1.00 85.11 285 A 1 
+ATOM 2302 O OG  . SER A 1 285 ? -20.627 55.225  -14.997 1.00 75.79 285 A 1 
+ATOM 2303 N N   . GLU A 1 286 ? -17.749 56.523  -15.735 1.00 86.48 286 A 1 
+ATOM 2304 C CA  . GLU A 1 286 ? -16.882 56.743  -16.896 1.00 87.28 286 A 1 
+ATOM 2305 C C   . GLU A 1 286 ? -15.481 57.185  -16.458 1.00 87.98 286 A 1 
+ATOM 2306 O O   . GLU A 1 286 ? -14.476 56.626  -16.905 1.00 85.55 286 A 1 
+ATOM 2307 C CB  . GLU A 1 286 ? -17.495 57.777  -17.856 1.00 87.81 286 A 1 
+ATOM 2308 C CG  . GLU A 1 286 ? -18.804 57.302  -18.507 1.00 78.45 286 A 1 
+ATOM 2309 C CD  . GLU A 1 286 ? -19.364 58.264  -19.576 1.00 73.01 286 A 1 
+ATOM 2310 O OE1 . GLU A 1 286 ? -20.336 57.852  -20.255 1.00 66.56 286 A 1 
+ATOM 2311 O OE2 . GLU A 1 286 ? -18.834 59.384  -19.737 1.00 67.57 286 A 1 
+ATOM 2312 N N   . THR A 1 287 ? -15.425 58.136  -15.505 1.00 85.39 287 A 1 
+ATOM 2313 C CA  . THR A 1 287 ? -14.172 58.608  -14.905 1.00 83.85 287 A 1 
+ATOM 2314 C C   . THR A 1 287 ? -13.447 57.479  -14.167 1.00 84.79 287 A 1 
+ATOM 2315 O O   . THR A 1 287 ? -12.229 57.334  -14.291 1.00 83.34 287 A 1 
+ATOM 2316 C CB  . THR A 1 287 ? -14.440 59.782  -13.950 1.00 82.89 287 A 1 
+ATOM 2317 O OG1 . THR A 1 287 ? -15.091 60.844  -14.615 1.00 76.98 287 A 1 
+ATOM 2318 C CG2 . THR A 1 287 ? -13.153 60.387  -13.390 1.00 75.38 287 A 1 
+ATOM 2319 N N   . TYR A 1 288 ? -14.174 56.639  -13.424 1.00 83.85 288 A 1 
+ATOM 2320 C CA  . TYR A 1 288 ? -13.586 55.473  -12.752 1.00 82.35 288 A 1 
+ATOM 2321 C C   . TYR A 1 288 ? -12.970 54.476  -13.746 1.00 82.93 288 A 1 
+ATOM 2322 O O   . TYR A 1 288 ? -11.837 54.028  -13.560 1.00 81.26 288 A 1 
+ATOM 2323 C CB  . TYR A 1 288 ? -14.650 54.788  -11.884 1.00 80.97 288 A 1 
+ATOM 2324 C CG  . TYR A 1 288 ? -14.118 53.560  -11.160 1.00 80.73 288 A 1 
+ATOM 2325 C CD1 . TYR A 1 288 ? -14.379 52.269  -11.666 1.00 72.51 288 A 1 
+ATOM 2326 C CD2 . TYR A 1 288 ? -13.325 53.713  -10.007 1.00 73.87 288 A 1 
+ATOM 2327 C CE1 . TYR A 1 288 ? -13.860 51.132  -11.010 1.00 71.47 288 A 1 
+ATOM 2328 C CE2 . TYR A 1 288 ? -12.799 52.580  -9.348  1.00 71.63 288 A 1 
+ATOM 2329 C CZ  . TYR A 1 288 ? -13.070 51.288  -9.851  1.00 75.58 288 A 1 
+ATOM 2330 O OH  . TYR A 1 288 ? -12.564 50.194  -9.216  1.00 74.45 288 A 1 
+ATOM 2331 N N   . ASP A 1 289 ? -13.674 54.163  -14.827 1.00 81.23 289 A 1 
+ATOM 2332 C CA  . ASP A 1 289 ? -13.187 53.249  -15.867 1.00 81.19 289 A 1 
+ATOM 2333 C C   . ASP A 1 289 ? -11.991 53.819  -16.643 1.00 81.58 289 A 1 
+ATOM 2334 O O   . ASP A 1 289 ? -11.122 53.068  -17.103 1.00 81.27 289 A 1 
+ATOM 2335 C CB  . ASP A 1 289 ? -14.328 52.908  -16.838 1.00 81.82 289 A 1 
+ATOM 2336 C CG  . ASP A 1 289 ? -15.281 51.812  -16.337 1.00 79.83 289 A 1 
+ATOM 2337 O OD1 . ASP A 1 289 ? -14.882 51.046  -15.428 1.00 74.17 289 A 1 
+ATOM 2338 O OD2 . ASP A 1 289 ? -16.341 51.653  -16.983 1.00 75.77 289 A 1 
+ATOM 2339 N N   . GLU A 1 290 ? -11.907 55.145  -16.791 1.00 82.13 290 A 1 
+ATOM 2340 C CA  . GLU A 1 290 ? -10.744 55.810  -17.374 1.00 80.96 290 A 1 
+ATOM 2341 C C   . GLU A 1 290 ? -9.536  55.756  -16.428 1.00 80.67 290 A 1 
+ATOM 2342 O O   . GLU A 1 290 ? -8.459  55.310  -16.841 1.00 78.68 290 A 1 
+ATOM 2343 C CB  . GLU A 1 290 ? -11.105 57.240  -17.793 1.00 81.59 290 A 1 
+ATOM 2344 C CG  . GLU A 1 290 ? -9.934  57.864  -18.565 1.00 72.55 290 A 1 
+ATOM 2345 C CD  . GLU A 1 290 ? -10.254 59.203  -19.247 1.00 68.17 290 A 1 
+ATOM 2346 O OE1 . GLU A 1 290 ? -9.412  59.578  -20.103 1.00 62.02 290 A 1 
+ATOM 2347 O OE2 . GLU A 1 290 ? -11.293 59.815  -18.933 1.00 62.66 290 A 1 
+ATOM 2348 N N   . MET A 1 291 ? -9.724  56.113  -15.140 1.00 79.84 291 A 1 
+ATOM 2349 C CA  . MET A 1 291 ? -8.682  55.997  -14.111 1.00 76.98 291 A 1 
+ATOM 2350 C C   . MET A 1 291 ? -8.132  54.572  -14.022 1.00 76.98 291 A 1 
+ATOM 2351 O O   . MET A 1 291 ? -6.915  54.366  -13.987 1.00 76.40 291 A 1 
+ATOM 2352 C CB  . MET A 1 291 ? -9.241  56.410  -12.739 1.00 76.94 291 A 1 
+ATOM 2353 C CG  . MET A 1 291 ? -9.469  57.913  -12.607 1.00 75.86 291 A 1 
+ATOM 2354 S SD  . MET A 1 291 ? -10.082 58.375  -10.958 1.00 71.79 291 A 1 
+ATOM 2355 C CE  . MET A 1 291 ? -10.339 60.144  -11.219 1.00 64.07 291 A 1 
+ATOM 2356 N N   . ARG A 1 292 ? -9.021  53.584  -14.057 1.00 77.93 292 A 1 
+ATOM 2357 C CA  . ARG A 1 292 ? -8.647  52.166  -14.041 1.00 75.43 292 A 1 
+ATOM 2358 C C   . ARG A 1 292 ? -7.836  51.768  -15.274 1.00 74.97 292 A 1 
+ATOM 2359 O O   . ARG A 1 292 ? -6.852  51.048  -15.143 1.00 75.53 292 A 1 
+ATOM 2360 C CB  . ARG A 1 292 ? -9.919  51.322  -13.893 1.00 74.76 292 A 1 
+ATOM 2361 C CG  . ARG A 1 292 ? -9.603  49.822  -13.765 1.00 69.26 292 A 1 
+ATOM 2362 C CD  . ARG A 1 292 ? -10.902 49.019  -13.653 1.00 69.08 292 A 1 
+ATOM 2363 N NE  . ARG A 1 292 ? -10.632 47.567  -13.632 1.00 62.71 292 A 1 
+ATOM 2364 C CZ  . ARG A 1 292 ? -11.536 46.609  -13.724 1.00 57.81 292 A 1 
+ATOM 2365 N NH1 . ARG A 1 292 ? -12.811 46.873  -13.844 1.00 54.62 292 A 1 
+ATOM 2366 N NH2 . ARG A 1 292 ? -11.173 45.361  -13.697 1.00 51.78 292 A 1 
+ATOM 2367 N N   . ARG A 1 293 ? -8.224  52.228  -16.468 1.00 77.84 293 A 1 
+ATOM 2368 C CA  . ARG A 1 293 ? -7.489  51.959  -17.718 1.00 77.48 293 A 1 
+ATOM 2369 C C   . ARG A 1 293 ? -6.111  52.605  -17.743 1.00 77.24 293 A 1 
+ATOM 2370 O O   . ARG A 1 293 ? -5.174  52.000  -18.247 1.00 75.34 293 A 1 
+ATOM 2371 C CB  . ARG A 1 293 ? -8.310  52.420  -18.931 1.00 79.64 293 A 1 
+ATOM 2372 C CG  . ARG A 1 293 ? -9.307  51.354  -19.387 1.00 74.38 293 A 1 
+ATOM 2373 C CD  . ARG A 1 293 ? -10.102 51.821  -20.619 1.00 74.93 293 A 1 
+ATOM 2374 N NE  . ARG A 1 293 ? -11.181 52.752  -20.254 1.00 66.12 293 A 1 
+ATOM 2375 C CZ  . ARG A 1 293 ? -11.909 53.485  -21.082 1.00 59.03 293 A 1 
+ATOM 2376 N NH1 . ARG A 1 293 ? -11.679 53.514  -22.362 1.00 53.62 293 A 1 
+ATOM 2377 N NH2 . ARG A 1 293 ? -12.893 54.216  -20.627 1.00 52.71 293 A 1 
+ATOM 2378 N N   . GLN A 1 294 ? -6.000  53.830  -17.213 1.00 79.90 294 A 1 
+ATOM 2379 C CA  . GLN A 1 294 ? -4.743  54.580  -17.192 1.00 78.23 294 A 1 
+ATOM 2380 C C   . GLN A 1 294 ? -3.843  54.228  -15.998 1.00 79.07 294 A 1 
+ATOM 2381 O O   . GLN A 1 294 ? -2.674  54.602  -15.989 1.00 72.82 294 A 1 
+ATOM 2382 C CB  . GLN A 1 294 ? -5.049  56.082  -17.250 1.00 79.64 294 A 1 
+ATOM 2383 C CG  . GLN A 1 294 ? -5.718  56.496  -18.576 1.00 79.41 294 A 1 
+ATOM 2384 C CD  . GLN A 1 294 ? -5.936  58.005  -18.694 1.00 73.14 294 A 1 
+ATOM 2385 O OE1 . GLN A 1 294 ? -5.484  58.801  -17.888 1.00 67.75 294 A 1 
+ATOM 2386 N NE2 . GLN A 1 294 ? -6.625  58.466  -19.718 1.00 64.43 294 A 1 
+ATOM 2387 N N   . GLY A 1 295 ? -4.355  53.509  -14.996 1.00 78.00 295 A 1 
+ATOM 2388 C CA  . GLY A 1 295 ? -3.611  53.141  -13.787 1.00 75.24 295 A 1 
+ATOM 2389 C C   . GLY A 1 295 ? -3.307  54.331  -12.867 1.00 77.59 295 A 1 
+ATOM 2390 O O   . GLY A 1 295 ? -2.346  54.284  -12.105 1.00 72.39 295 A 1 
+ATOM 2391 N N   . VAL A 1 296 ? -4.106  55.404  -12.938 1.00 78.22 296 A 1 
+ATOM 2392 C CA  . VAL A 1 296 ? -3.928  56.632  -12.152 1.00 78.40 296 A 1 
+ATOM 2393 C C   . VAL A 1 296 ? -5.229  57.009  -11.453 1.00 79.51 296 A 1 
+ATOM 2394 O O   . VAL A 1 296 ? -6.312  56.804  -11.993 1.00 76.33 296 A 1 
+ATOM 2395 C CB  . VAL A 1 296 ? -3.409  57.805  -13.007 1.00 74.56 296 A 1 
+ATOM 2396 C CG1 . VAL A 1 296 ? -2.008  57.515  -13.571 1.00 64.41 296 A 1 
+ATOM 2397 C CG2 . VAL A 1 296 ? -4.334  58.176  -14.172 1.00 66.73 296 A 1 
+ATOM 2398 N N   . VAL A 1 297 ? -5.121  57.602  -10.251 1.00 76.22 297 A 1 
+ATOM 2399 C CA  . VAL A 1 297 ? -6.270  58.135  -9.508  1.00 75.30 297 A 1 
+ATOM 2400 C C   . VAL A 1 297 ? -6.100  59.644  -9.383  1.00 76.43 297 A 1 
+ATOM 2401 O O   . VAL A 1 297 ? -5.115  60.120  -8.817  1.00 74.46 297 A 1 
+ATOM 2402 C CB  . VAL A 1 297 ? -6.430  57.458  -8.134  1.00 72.78 297 A 1 
+ATOM 2403 C CG1 . VAL A 1 297 ? -7.655  58.021  -7.403  1.00 68.02 297 A 1 
+ATOM 2404 C CG2 . VAL A 1 297 ? -6.624  55.943  -8.265  1.00 69.09 297 A 1 
+ATOM 2405 N N   . MET A 1 298 ? -7.067  60.404  -9.898  1.00 79.12 298 A 1 
+ATOM 2406 C CA  . MET A 1 298 ? -7.098  61.862  -9.822  1.00 78.48 298 A 1 
+ATOM 2407 C C   . MET A 1 298 ? -8.259  62.306  -8.931  1.00 79.30 298 A 1 
+ATOM 2408 O O   . MET A 1 298 ? -9.412  61.995  -9.211  1.00 76.31 298 A 1 
+ATOM 2409 C CB  . MET A 1 298 ? -7.183  62.445  -11.237 1.00 75.36 298 A 1 
+ATOM 2410 C CG  . MET A 1 298 ? -7.055  63.974  -11.240 1.00 65.48 298 A 1 
+ATOM 2411 S SD  . MET A 1 298 ? -7.026  64.683  -12.910 1.00 61.77 298 A 1 
+ATOM 2412 C CE  . MET A 1 298 ? -6.901  66.435  -12.502 1.00 53.64 298 A 1 
+ATOM 2413 N N   . LEU A 1 299 ? -7.952  63.049  -7.849  1.00 77.33 299 A 1 
+ATOM 2414 C CA  . LEU A 1 299 ? -8.946  63.574  -6.917  1.00 76.39 299 A 1 
+ATOM 2415 C C   . LEU A 1 299 ? -8.868  65.099  -6.855  1.00 78.18 299 A 1 
+ATOM 2416 O O   . LEU A 1 299 ? -7.779  65.672  -6.788  1.00 74.49 299 A 1 
+ATOM 2417 C CB  . LEU A 1 299 ? -8.731  62.992  -5.515  1.00 71.84 299 A 1 
+ATOM 2418 C CG  . LEU A 1 299 ? -8.863  61.467  -5.391  1.00 69.23 299 A 1 
+ATOM 2419 C CD1 . LEU A 1 299 ? -8.636  61.122  -3.920  1.00 65.27 299 A 1 
+ATOM 2420 C CD2 . LEU A 1 299 ? -10.237 60.949  -5.810  1.00 66.53 299 A 1 
+ATOM 2421 N N   . ASN A 1 300 ? -10.027 65.747  -6.785  1.00 80.49 300 A 1 
+ATOM 2422 C CA  . ASN A 1 300 ? -10.121 67.181  -6.534  1.00 80.47 300 A 1 
+ATOM 2423 C C   . ASN A 1 300 ? -10.196 67.426  -5.022  1.00 81.52 300 A 1 
+ATOM 2424 O O   . ASN A 1 300 ? -11.197 67.107  -4.383  1.00 75.60 300 A 1 
+ATOM 2425 C CB  . ASN A 1 300 ? -11.326 67.751  -7.296  1.00 76.11 300 A 1 
+ATOM 2426 C CG  . ASN A 1 300 ? -11.109 67.761  -8.805  1.00 69.51 300 A 1 
+ATOM 2427 O OD1 . ASN A 1 300 ? -10.004 67.884  -9.296  1.00 63.41 300 A 1 
+ATOM 2428 N ND2 . ASN A 1 300 ? -12.160 67.658  -9.581  1.00 63.93 300 A 1 
+ATOM 2429 N N   . SER A 1 301 ? -9.137  68.000  -4.430  1.00 79.59 301 A 1 
+ATOM 2430 C CA  . SER A 1 301 ? -9.108  68.391  -3.017  1.00 78.64 301 A 1 
+ATOM 2431 C C   . SER A 1 301 ? -9.291  69.904  -2.872  1.00 79.41 301 A 1 
+ATOM 2432 O O   . SER A 1 301 ? -8.657  70.680  -3.584  1.00 74.77 301 A 1 
+ATOM 2433 C CB  . SER A 1 301 ? -7.811  67.937  -2.353  1.00 74.26 301 A 1 
+ATOM 2434 O OG  . SER A 1 301 ? -7.737  66.520  -2.305  1.00 68.61 301 A 1 
+ATOM 2435 N N   . SER A 1 302 ? -10.120 70.333  -1.914  1.00 81.28 302 A 1 
+ATOM 2436 C CA  . SER A 1 302 ? -10.257 71.739  -1.510  1.00 80.16 302 A 1 
+ATOM 2437 C C   . SER A 1 302 ? -9.748  71.943  -0.077  1.00 81.17 302 A 1 
+ATOM 2438 O O   . SER A 1 302 ? -9.644  70.983  0.687   1.00 75.55 302 A 1 
+ATOM 2439 C CB  . SER A 1 302 ? -11.710 72.203  -1.682  1.00 75.97 302 A 1 
+ATOM 2440 O OG  . SER A 1 302 ? -12.573 71.522  -0.798  1.00 68.34 302 A 1 
+ATOM 2441 N N   . GLU A 1 303 ? -9.435  73.210  0.326   1.00 82.39 303 A 1 
+ATOM 2442 C CA  . GLU A 1 303 ? -8.866  73.504  1.656   1.00 82.27 303 A 1 
+ATOM 2443 C C   . GLU A 1 303 ? -9.730  72.993  2.824   1.00 83.09 303 A 1 
+ATOM 2444 O O   . GLU A 1 303 ? -9.198  72.576  3.851   1.00 75.76 303 A 1 
+ATOM 2445 C CB  . GLU A 1 303 ? -8.631  75.013  1.825   1.00 78.76 303 A 1 
+ATOM 2446 C CG  . GLU A 1 303 ? -7.412  75.533  1.046   1.00 72.35 303 A 1 
+ATOM 2447 C CD  . GLU A 1 303 ? -7.073  77.002  1.370   1.00 65.84 303 A 1 
+ATOM 2448 O OE1 . GLU A 1 303 ? -5.881  77.358  1.231   1.00 61.49 303 A 1 
+ATOM 2449 O OE2 . GLU A 1 303 ? -8.004  77.751  1.737   1.00 62.20 303 A 1 
+ATOM 2450 N N   . ASN A 1 304 ? -11.068 72.984  2.646   1.00 83.28 304 A 1 
+ATOM 2451 C CA  . ASN A 1 304 ? -12.018 72.551  3.677   1.00 81.85 304 A 1 
+ATOM 2452 C C   . ASN A 1 304 ? -12.497 71.094  3.526   1.00 82.75 304 A 1 
+ATOM 2453 O O   . ASN A 1 304 ? -13.130 70.569  4.439   1.00 78.14 304 A 1 
+ATOM 2454 C CB  . ASN A 1 304 ? -13.193 73.543  3.687   1.00 79.88 304 A 1 
+ATOM 2455 C CG  . ASN A 1 304 ? -12.798 74.922  4.205   1.00 76.81 304 A 1 
+ATOM 2456 O OD1 . ASN A 1 304 ? -11.887 75.096  4.989   1.00 69.99 304 A 1 
+ATOM 2457 N ND2 . ASN A 1 304 ? -13.488 75.959  3.791   1.00 71.29 304 A 1 
+ATOM 2458 N N   . LEU A 1 305 ? -12.222 70.437  2.386   1.00 80.75 305 A 1 
+ATOM 2459 C CA  . LEU A 1 305 ? -12.633 69.063  2.086   1.00 81.23 305 A 1 
+ATOM 2460 C C   . LEU A 1 305 ? -11.480 68.338  1.386   1.00 82.25 305 A 1 
+ATOM 2461 O O   . LEU A 1 305 ? -11.329 68.403  0.165   1.00 77.54 305 A 1 
+ATOM 2462 C CB  . LEU A 1 305 ? -13.915 69.083  1.227   1.00 78.80 305 A 1 
+ATOM 2463 C CG  . LEU A 1 305 ? -15.210 69.278  2.040   1.00 73.25 305 A 1 
+ATOM 2464 C CD1 . LEU A 1 305 ? -16.327 69.790  1.137   1.00 68.45 305 A 1 
+ATOM 2465 C CD2 . LEU A 1 305 ? -15.663 67.961  2.675   1.00 69.69 305 A 1 
+ATOM 2466 N N   . LYS A 1 306 ? -10.648 67.687  2.191   1.00 82.81 306 A 1 
+ATOM 2467 C CA  . LYS A 1 306 ? -9.553  66.869  1.662   1.00 83.11 306 A 1 
+ATOM 2468 C C   . LYS A 1 306 ? -10.104 65.541  1.156   1.00 84.17 306 A 1 
+ATOM 2469 O O   . LYS A 1 306 ? -10.640 64.759  1.945   1.00 79.53 306 A 1 
+ATOM 2470 C CB  . LYS A 1 306 ? -8.460  66.663  2.712   1.00 78.76 306 A 1 
+ATOM 2471 C CG  . LYS A 1 306 ? -7.725  67.975  3.017   1.00 73.02 306 A 1 
+ATOM 2472 C CD  . LYS A 1 306 ? -6.533  67.734  3.950   1.00 67.25 306 A 1 
+ATOM 2473 C CE  . LYS A 1 306 ? -5.822  69.063  4.200   1.00 61.33 306 A 1 
+ATOM 2474 N NZ  . LYS A 1 306 ? -4.619  68.898  5.050   1.00 51.56 306 A 1 
+ATOM 2475 N N   . SER A 1 307 ? -9.955  65.303  -0.142  1.00 81.90 307 A 1 
+ATOM 2476 C CA  . SER A 1 307 ? -10.218 63.997  -0.743  1.00 80.73 307 A 1 
+ATOM 2477 C C   . SER A 1 307 ? -9.014  63.077  -0.544  1.00 81.35 307 A 1 
+ATOM 2478 O O   . SER A 1 307 ? -7.869  63.516  -0.633  1.00 78.49 307 A 1 
+ATOM 2479 C CB  . SER A 1 307 ? -10.547 64.139  -2.226  1.00 78.12 307 A 1 
+ATOM 2480 O OG  . SER A 1 307 ? -11.666 64.994  -2.405  1.00 70.96 307 A 1 
+ATOM 2481 N N   . ASP A 1 308 ? -9.276  61.814  -0.266  1.00 84.07 308 A 1 
+ATOM 2482 C CA  . ASP A 1 308 ? -8.253  60.794  -0.026  1.00 83.55 308 A 1 
+ATOM 2483 C C   . ASP A 1 308 ? -8.697  59.449  -0.621  1.00 83.38 308 A 1 
+ATOM 2484 O O   . ASP A 1 308 ? -9.896  59.189  -0.763  1.00 80.25 308 A 1 
+ATOM 2485 C CB  . ASP A 1 308 ? -7.987  60.700  1.495   1.00 81.28 308 A 1 
+ATOM 2486 C CG  . ASP A 1 308 ? -6.739  59.899  1.891   1.00 79.70 308 A 1 
+ATOM 2487 O OD1 . ASP A 1 308 ? -5.909  59.611  1.008   1.00 74.39 308 A 1 
+ATOM 2488 O OD2 . ASP A 1 308 ? -6.628  59.586  3.102   1.00 74.75 308 A 1 
+ATOM 2489 N N   . VAL A 1 309 ? -7.743  58.604  -0.973  1.00 83.24 309 A 1 
+ATOM 2490 C CA  . VAL A 1 309 ? -7.979  57.230  -1.426  1.00 82.22 309 A 1 
+ATOM 2491 C C   . VAL A 1 309 ? -7.304  56.282  -0.465  1.00 83.14 309 A 1 
+ATOM 2492 O O   . VAL A 1 309 ? -6.099  56.369  -0.241  1.00 80.87 309 A 1 
+ATOM 2493 C CB  . VAL A 1 309 ? -7.486  56.968  -2.858  1.00 79.84 309 A 1 
+ATOM 2494 C CG1 . VAL A 1 309 ? -7.727  55.516  -3.292  1.00 72.10 309 A 1 
+ATOM 2495 C CG2 . VAL A 1 309 ? -8.242  57.840  -3.848  1.00 73.87 309 A 1 
+ATOM 2496 N N   . LYS A 1 310 ? -8.067  55.349  0.059   1.00 80.76 310 A 1 
+ATOM 2497 C CA  . LYS A 1 310 ? -7.551  54.304  0.939   1.00 79.32 310 A 1 
+ATOM 2498 C C   . LYS A 1 310 ? -7.938  52.934  0.420   1.00 79.92 310 A 1 
+ATOM 2499 O O   . LYS A 1 310 ? -9.033  52.737  -0.093  1.00 76.70 310 A 1 
+ATOM 2500 C CB  . LYS A 1 310 ? -8.035  54.520  2.377   1.00 77.52 310 A 1 
+ATOM 2501 C CG  . LYS A 1 310 ? -7.456  55.824  2.942   1.00 75.98 310 A 1 
+ATOM 2502 C CD  . LYS A 1 310 ? -7.786  55.990  4.423   1.00 72.95 310 A 1 
+ATOM 2503 C CE  . LYS A 1 310 ? -7.156  57.315  4.854   1.00 67.53 310 A 1 
+ATOM 2504 N NZ  . LYS A 1 310 ? -7.388  57.603  6.284   1.00 58.01 310 A 1 
+ATOM 2505 N N   . THR A 1 311 ? -7.056  51.992  0.615   1.00 80.69 311 A 1 
+ATOM 2506 C CA  . THR A 1 311 ? -7.366  50.580  0.415   1.00 79.26 311 A 1 
+ATOM 2507 C C   . THR A 1 311 ? -7.798  49.964  1.741   1.00 79.57 311 A 1 
+ATOM 2508 O O   . THR A 1 311 ? -7.121  50.123  2.757   1.00 75.57 311 A 1 
+ATOM 2509 C CB  . THR A 1 311 ? -6.181  49.826  -0.200  1.00 75.39 311 A 1 
+ATOM 2510 O OG1 . THR A 1 311 ? -4.993  50.103  0.503   1.00 67.72 311 A 1 
+ATOM 2511 C CG2 . THR A 1 311 ? -5.941  50.252  -1.650  1.00 66.89 311 A 1 
+ATOM 2512 N N   . ILE A 1 312 ? -8.937  49.279  1.745   1.00 76.49 312 A 1 
+ATOM 2513 C CA  . ILE A 1 312 ? -9.311  48.416  2.868   1.00 74.33 312 A 1 
+ATOM 2514 C C   . ILE A 1 312 ? -8.711  47.047  2.590   1.00 74.31 312 A 1 
+ATOM 2515 O O   . ILE A 1 312 ? -9.209  46.295  1.749   1.00 70.63 312 A 1 
+ATOM 2516 C CB  . ILE A 1 312 ? -10.835 48.359  3.097   1.00 71.87 312 A 1 
+ATOM 2517 C CG1 . ILE A 1 312 ? -11.368 49.772  3.433   1.00 69.53 312 A 1 
+ATOM 2518 C CG2 . ILE A 1 312 ? -11.156 47.376  4.241   1.00 68.02 312 A 1 
+ATOM 2519 C CD1 . ILE A 1 312 ? -12.871 49.822  3.731   1.00 62.54 312 A 1 
+ATOM 2520 N N   . VAL A 1 313 ? -7.650  46.760  3.316   1.00 75.08 313 A 1 
+ATOM 2521 C CA  . VAL A 1 313 ? -6.985  45.459  3.269   1.00 73.33 313 A 1 
+ATOM 2522 C C   . VAL A 1 313 ? -6.836  44.965  4.699   1.00 75.16 313 A 1 
+ATOM 2523 O O   . VAL A 1 313 ? -6.269  45.665  5.539   1.00 70.38 313 A 1 
+ATOM 2524 C CB  . VAL A 1 313 ? -5.618  45.523  2.566   1.00 67.69 313 A 1 
+ATOM 2525 C CG1 . VAL A 1 313 ? -5.154  44.105  2.234   1.00 59.57 313 A 1 
+ATOM 2526 C CG2 . VAL A 1 313 ? -5.648  46.314  1.250   1.00 60.43 313 A 1 
+ATOM 2527 N N   . ASN A 1 314 ? -7.358  43.788  4.972   1.00 75.77 314 A 1 
+ATOM 2528 C CA  . ASN A 1 314 ? -7.082  43.064  6.203   1.00 74.92 314 A 1 
+ATOM 2529 C C   . ASN A 1 314 ? -6.149  41.910  5.833   1.00 76.81 314 A 1 
+ATOM 2530 O O   . ASN A 1 314 ? -6.616  40.929  5.256   1.00 71.56 314 A 1 
+ATOM 2531 C CB  . ASN A 1 314 ? -8.407  42.614  6.835   1.00 69.12 314 A 1 
+ATOM 2532 C CG  . ASN A 1 314 ? -8.205  42.091  8.245   1.00 62.93 314 A 1 
+ATOM 2533 O OD1 . ASN A 1 314 ? -7.247  42.418  8.922   1.00 58.13 314 A 1 
+ATOM 2534 N ND2 . ASN A 1 314 ? -9.127  41.317  8.757   1.00 57.25 314 A 1 
+ATOM 2535 N N   . GLN A 1 315 ? -4.861  42.096  6.055   1.00 75.06 315 A 1 
+ATOM 2536 C CA  . GLN A 1 315 ? -3.843  41.118  5.684   1.00 75.10 315 A 1 
+ATOM 2537 C C   . GLN A 1 315 ? -3.629  40.136  6.828   1.00 77.47 315 A 1 
+ATOM 2538 O O   . GLN A 1 315 ? -3.416  40.547  7.973   1.00 72.19 315 A 1 
+ATOM 2539 C CB  . GLN A 1 315 ? -2.520  41.808  5.305   1.00 68.91 315 A 1 
+ATOM 2540 C CG  . GLN A 1 315 ? -2.658  42.603  4.002   1.00 61.93 315 A 1 
+ATOM 2541 C CD  . GLN A 1 315 ? -1.386  43.314  3.552   1.00 58.51 315 A 1 
+ATOM 2542 O OE1 . GLN A 1 315 ? -0.417  43.489  4.260   1.00 53.50 315 A 1 
+ATOM 2543 N NE2 . GLN A 1 315 ? -1.349  43.793  2.330   1.00 49.78 315 A 1 
+ATOM 2544 N N   . LEU A 1 316 ? -3.644  38.857  6.518   1.00 76.83 316 A 1 
+ATOM 2545 C CA  . LEU A 1 316 ? -3.168  37.829  7.426   1.00 77.42 316 A 1 
+ATOM 2546 C C   . LEU A 1 316 ? -1.635  37.875  7.505   1.00 80.63 316 A 1 
+ATOM 2547 O O   . LEU A 1 316 ? -0.940  38.131  6.519   1.00 78.14 316 A 1 
+ATOM 2548 C CB  . LEU A 1 316 ? -3.671  36.450  6.973   1.00 73.03 316 A 1 
+ATOM 2549 C CG  . LEU A 1 316 ? -5.198  36.260  7.077   1.00 67.29 316 A 1 
+ATOM 2550 C CD1 . LEU A 1 316 ? -5.604  34.942  6.419   1.00 63.55 316 A 1 
+ATOM 2551 C CD2 . LEU A 1 316 ? -5.674  36.228  8.530   1.00 62.60 316 A 1 
+ATOM 2552 N N   . ASP A 1 317 ? -1.105  37.572  8.685   1.00 80.98 317 A 1 
+ATOM 2553 C CA  . ASP A 1 317 ? 0.335   37.350  8.833   1.00 82.42 317 A 1 
+ATOM 2554 C C   . ASP A 1 317 ? 0.743   36.052  8.115   1.00 83.21 317 A 1 
+ATOM 2555 O O   . ASP A 1 317 ? 0.635   34.948  8.658   1.00 80.25 317 A 1 
+ATOM 2556 C CB  . ASP A 1 317 ? 0.746   37.340  10.314  1.00 80.82 317 A 1 
+ATOM 2557 C CG  . ASP A 1 317 ? 2.241   37.019  10.499  1.00 81.68 317 A 1 
+ATOM 2558 O OD1 . ASP A 1 317 ? 3.013   37.095  9.508   1.00 76.09 317 A 1 
+ATOM 2559 O OD2 . ASP A 1 317 ? 2.608   36.642  11.629  1.00 76.43 317 A 1 
+ATOM 2560 N N   . GLN A 1 318 ? 1.223   36.197  6.887   1.00 83.23 318 A 1 
+ATOM 2561 C CA  . GLN A 1 318 ? 1.644   35.077  6.045   1.00 82.54 318 A 1 
+ATOM 2562 C C   . GLN A 1 318 ? 2.792   34.260  6.665   1.00 85.50 318 A 1 
+ATOM 2563 O O   . GLN A 1 318 ? 2.854   33.051  6.441   1.00 84.23 318 A 1 
+ATOM 2564 C CB  . GLN A 1 318 ? 2.032   35.601  4.652   1.00 79.53 318 A 1 
+ATOM 2565 C CG  . GLN A 1 318 ? 0.831   36.180  3.873   1.00 74.98 318 A 1 
+ATOM 2566 C CD  . GLN A 1 318 ? -0.231  35.133  3.528   1.00 71.33 318 A 1 
+ATOM 2567 O OE1 . GLN A 1 318 ? 0.067   33.969  3.293   1.00 64.70 318 A 1 
+ATOM 2568 N NE2 . GLN A 1 318 ? -1.492  35.492  3.474   1.00 61.71 318 A 1 
+ATOM 2569 N N   . ASN A 1 319 ? 3.665   34.883  7.453   1.00 85.53 319 A 1 
+ATOM 2570 C CA  . ASN A 1 319 ? 4.747   34.168  8.132   1.00 86.56 319 A 1 
+ATOM 2571 C C   . ASN A 1 319 ? 4.205   33.309  9.280   1.00 88.66 319 A 1 
+ATOM 2572 O O   . ASN A 1 319 ? 4.529   32.125  9.361   1.00 87.49 319 A 1 
+ATOM 2573 C CB  . ASN A 1 319 ? 5.804   35.164  8.640   1.00 85.24 319 A 1 
+ATOM 2574 C CG  . ASN A 1 319 ? 6.619   35.802  7.529   1.00 80.59 319 A 1 
+ATOM 2575 O OD1 . ASN A 1 319 ? 6.889   35.231  6.488   1.00 72.98 319 A 1 
+ATOM 2576 N ND2 . ASN A 1 319 ? 7.069   37.020  7.730   1.00 72.71 319 A 1 
+ATOM 2577 N N   . GLY A 1 320 ? 3.331   33.882  10.120  1.00 90.19 320 A 1 
+ATOM 2578 C CA  . GLY A 1 320 ? 2.648   33.136  11.181  1.00 89.80 320 A 1 
+ATOM 2579 C C   . GLY A 1 320 ? 1.780   32.004  10.634  1.00 90.99 320 A 1 
+ATOM 2580 O O   . GLY A 1 320 ? 1.834   30.879  11.135  1.00 89.48 320 A 1 
+ATOM 2581 N N   . MET A 1 321 ? 1.042   32.261  9.543   1.00 90.26 321 A 1 
+ATOM 2582 C CA  . MET A 1 321 ? 0.250   31.220  8.880   1.00 90.52 321 A 1 
+ATOM 2583 C C   . MET A 1 321 ? 1.116   30.123  8.246   1.00 91.83 321 A 1 
+ATOM 2584 O O   . MET A 1 321 ? 0.701   28.968  8.208   1.00 90.66 321 A 1 
+ATOM 2585 C CB  . MET A 1 321 ? -0.653  31.840  7.809   1.00 88.08 321 A 1 
+ATOM 2586 C CG  . MET A 1 321 ? -1.773  32.728  8.380   1.00 80.75 321 A 1 
+ATOM 2587 S SD  . MET A 1 321 ? -2.962  31.894  9.470   1.00 74.99 321 A 1 
+ATOM 2588 C CE  . MET A 1 321 ? -2.353  32.420  11.094  1.00 63.94 321 A 1 
+ATOM 2589 N N   . ASN A 1 322 ? 2.301   30.462  7.743   1.00 91.61 322 A 1 
+ATOM 2590 C CA  . ASN A 1 322 ? 3.231   29.463  7.215   1.00 91.32 322 A 1 
+ATOM 2591 C C   . ASN A 1 322 ? 3.792   28.564  8.322   1.00 92.46 322 A 1 
+ATOM 2592 O O   . ASN A 1 322 ? 3.835   27.353  8.141   1.00 92.22 322 A 1 
+ATOM 2593 C CB  . ASN A 1 322 ? 4.358   30.157  6.446   1.00 89.44 322 A 1 
+ATOM 2594 C CG  . ASN A 1 322 ? 5.182   29.133  5.685   1.00 84.40 322 A 1 
+ATOM 2595 O OD1 . ASN A 1 322 ? 4.689   28.503  4.754   1.00 76.77 322 A 1 
+ATOM 2596 N ND2 . ASN A 1 322 ? 6.425   28.933  6.047   1.00 75.87 322 A 1 
+ATOM 2597 N N   . LEU A 1 323 ? 4.169   29.154  9.455   1.00 92.39 323 A 1 
+ATOM 2598 C CA  . LEU A 1 323 ? 4.626   28.396  10.621  1.00 92.82 323 A 1 
+ATOM 2599 C C   . LEU A 1 323 ? 3.526   27.450  11.114  1.00 93.58 323 A 1 
+ATOM 2600 O O   . LEU A 1 323 ? 3.775   26.261  11.280  1.00 93.36 323 A 1 
+ATOM 2601 C CB  . LEU A 1 323 ? 5.076   29.381  11.711  1.00 92.24 323 A 1 
+ATOM 2602 C CG  . LEU A 1 323 ? 5.605   28.697  12.988  1.00 82.89 323 A 1 
+ATOM 2603 C CD1 . LEU A 1 323 ? 6.873   27.880  12.713  1.00 77.71 323 A 1 
+ATOM 2604 C CD2 . LEU A 1 323 ? 5.936   29.764  14.034  1.00 79.41 323 A 1 
+ATOM 2605 N N   . PHE A 1 324 ? 2.294   27.955  11.242  1.00 93.61 324 A 1 
+ATOM 2606 C CA  . PHE A 1 324 ? 1.162   27.123  11.648  1.00 93.96 324 A 1 
+ATOM 2607 C C   . PHE A 1 324 ? 0.858   25.995  10.644  1.00 94.73 324 A 1 
+ATOM 2608 O O   . PHE A 1 324 ? 0.559   24.873  11.048  1.00 94.53 324 A 1 
+ATOM 2609 C CB  . PHE A 1 324 ? -0.060  28.026  11.864  1.00 93.88 324 A 1 
+ATOM 2610 C CG  . PHE A 1 324 ? -1.270  27.291  12.413  1.00 93.92 324 A 1 
+ATOM 2611 C CD1 . PHE A 1 324 ? -2.498  27.317  11.724  1.00 89.98 324 A 1 
+ATOM 2612 C CD2 . PHE A 1 324 ? -1.162  26.564  13.613  1.00 91.11 324 A 1 
+ATOM 2613 C CE1 . PHE A 1 324 ? -3.609  26.623  12.232  1.00 90.66 324 A 1 
+ATOM 2614 C CE2 . PHE A 1 324 ? -2.271  25.859  14.118  1.00 90.73 324 A 1 
+ATOM 2615 C CZ  . PHE A 1 324 ? -3.497  25.890  13.427  1.00 92.29 324 A 1 
+ATOM 2616 N N   . ALA A 1 325 ? 0.970   26.253  9.339   1.00 94.34 325 A 1 
+ATOM 2617 C CA  . ALA A 1 325 ? 0.829   25.209  8.322   1.00 93.93 325 A 1 
+ATOM 2618 C C   . ALA A 1 325 ? 1.886   24.106  8.483   1.00 94.65 325 A 1 
+ATOM 2619 O O   . ALA A 1 325 ? 1.542   22.926  8.422   1.00 94.37 325 A 1 
+ATOM 2620 C CB  . ALA A 1 325 ? 0.899   25.843  6.922   1.00 92.73 325 A 1 
+ATOM 2621 N N   . GLN A 1 326 ? 3.142   24.489  8.729   1.00 94.15 326 A 1 
+ATOM 2622 C CA  . GLN A 1 326 ? 4.235   23.546  8.979   1.00 93.60 326 A 1 
+ATOM 2623 C C   . GLN A 1 326 ? 3.986   22.722  10.248  1.00 94.28 326 A 1 
+ATOM 2624 O O   . GLN A 1 326 ? 4.112   21.500  10.205  1.00 93.87 326 A 1 
+ATOM 2625 C CB  . GLN A 1 326 ? 5.566   24.307  9.083   1.00 92.30 326 A 1 
+ATOM 2626 C CG  . GLN A 1 326 ? 6.037   24.832  7.719   1.00 86.19 326 A 1 
+ATOM 2627 C CD  . GLN A 1 326 ? 7.269   25.734  7.801   1.00 84.14 326 A 1 
+ATOM 2628 O OE1 . GLN A 1 326 ? 7.683   26.240  8.827   1.00 78.92 326 A 1 
+ATOM 2629 N NE2 . GLN A 1 326 ? 7.912   25.994  6.682   1.00 75.02 326 A 1 
+ATOM 2630 N N   . GLU A 1 327 ? 3.543   23.358  11.335  1.00 94.68 327 A 1 
+ATOM 2631 C CA  . GLU A 1 327 ? 3.183   22.660  12.576  1.00 94.85 327 A 1 
+ATOM 2632 C C   . GLU A 1 327 ? 2.066   21.622  12.353  1.00 95.30 327 A 1 
+ATOM 2633 O O   . GLU A 1 327 ? 2.149   20.501  12.855  1.00 94.86 327 A 1 
+ATOM 2634 C CB  . GLU A 1 327 ? 2.722   23.675  13.637  1.00 94.63 327 A 1 
+ATOM 2635 C CG  . GLU A 1 327 ? 3.861   24.524  14.231  1.00 85.82 327 A 1 
+ATOM 2636 C CD  . GLU A 1 327 ? 3.365   25.616  15.203  1.00 83.02 327 A 1 
+ATOM 2637 O OE1 . GLU A 1 327 ? 4.223   26.362  15.726  1.00 72.35 327 A 1 
+ATOM 2638 O OE2 . GLU A 1 327 ? 2.134   25.711  15.437  1.00 76.11 327 A 1 
+ATOM 2639 N N   . LEU A 1 328 ? 1.028   21.959  11.571  1.00 96.52 328 A 1 
+ATOM 2640 C CA  . LEU A 1 328 ? -0.039  21.009  11.234  1.00 96.73 328 A 1 
+ATOM 2641 C C   . LEU A 1 328 ? 0.477   19.827  10.397  1.00 96.76 328 A 1 
+ATOM 2642 O O   . LEU A 1 328 ? 0.065   18.689  10.634  1.00 96.52 328 A 1 
+ATOM 2643 C CB  . LEU A 1 328 ? -1.176  21.727  10.486  1.00 96.85 328 A 1 
+ATOM 2644 C CG  . LEU A 1 328 ? -2.023  22.718  11.304  1.00 95.74 328 A 1 
+ATOM 2645 C CD1 . LEU A 1 328 ? -3.083  23.323  10.374  1.00 93.92 328 A 1 
+ATOM 2646 C CD2 . LEU A 1 328 ? -2.745  22.069  12.480  1.00 93.69 328 A 1 
+ATOM 2647 N N   . GLU A 1 329 ? 1.365   20.071  9.436   1.00 96.29 329 A 1 
+ATOM 2648 C CA  . GLU A 1 329 ? 1.980   19.003  8.636   1.00 95.90 329 A 1 
+ATOM 2649 C C   . GLU A 1 329 ? 2.899   18.107  9.482   1.00 95.79 329 A 1 
+ATOM 2650 O O   . GLU A 1 329 ? 2.852   16.883  9.352   1.00 94.81 329 A 1 
+ATOM 2651 C CB  . GLU A 1 329 ? 2.754   19.588  7.447   1.00 95.06 329 A 1 
+ATOM 2652 C CG  . GLU A 1 329 ? 1.831   20.116  6.336   1.00 90.14 329 A 1 
+ATOM 2653 C CD  . GLU A 1 329 ? 2.583   20.609  5.084   1.00 87.52 329 A 1 
+ATOM 2654 O OE1 . GLU A 1 329 ? 1.888   21.114  4.165   1.00 77.46 329 A 1 
+ATOM 2655 O OE2 . GLU A 1 329 ? 3.822   20.423  5.003   1.00 79.09 329 A 1 
+ATOM 2656 N N   . GLU A 1 330 ? 3.690   18.687  10.382  1.00 94.60 330 A 1 
+ATOM 2657 C CA  . GLU A 1 330 ? 4.529   17.929  11.319  1.00 93.98 330 A 1 
+ATOM 2658 C C   . GLU A 1 330 ? 3.685   17.062  12.264  1.00 94.61 330 A 1 
+ATOM 2659 O O   . GLU A 1 330 ? 3.973   15.875  12.446  1.00 93.78 330 A 1 
+ATOM 2660 C CB  . GLU A 1 330 ? 5.417   18.882  12.135  1.00 92.34 330 A 1 
+ATOM 2661 C CG  . GLU A 1 330 ? 6.582   19.447  11.305  1.00 82.69 330 A 1 
+ATOM 2662 C CD  . GLU A 1 330 ? 7.497   20.394  12.103  1.00 79.04 330 A 1 
+ATOM 2663 O OE1 . GLU A 1 330 ? 8.444   20.930  11.479  1.00 70.17 330 A 1 
+ATOM 2664 O OE2 . GLU A 1 330 ? 7.287   20.539  13.331  1.00 70.60 330 A 1 
+ATOM 2665 N N   . LEU A 1 331 ? 2.594   17.621  12.802  1.00 96.04 331 A 1 
+ATOM 2666 C CA  . LEU A 1 331 ? 1.630   16.864  13.603  1.00 96.35 331 A 1 
+ATOM 2667 C C   . LEU A 1 331 ? 1.002   15.724  12.797  1.00 96.53 331 A 1 
+ATOM 2668 O O   . LEU A 1 331 ? 0.891   14.610  13.310  1.00 96.12 331 A 1 
+ATOM 2669 C CB  . LEU A 1 331 ? 0.535   17.809  14.131  1.00 96.27 331 A 1 
+ATOM 2670 C CG  . LEU A 1 331 ? 0.979   18.712  15.295  1.00 88.83 331 A 1 
+ATOM 2671 C CD1 . LEU A 1 331 ? -0.120  19.741  15.580  1.00 85.18 331 A 1 
+ATOM 2672 C CD2 . LEU A 1 331 ? 1.225   17.915  16.580  1.00 86.05 331 A 1 
+ATOM 2673 N N   . LEU A 1 332 ? 0.629   15.975  11.543  1.00 96.97 332 A 1 
+ATOM 2674 C CA  . LEU A 1 332 ? 0.092   14.943  10.653  1.00 97.11 332 A 1 
+ATOM 2675 C C   . LEU A 1 332 ? 1.092   13.795  10.469  1.00 96.88 332 A 1 
+ATOM 2676 O O   . LEU A 1 332 ? 0.732   12.628  10.645  1.00 96.40 332 A 1 
+ATOM 2677 C CB  . LEU A 1 332 ? -0.298  15.583  9.305   1.00 97.31 332 A 1 
+ATOM 2678 C CG  . LEU A 1 332 ? -0.822  14.587  8.252   1.00 96.93 332 A 1 
+ATOM 2679 C CD1 . LEU A 1 332 ? -2.128  13.926  8.686   1.00 95.52 332 A 1 
+ATOM 2680 C CD2 . LEU A 1 332 ? -1.068  15.302  6.928   1.00 95.49 332 A 1 
+ATOM 2681 N N   . TYR A 1 333 ? 2.339   14.107  10.159  1.00 96.39 333 A 1 
+ATOM 2682 C CA  . TYR A 1 333 ? 3.372   13.095  9.937   1.00 95.83 333 A 1 
+ATOM 2683 C C   . TYR A 1 333 ? 3.699   12.316  11.209  1.00 95.88 333 A 1 
+ATOM 2684 O O   . TYR A 1 333 ? 3.820   11.092  11.146  1.00 94.80 333 A 1 
+ATOM 2685 C CB  . TYR A 1 333 ? 4.628   13.749  9.343   1.00 94.51 333 A 1 
+ATOM 2686 C CG  . TYR A 1 333 ? 4.450   14.448  8.002   1.00 92.50 333 A 1 
+ATOM 2687 C CD1 . TYR A 1 333 ? 3.407   14.091  7.122   1.00 86.74 333 A 1 
+ATOM 2688 C CD2 . TYR A 1 333 ? 5.338   15.477  7.642   1.00 86.22 333 A 1 
+ATOM 2689 C CE1 . TYR A 1 333 ? 3.241   14.772  5.898   1.00 83.84 333 A 1 
+ATOM 2690 C CE2 . TYR A 1 333 ? 5.182   16.156  6.418   1.00 83.89 333 A 1 
+ATOM 2691 C CZ  . TYR A 1 333 ? 4.127   15.809  5.547   1.00 83.73 333 A 1 
+ATOM 2692 O OH  . TYR A 1 333 ? 3.969   16.476  4.373   1.00 81.72 333 A 1 
+ATOM 2693 N N   . SER A 1 334 ? 3.749   12.996  12.353  1.00 94.71 334 A 1 
+ATOM 2694 C CA  . SER A 1 334 ? 3.971   12.369  13.658  1.00 94.33 334 A 1 
+ATOM 2695 C C   . SER A 1 334 ? 2.821   11.436  14.058  1.00 94.85 334 A 1 
+ATOM 2696 O O   . SER A 1 334 ? 3.065   10.309  14.483  1.00 93.74 334 A 1 
+ATOM 2697 C CB  . SER A 1 334 ? 4.174   13.462  14.707  1.00 92.91 334 A 1 
+ATOM 2698 O OG  . SER A 1 334 ? 4.418   12.894  15.977  1.00 78.87 334 A 1 
+ATOM 2699 N N   . LEU A 1 335 ? 1.559   11.863  13.878  1.00 96.16 335 A 1 
+ATOM 2700 C CA  . LEU A 1 335 ? 0.389   11.046  14.234  1.00 96.48 335 A 1 
+ATOM 2701 C C   . LEU A 1 335 ? 0.238   9.808   13.348  1.00 96.49 335 A 1 
+ATOM 2702 O O   . LEU A 1 335 ? -0.194  8.760   13.830  1.00 95.76 335 A 1 
+ATOM 2703 C CB  . LEU A 1 335 ? -0.883  11.907  14.137  1.00 96.64 335 A 1 
+ATOM 2704 C CG  . LEU A 1 335 ? -1.046  12.933  15.267  1.00 95.62 335 A 1 
+ATOM 2705 C CD1 . LEU A 1 335 ? -2.232  13.845  14.949  1.00 93.42 335 A 1 
+ATOM 2706 C CD2 . LEU A 1 335 ? -1.313  12.265  16.619  1.00 93.32 335 A 1 
+ATOM 2707 N N   . VAL A 1 336 ? 0.566   9.932   12.070  1.00 96.81 336 A 1 
+ATOM 2708 C CA  . VAL A 1 336 ? 0.501   8.813   11.123  1.00 96.73 336 A 1 
+ATOM 2709 C C   . VAL A 1 336 ? 1.764   7.951   11.192  1.00 96.39 336 A 1 
+ATOM 2710 O O   . VAL A 1 336 ? 1.724   6.788   10.803  1.00 93.77 336 A 1 
+ATOM 2711 C CB  . VAL A 1 336 ? 0.222   9.330   9.700   1.00 96.11 336 A 1 
+ATOM 2712 C CG1 . VAL A 1 336 ? 0.137   8.205   8.668   1.00 91.27 336 A 1 
+ATOM 2713 C CG2 . VAL A 1 336 ? -1.121  10.069  9.638   1.00 90.94 336 A 1 
+ATOM 2714 N N   . GLY A 1 337 ? 2.876   8.482   11.698  1.00 95.10 337 A 1 
+ATOM 2715 C CA  . GLY A 1 337 ? 4.174   7.807   11.771  1.00 94.33 337 A 1 
+ATOM 2716 C C   . GLY A 1 337 ? 4.846   7.639   10.407  1.00 94.37 337 A 1 
+ATOM 2717 O O   . GLY A 1 337 ? 5.441   6.601   10.124  1.00 92.22 337 A 1 
+ATOM 2718 N N   . VAL A 1 338 ? 4.720   8.629   9.525   1.00 94.82 338 A 1 
+ATOM 2719 C CA  . VAL A 1 338 ? 5.407   8.640   8.226   1.00 94.39 338 A 1 
+ATOM 2720 C C   . VAL A 1 338 ? 6.547   9.663   8.214   1.00 93.56 338 A 1 
+ATOM 2721 O O   . VAL A 1 338 ? 6.390   10.752  8.758   1.00 90.59 338 A 1 
+ATOM 2722 C CB  . VAL A 1 338 ? 4.468   8.861   7.026   1.00 93.23 338 A 1 
+ATOM 2723 C CG1 . VAL A 1 338 ? 3.502   7.686   6.859   1.00 87.31 338 A 1 
+ATOM 2724 C CG2 . VAL A 1 338 ? 3.679   10.167  7.075   1.00 87.69 338 A 1 
+ATOM 2725 N N   . PRO A 1 339 ? 7.666   9.367   7.545   1.00 92.04 339 A 1 
+ATOM 2726 C CA  . PRO A 1 339 ? 8.796   10.284  7.491   1.00 90.39 339 A 1 
+ATOM 2727 C C   . PRO A 1 339 ? 8.435   11.644  6.884   1.00 90.64 339 A 1 
+ATOM 2728 O O   . PRO A 1 339 ? 7.813   11.714  5.810   1.00 88.82 339 A 1 
+ATOM 2729 C CB  . PRO A 1 339 ? 9.871   9.581   6.659   1.00 87.25 339 A 1 
+ATOM 2730 C CG  . PRO A 1 339 ? 9.520   8.104   6.788   1.00 84.65 339 A 1 
+ATOM 2731 C CD  . PRO A 1 339 ? 8.010   8.094   6.931   1.00 88.58 339 A 1 
+ATOM 2732 N N   . SER A 1 340 ? 8.885   12.718  7.518   1.00 87.90 340 A 1 
+ATOM 2733 C CA  . SER A 1 340 ? 8.865   14.072  6.966   1.00 85.36 340 A 1 
+ATOM 2734 C C   . SER A 1 340 ? 10.173  14.372  6.221   1.00 84.01 340 A 1 
+ATOM 2735 O O   . SER A 1 340 ? 11.201  13.722  6.426   1.00 78.69 340 A 1 
+ATOM 2736 C CB  . SER A 1 340 ? 8.564   15.097  8.071   1.00 81.64 340 A 1 
+ATOM 2737 O OG  . SER A 1 340 ? 9.615   15.125  9.004   1.00 73.37 340 A 1 
+ATOM 2738 N N   . ARG A 1 341 ? 10.135  15.345  5.312   1.00 80.64 341 A 1 
+ATOM 2739 C CA  . ARG A 1 341 ? 11.369  15.940  4.782   1.00 76.49 341 A 1 
+ATOM 2740 C C   . ARG A 1 341 ? 11.702  17.141  5.652   1.00 74.50 341 A 1 
+ATOM 2741 O O   . ARG A 1 341 ? 11.011  18.147  5.573   1.00 67.33 341 A 1 
+ATOM 2742 C CB  . ARG A 1 341 ? 11.214  16.357  3.313   1.00 72.54 341 A 1 
+ATOM 2743 C CG  . ARG A 1 341 ? 11.301  15.161  2.360   1.00 66.01 341 A 1 
+ATOM 2744 C CD  . ARG A 1 341 ? 11.273  15.674  0.917   1.00 62.22 341 A 1 
+ATOM 2745 N NE  . ARG A 1 341 ? 11.522  14.590  -0.052  1.00 57.42 341 A 1 
+ATOM 2746 C CZ  . ARG A 1 341 ? 11.649  14.738  -1.360  1.00 50.63 341 A 1 
+ATOM 2747 N NH1 . ARG A 1 341 ? 11.523  15.905  -1.934  1.00 47.89 341 A 1 
+ATOM 2748 N NH2 . ARG A 1 341 ? 11.909  13.714  -2.116  1.00 46.45 341 A 1 
+ATOM 2749 N N   . HIS A 1 342 ? 12.747  17.025  6.452   1.00 72.12 342 A 1 
+ATOM 2750 C CA  . HIS A 1 342 ? 13.220  18.154  7.243   1.00 68.40 342 A 1 
+ATOM 2751 C C   . HIS A 1 342 ? 14.308  18.910  6.465   1.00 67.01 342 A 1 
+ATOM 2752 O O   . HIS A 1 342 ? 15.302  18.308  6.055   1.00 58.08 342 A 1 
+ATOM 2753 C CB  . HIS A 1 342 ? 13.678  17.656  8.621   1.00 61.04 342 A 1 
+ATOM 2754 C CG  . HIS A 1 342 ? 13.679  18.747  9.661   1.00 53.87 342 A 1 
+ATOM 2755 N ND1 . HIS A 1 342 ? 12.575  19.258  10.304  1.00 48.13 342 A 1 
+ATOM 2756 C CD2 . HIS A 1 342 ? 14.773  19.424  10.130  1.00 46.34 342 A 1 
+ATOM 2757 C CE1 . HIS A 1 342 ? 12.996  20.220  11.139  1.00 40.46 342 A 1 
+ATOM 2758 N NE2 . HIS A 1 342 ? 14.329  20.359  11.071  1.00 41.87 342 A 1 
+ATOM 2759 N N   . ASP A 1 343 ? 14.137  20.211  6.268   1.00 53.50 343 A 1 
+ATOM 2760 C CA  . ASP A 1 343 ? 15.073  21.076  5.512   1.00 51.43 343 A 1 
+ATOM 2761 C C   . ASP A 1 343 ? 16.373  21.418  6.278   1.00 51.60 343 A 1 
+ATOM 2762 O O   . ASP A 1 343 ? 17.141  22.303  5.901   1.00 46.98 343 A 1 
+ATOM 2763 C CB  . ASP A 1 343 ? 14.330  22.347  5.025   1.00 44.65 343 A 1 
+ATOM 2764 C CG  . ASP A 1 343 ? 13.491  22.144  3.758   1.00 39.84 343 A 1 
+ATOM 2765 O OD1 . ASP A 1 343 ? 13.859  21.269  2.939   1.00 36.43 343 A 1 
+ATOM 2766 O OD2 . ASP A 1 343 ? 12.520  22.909  3.583   1.00 35.63 343 A 1 
+ATOM 2767 N N   . GLY A 1 344 ? 16.639  20.721  7.373   1.00 55.81 344 A 1 
+ATOM 2768 C CA  . GLY A 1 344 ? 17.809  20.933  8.221   1.00 54.61 344 A 1 
+ATOM 2769 C C   . GLY A 1 344 ? 18.972  20.004  7.893   1.00 55.16 344 A 1 
+ATOM 2770 O O   . GLY A 1 344 ? 19.179  19.011  8.591   1.00 50.63 344 A 1 
+ATOM 2771 N N   . ALA A 1 345 ? 19.765  20.333  6.884   1.00 51.93 345 A 1 
+ATOM 2772 C CA  . ALA A 1 345 ? 21.087  19.725  6.723   1.00 52.02 345 A 1 
+ATOM 2773 C C   . ALA A 1 345 ? 22.036  20.266  7.810   1.00 53.12 345 A 1 
+ATOM 2774 O O   . ALA A 1 345 ? 22.722  21.269  7.616   1.00 48.58 345 A 1 
+ATOM 2775 C CB  . ALA A 1 345 ? 21.599  19.979  5.297   1.00 45.89 345 A 1 
+ATOM 2776 N N   . SER A 1 346 ? 22.078  19.612  8.971   1.00 51.94 346 A 1 
+ATOM 2777 C CA  . SER A 1 346 ? 23.144  19.833  9.950   1.00 52.01 346 A 1 
+ATOM 2778 C C   . SER A 1 346 ? 24.353  18.986  9.548   1.00 52.19 346 A 1 
+ATOM 2779 O O   . SER A 1 346 ? 24.309  17.755  9.552   1.00 47.46 346 A 1 
+ATOM 2780 C CB  . SER A 1 346 ? 22.672  19.535  11.371  1.00 46.62 346 A 1 
+ATOM 2781 O OG  . SER A 1 346 ? 23.631  20.022  12.284  1.00 42.04 346 A 1 
+ATOM 2782 N N   . GLY A 1 347 ? 25.427  19.650  9.142   1.00 56.76 347 A 1 
+ATOM 2783 C CA  . GLY A 1 347 ? 26.673  18.984  8.779   1.00 57.62 347 A 1 
+ATOM 2784 C C   . GLY A 1 347 ? 27.294  18.297  9.998   1.00 59.59 347 A 1 
+ATOM 2785 O O   . GLY A 1 347 ? 27.913  18.961  10.820  1.00 54.40 347 A 1 
+ATOM 2786 N N   . GLY A 1 348 ? 27.123  16.991  10.104  1.00 59.53 348 A 1 
+ATOM 2787 C CA  . GLY A 1 348 ? 27.663  16.159  11.188  1.00 60.92 348 A 1 
+ATOM 2788 C C   . GLY A 1 348 ? 26.762  15.010  11.644  1.00 63.75 348 A 1 
+ATOM 2789 O O   . GLY A 1 348 ? 27.219  14.164  12.414  1.00 58.28 348 A 1 
+ATOM 2790 N N   . ASP A 1 349 ? 25.512  14.939  11.160  1.00 55.05 349 A 1 
+ATOM 2791 C CA  . ASP A 1 349 ? 24.587  13.865  11.522  1.00 57.50 349 A 1 
+ATOM 2792 C C   . ASP A 1 349 ? 25.016  12.522  10.903  1.00 57.85 349 A 1 
+ATOM 2793 O O   . ASP A 1 349 ? 25.280  12.405  9.704   1.00 53.81 349 A 1 
+ATOM 2794 C CB  . ASP A 1 349 ? 23.151  14.231  11.118  1.00 53.75 349 A 1 
+ATOM 2795 C CG  . ASP A 1 349 ? 22.504  15.309  12.002  1.00 49.83 349 A 1 
+ATOM 2796 O OD1 . ASP A 1 349 ? 22.940  15.458  13.164  1.00 48.82 349 A 1 
+ATOM 2797 O OD2 . ASP A 1 349 ? 21.536  15.943  11.516  1.00 49.21 349 A 1 
+ATOM 2798 N N   . THR A 1 350 ? 25.065  11.472  11.727  1.00 64.20 350 A 1 
+ATOM 2799 C CA  . THR A 1 350 ? 25.224  10.094  11.233  1.00 65.35 350 A 1 
+ATOM 2800 C C   . THR A 1 350 ? 23.942  9.644   10.529  1.00 68.05 350 A 1 
+ATOM 2801 O O   . THR A 1 350 ? 22.849  10.055  10.917  1.00 61.23 350 A 1 
+ATOM 2802 C CB  . THR A 1 350 ? 25.601  9.112   12.357  1.00 58.38 350 A 1 
+ATOM 2803 O OG1 . THR A 1 350 ? 24.598  9.056   13.344  1.00 52.60 350 A 1 
+ATOM 2804 C CG2 . THR A 1 350 ? 26.911  9.493   13.052  1.00 52.63 350 A 1 
+ATOM 2805 N N   . GLY A 1 351 ? 24.043  8.763   9.538   1.00 59.37 351 A 1 
+ATOM 2806 C CA  . GLY A 1 351 ? 22.858  8.271   8.809   1.00 60.37 351 A 1 
+ATOM 2807 C C   . GLY A 1 351 ? 21.775  7.683   9.723   1.00 63.13 351 A 1 
+ATOM 2808 O O   . GLY A 1 351 ? 20.592  7.877   9.469   1.00 59.97 351 A 1 
+ATOM 2809 N N   . LEU A 1 352 ? 22.176  7.052   10.839  1.00 60.28 352 A 1 
+ATOM 2810 C CA  . LEU A 1 352 ? 21.256  6.538   11.862  1.00 62.24 352 A 1 
+ATOM 2811 C C   . LEU A 1 352 ? 20.515  7.659   12.614  1.00 63.64 352 A 1 
+ATOM 2812 O O   . LEU A 1 352 ? 19.337  7.522   12.924  1.00 60.38 352 A 1 
+ATOM 2813 C CB  . LEU A 1 352 ? 22.067  5.675   12.849  1.00 60.33 352 A 1 
+ATOM 2814 C CG  . LEU A 1 352 ? 21.196  4.873   13.839  1.00 54.61 352 A 1 
+ATOM 2815 C CD1 . LEU A 1 352 ? 20.541  3.673   13.163  1.00 53.10 352 A 1 
+ATOM 2816 C CD2 . LEU A 1 352 ? 22.063  4.357   14.987  1.00 52.69 352 A 1 
+ATOM 2817 N N   . ALA A 1 353 ? 21.189  8.763   12.920  1.00 64.82 353 A 1 
+ATOM 2818 C CA  . ALA A 1 353 ? 20.566  9.899   13.598  1.00 65.45 353 A 1 
+ATOM 2819 C C   . ALA A 1 353 ? 19.535  10.595  12.696  1.00 66.66 353 A 1 
+ATOM 2820 O O   . ALA A 1 353 ? 18.478  10.991  13.175  1.00 65.81 353 A 1 
+ATOM 2821 C CB  . ALA A 1 353 ? 21.663  10.866  14.065  1.00 62.39 353 A 1 
+ATOM 2822 N N   . ILE A 1 354 ? 19.815  10.677  11.397  1.00 62.31 354 A 1 
+ATOM 2823 C CA  . ILE A 1 354 ? 18.871  11.186  10.390  1.00 63.92 354 A 1 
+ATOM 2824 C C   . ILE A 1 354 ? 17.653  10.263  10.295  1.00 66.40 354 A 1 
+ATOM 2825 O O   . ILE A 1 354 ? 16.522  10.733  10.367  1.00 63.50 354 A 1 
+ATOM 2826 C CB  . ILE A 1 354 ? 19.582  11.366  9.027   1.00 61.16 354 A 1 
+ATOM 2827 C CG1 . ILE A 1 354 ? 20.696  12.433  9.143   1.00 56.65 354 A 1 
+ATOM 2828 C CG2 . ILE A 1 354 ? 18.583  11.748  7.925   1.00 57.55 354 A 1 
+ATOM 2829 C CD1 . ILE A 1 354 ? 21.601  12.538  7.904   1.00 55.11 354 A 1 
+ATOM 2830 N N   . GLU A 1 355 ? 17.859  8.955   10.217  1.00 61.26 355 A 1 
+ATOM 2831 C CA  . GLU A 1 355 ? 16.775  7.965   10.133  1.00 61.25 355 A 1 
+ATOM 2832 C C   . GLU A 1 355 ? 15.832  8.023   11.348  1.00 61.93 355 A 1 
+ATOM 2833 O O   . GLU A 1 355 ? 14.610  7.982   11.190  1.00 61.26 355 A 1 
+ATOM 2834 C CB  . GLU A 1 355 ? 17.405  6.574   9.964   1.00 59.98 355 A 1 
+ATOM 2835 C CG  . GLU A 1 355 ? 16.366  5.470   9.714   1.00 54.23 355 A 1 
+ATOM 2836 C CD  . GLU A 1 355 ? 16.989  4.095   9.414   1.00 52.65 355 A 1 
+ATOM 2837 O OE1 . GLU A 1 355 ? 16.204  3.163   9.110   1.00 49.20 355 A 1 
+ATOM 2838 O OE2 . GLU A 1 355 ? 18.232  3.961   9.454   1.00 49.97 355 A 1 
+ATOM 2839 N N   . LEU A 1 356 ? 16.385  8.162   12.558  1.00 58.82 356 A 1 
+ATOM 2840 C CA  . LEU A 1 356 ? 15.594  8.303   13.783  1.00 57.90 356 A 1 
+ATOM 2841 C C   . LEU A 1 356 ? 14.869  9.653   13.860  1.00 60.87 356 A 1 
+ATOM 2842 O O   . LEU A 1 356 ? 13.720  9.697   14.288  1.00 57.29 356 A 1 
+ATOM 2843 C CB  . LEU A 1 356 ? 16.513  8.116   15.005  1.00 54.72 356 A 1 
+ATOM 2844 C CG  . LEU A 1 356 ? 16.995  6.668   15.222  1.00 51.39 356 A 1 
+ATOM 2845 C CD1 . LEU A 1 356 ? 18.059  6.649   16.322  1.00 49.75 356 A 1 
+ATOM 2846 C CD2 . LEU A 1 356 ? 15.859  5.738   15.651  1.00 50.51 356 A 1 
+ATOM 2847 N N   . ARG A 1 357 ? 15.524  10.731  13.439  1.00 58.58 357 A 1 
+ATOM 2848 C CA  . ARG A 1 357 ? 14.943  12.084  13.469  1.00 55.63 357 A 1 
+ATOM 2849 C C   . ARG A 1 357 ? 13.801  12.240  12.466  1.00 57.60 357 A 1 
+ATOM 2850 O O   . ARG A 1 357 ? 12.785  12.836  12.796  1.00 54.25 357 A 1 
+ATOM 2851 C CB  . ARG A 1 357 ? 16.056  13.106  13.195  1.00 50.58 357 A 1 
+ATOM 2852 C CG  . ARG A 1 357 ? 15.569  14.562  13.322  1.00 46.58 357 A 1 
+ATOM 2853 C CD  . ARG A 1 357 ? 16.629  15.547  12.817  1.00 46.79 357 A 1 
+ATOM 2854 N NE  . ARG A 1 357 ? 16.769  15.454  11.355  1.00 42.88 357 A 1 
+ATOM 2855 C CZ  . ARG A 1 357 ? 17.811  15.813  10.632  1.00 37.42 357 A 1 
+ATOM 2856 N NH1 . ARG A 1 357 ? 18.863  16.389  11.150  1.00 37.51 357 A 1 
+ATOM 2857 N NH2 . ARG A 1 357 ? 17.800  15.577  9.355   1.00 35.56 357 A 1 
+ATOM 2858 N N   . ASP A 1 358 ? 13.964  11.703  11.270  1.00 64.87 358 A 1 
+ATOM 2859 C CA  . ASP A 1 358 ? 13.041  11.947  10.155  1.00 63.93 358 A 1 
+ATOM 2860 C C   . ASP A 1 358 ? 11.805  11.018  10.177  1.00 67.73 358 A 1 
+ATOM 2861 O O   . ASP A 1 358 ? 10.954  11.103  9.296   1.00 62.75 358 A 1 
+ATOM 2862 C CB  . ASP A 1 358 ? 13.805  11.893  8.817   1.00 57.80 358 A 1 
+ATOM 2863 C CG  . ASP A 1 358 ? 14.889  12.974  8.625   1.00 53.41 358 A 1 
+ATOM 2864 O OD1 . ASP A 1 358 ? 15.050  13.883  9.476   1.00 50.96 358 A 1 
+ATOM 2865 O OD2 . ASP A 1 358 ? 15.597  12.890  7.592   1.00 49.36 358 A 1 
+ATOM 2866 N N   . GLY A 1 359 ? 11.682  10.132  11.177  1.00 77.63 359 A 1 
+ATOM 2867 C CA  . GLY A 1 359 ? 10.493  9.285   11.401  1.00 79.18 359 A 1 
+ATOM 2868 C C   . GLY A 1 359 ? 10.513  7.921   10.699  1.00 83.82 359 A 1 
+ATOM 2869 O O   . GLY A 1 359 ? 9.502   7.224   10.657  1.00 80.80 359 A 1 
+ATOM 2870 N N   . TRP A 1 360 ? 11.649  7.492   10.149  1.00 82.59 360 A 1 
+ATOM 2871 C CA  . TRP A 1 360 ? 11.772  6.155   9.538   1.00 83.45 360 A 1 
+ATOM 2872 C C   . TRP A 1 360 ? 11.617  5.017   10.554  1.00 85.91 360 A 1 
+ATOM 2873 O O   . TRP A 1 360 ? 11.100  3.954   10.209  1.00 85.16 360 A 1 
+ATOM 2874 C CB  . TRP A 1 360 ? 13.116  6.036   8.815   1.00 81.67 360 A 1 
+ATOM 2875 C CG  . TRP A 1 360 ? 13.216  6.850   7.565   1.00 80.14 360 A 1 
+ATOM 2876 C CD1 . TRP A 1 360 ? 13.821  8.049   7.439   1.00 76.71 360 A 1 
+ATOM 2877 C CD2 . TRP A 1 360 ? 12.661  6.543   6.246   1.00 78.19 360 A 1 
+ATOM 2878 N NE1 . TRP A 1 360 ? 13.684  8.511   6.144   1.00 72.93 360 A 1 
+ATOM 2879 C CE2 . TRP A 1 360 ? 12.975  7.622   5.368   1.00 75.06 360 A 1 
+ATOM 2880 C CE3 . TRP A 1 360 ? 11.923  5.465   5.716   1.00 73.29 360 A 1 
+ATOM 2881 C CZ2 . TRP A 1 360 ? 12.568  7.636   4.025   1.00 74.20 360 A 1 
+ATOM 2882 C CZ3 . TRP A 1 360 ? 11.510  5.471   4.369   1.00 73.08 360 A 1 
+ATOM 2883 C CH2 . TRP A 1 360 ? 11.830  6.550   3.522   1.00 72.17 360 A 1 
+ATOM 2884 N N   . ALA A 1 361 ? 12.013  5.244   11.805  1.00 86.08 361 A 1 
+ATOM 2885 C CA  . ALA A 1 361 ? 11.820  4.284   12.890  1.00 86.16 361 A 1 
+ATOM 2886 C C   . ALA A 1 361 ? 10.329  4.050   13.190  1.00 88.98 361 A 1 
+ATOM 2887 O O   . ALA A 1 361 ? 9.918   2.907   13.388  1.00 88.80 361 A 1 
+ATOM 2888 C CB  . ALA A 1 361 ? 12.574  4.794   14.127  1.00 83.24 361 A 1 
+ATOM 2889 N N   . ASP A 1 362 ? 9.508   5.108   13.157  1.00 90.89 362 A 1 
+ATOM 2890 C CA  . ASP A 1 362 ? 8.061   5.003   13.382  1.00 92.03 362 A 1 
+ATOM 2891 C C   . ASP A 1 362 ? 7.382   4.243   12.239  1.00 93.54 362 A 1 
+ATOM 2892 O O   . ASP A 1 362 ? 6.584   3.333   12.483  1.00 93.40 362 A 1 
+ATOM 2893 C CB  . ASP A 1 362 ? 7.453   6.402   13.562  1.00 90.93 362 A 1 
+ATOM 2894 C CG  . ASP A 1 362 ? 7.960   7.110   14.823  1.00 87.49 362 A 1 
+ATOM 2895 O OD1 . ASP A 1 362 ? 8.233   6.400   15.822  1.00 82.54 362 A 1 
+ATOM 2896 O OD2 . ASP A 1 362 ? 8.088   8.351   14.772  1.00 81.53 362 A 1 
+ATOM 2897 N N   . LEU A 1 363 ? 7.773   4.519   10.995  1.00 92.63 363 A 1 
+ATOM 2898 C CA  . LEU A 1 363 ? 7.297   3.769   9.830   1.00 93.25 363 A 1 
+ATOM 2899 C C   . LEU A 1 363 ? 7.648   2.274   9.929   1.00 93.72 363 A 1 
+ATOM 2900 O O   . LEU A 1 363 ? 6.822   1.418   9.603   1.00 93.40 363 A 1 
+ATOM 2901 C CB  . LEU A 1 363 ? 7.877   4.414   8.557   1.00 93.20 363 A 1 
+ATOM 2902 C CG  . LEU A 1 363 ? 7.394   3.752   7.253   1.00 92.23 363 A 1 
+ATOM 2903 C CD1 . LEU A 1 363 ? 5.876   3.827   7.080   1.00 90.43 363 A 1 
+ATOM 2904 C CD2 . LEU A 1 363 ? 8.039   4.437   6.052   1.00 90.31 363 A 1 
+ATOM 2905 N N   . GLU A 1 364 ? 8.834   1.935   10.422  1.00 91.88 364 A 1 
+ATOM 2906 C CA  . GLU A 1 364 ? 9.243   0.543   10.653  1.00 91.25 364 A 1 
+ATOM 2907 C C   . GLU A 1 364 ? 8.372   -0.132  11.726  1.00 92.51 364 A 1 
+ATOM 2908 O O   . GLU A 1 364 ? 7.968   -1.284  11.550  1.00 92.03 364 A 1 
+ATOM 2909 C CB  . GLU A 1 364 ? 10.742  0.522   11.013  1.00 89.42 364 A 1 
+ATOM 2910 C CG  . GLU A 1 364 ? 11.318  -0.857  11.381  1.00 85.19 364 A 1 
+ATOM 2911 C CD  . GLU A 1 364 ? 11.269  -1.910  10.265  1.00 84.45 364 A 1 
+ATOM 2912 O OE1 . GLU A 1 364 ? 11.340  -3.119  10.621  1.00 76.70 364 A 1 
+ATOM 2913 O OE2 . GLU A 1 364 ? 11.185  -1.575  9.073   1.00 77.33 364 A 1 
+ATOM 2914 N N   . ILE A 1 365 ? 8.020   0.573   12.809  1.00 92.92 365 A 1 
+ATOM 2915 C CA  . ILE A 1 365 ? 7.107   0.066   13.849  1.00 93.76 365 A 1 
+ATOM 2916 C C   . ILE A 1 365 ? 5.721   -0.216  13.260  1.00 94.96 365 A 1 
+ATOM 2917 O O   . ILE A 1 365 ? 5.160   -1.291  13.491  1.00 94.93 365 A 1 
+ATOM 2918 C CB  . ILE A 1 365 ? 7.039   1.052   15.043  1.00 93.21 365 A 1 
+ATOM 2919 C CG1 . ILE A 1 365 ? 8.389   1.080   15.801  1.00 91.62 365 A 1 
+ATOM 2920 C CG2 . ILE A 1 365 ? 5.904   0.673   16.023  1.00 91.79 365 A 1 
+ATOM 2921 C CD1 . ILE A 1 365 ? 8.542   2.274   16.753  1.00 87.57 365 A 1 
+ATOM 2922 N N   . ILE A 1 366 ? 5.177   0.712   12.467  1.00 95.72 366 A 1 
+ATOM 2923 C CA  . ILE A 1 366 ? 3.885   0.530   11.786  1.00 96.29 366 A 1 
+ATOM 2924 C C   . ILE A 1 366 ? 3.930   -0.703  10.895  1.00 96.94 366 A 1 
+ATOM 2925 O O   . ILE A 1 366 ? 3.060   -1.574  10.998  1.00 96.77 366 A 1 
+ATOM 2926 C CB  . ILE A 1 366 ? 3.519   1.792   10.974  1.00 95.89 366 A 1 
+ATOM 2927 C CG1 . ILE A 1 366 ? 3.215   2.950   11.944  1.00 93.40 366 A 1 
+ATOM 2928 C CG2 . ILE A 1 366 ? 2.307   1.553   10.048  1.00 93.67 366 A 1 
+ATOM 2929 C CD1 . ILE A 1 366 ? 3.251   4.300   11.237  1.00 83.81 366 A 1 
+ATOM 2930 N N   . CYS A 1 367 ? 4.955   -0.827  10.065  1.00 95.32 367 A 1 
+ATOM 2931 C CA  . CYS A 1 367 ? 5.081   -1.952  9.147   1.00 95.46 367 A 1 
+ATOM 2932 C C   . CYS A 1 367 ? 5.252   -3.290  9.878   1.00 95.90 367 A 1 
+ATOM 2933 O O   . CYS A 1 367 ? 4.678   -4.279  9.434   1.00 95.45 367 A 1 
+ATOM 2934 C CB  . CYS A 1 367 ? 6.216   -1.683  8.166   1.00 94.82 367 A 1 
+ATOM 2935 S SG  . CYS A 1 367 ? 5.735   -0.325  7.069   1.00 92.87 367 A 1 
+ATOM 2936 N N   . LYS A 1 368 ? 5.948   -3.337  11.018  1.00 95.65 368 A 1 
+ATOM 2937 C CA  . LYS A 1 368 ? 6.022   -4.541  11.870  1.00 95.15 368 A 1 
+ATOM 2938 C C   . LYS A 1 368 ? 4.659   -4.943  12.428  1.00 96.27 368 A 1 
+ATOM 2939 O O   . LYS A 1 368 ? 4.316   -6.121  12.398  1.00 96.06 368 A 1 
+ATOM 2940 C CB  . LYS A 1 368 ? 7.009   -4.326  13.025  1.00 93.68 368 A 1 
+ATOM 2941 C CG  . LYS A 1 368 ? 8.456   -4.482  12.548  1.00 88.40 368 A 1 
+ATOM 2942 C CD  . LYS A 1 368 ? 9.434   -4.184  13.690  1.00 81.89 368 A 1 
+ATOM 2943 C CE  . LYS A 1 368 ? 10.857  -4.362  13.157  1.00 74.65 368 A 1 
+ATOM 2944 N NZ  . LYS A 1 368 ? 11.872  -3.933  14.151  1.00 65.15 368 A 1 
+ATOM 2945 N N   . ASN A 1 369 ? 3.867   -3.976  12.887  1.00 96.99 369 A 1 
+ATOM 2946 C CA  . ASN A 1 369 ? 2.519   -4.252  13.384  1.00 97.20 369 A 1 
+ATOM 2947 C C   . ASN A 1 369 ? 1.602   -4.763  12.265  1.00 97.68 369 A 1 
+ATOM 2948 O O   . ASN A 1 369 ? 0.886   -5.748  12.455  1.00 97.10 369 A 1 
+ATOM 2949 C CB  . ASN A 1 369 ? 1.961   -2.980  14.043  1.00 96.69 369 A 1 
+ATOM 2950 C CG  . ASN A 1 369 ? 2.644   -2.644  15.360  1.00 94.54 369 A 1 
+ATOM 2951 O OD1 . ASN A 1 369 ? 3.161   -3.494  16.067  1.00 86.71 369 A 1 
+ATOM 2952 N ND2 . ASN A 1 369 ? 2.635   -1.391  15.753  1.00 86.16 369 A 1 
+ATOM 2953 N N   . LYS A 1 370 ? 1.667   -4.143  11.076  1.00 97.49 370 A 1 
+ATOM 2954 C CA  . LYS A 1 370 ? 0.927   -4.595  9.890   1.00 97.64 370 A 1 
+ATOM 2955 C C   . LYS A 1 370 ? 1.366   -5.991  9.448   1.00 97.98 370 A 1 
+ATOM 2956 O O   . LYS A 1 370 ? 0.520   -6.816  9.119   1.00 97.40 370 A 1 
+ATOM 2957 C CB  . LYS A 1 370 ? 1.087   -3.586  8.740   1.00 97.03 370 A 1 
+ATOM 2958 C CG  . LYS A 1 370 ? 0.372   -2.250  9.028   1.00 95.02 370 A 1 
+ATOM 2959 C CD  . LYS A 1 370 ? 0.564   -1.219  7.912   1.00 93.84 370 A 1 
+ATOM 2960 C CE  . LYS A 1 370 ? -0.254  -1.546  6.654   1.00 89.76 370 A 1 
+ATOM 2961 N NZ  . LYS A 1 370 ? -1.296  -0.537  6.400   1.00 87.79 370 A 1 
+ATOM 2962 N N   . GLU A 1 371 ? 2.663   -6.283  9.487   1.00 97.70 371 A 1 
+ATOM 2963 C CA  . GLU A 1 371 ? 3.228   -7.583  9.104   1.00 97.55 371 A 1 
+ATOM 2964 C C   . GLU A 1 371 ? 2.632   -8.731  9.917   1.00 97.97 371 A 1 
+ATOM 2965 O O   . GLU A 1 371 ? 2.272   -9.759  9.347   1.00 97.28 371 A 1 
+ATOM 2966 C CB  . GLU A 1 371 ? 4.761   -7.532  9.257   1.00 95.72 371 A 1 
+ATOM 2967 C CG  . GLU A 1 371 ? 5.447   -8.835  8.836   1.00 87.53 371 A 1 
+ATOM 2968 C CD  . GLU A 1 371 ? 6.977   -8.802  8.970   1.00 89.02 371 A 1 
+ATOM 2969 O OE1 . GLU A 1 371 ? 7.548   -9.906  9.170   1.00 80.21 371 A 1 
+ATOM 2970 O OE2 . GLU A 1 371 ? 7.586   -7.714  8.859   1.00 83.20 371 A 1 
+ATOM 2971 N N   . LEU A 1 372 ? 2.468   -8.563  11.232  1.00 97.79 372 A 1 
+ATOM 2972 C CA  . LEU A 1 372 ? 1.881   -9.595  12.097  1.00 97.82 372 A 1 
+ATOM 2973 C C   . LEU A 1 372 ? 0.448   -9.949  11.680  1.00 98.02 372 A 1 
+ATOM 2974 O O   . LEU A 1 372 ? 0.100   -11.128 11.599  1.00 97.38 372 A 1 
+ATOM 2975 C CB  . LEU A 1 372 ? 1.906   -9.115  13.560  1.00 97.33 372 A 1 
+ATOM 2976 C CG  . LEU A 1 372 ? 3.312   -8.995  14.179  1.00 95.07 372 A 1 
+ATOM 2977 C CD1 . LEU A 1 372 ? 3.202   -8.379  15.576  1.00 90.72 372 A 1 
+ATOM 2978 C CD2 . LEU A 1 372 ? 4.007   -10.355 14.305  1.00 90.89 372 A 1 
+ATOM 2979 N N   . ILE A 1 373 ? -0.358  -8.935  11.370  1.00 97.90 373 A 1 
+ATOM 2980 C CA  . ILE A 1 373 ? -1.759  -9.107  10.967  1.00 97.92 373 A 1 
+ATOM 2981 C C   . ILE A 1 373 ? -1.841  -9.657  9.543   1.00 98.16 373 A 1 
+ATOM 2982 O O   . ILE A 1 373 ? -2.594  -10.595 9.278   1.00 97.58 373 A 1 
+ATOM 2983 C CB  . ILE A 1 373 ? -2.515  -7.770  11.134  1.00 97.24 373 A 1 
+ATOM 2984 C CG1 . ILE A 1 373 ? -2.463  -7.320  12.617  1.00 93.89 373 A 1 
+ATOM 2985 C CG2 . ILE A 1 373 ? -3.974  -7.915  10.665  1.00 93.44 373 A 1 
+ATOM 2986 C CD1 . ILE A 1 373 ? -3.018  -5.916  12.857  1.00 80.18 373 A 1 
+ATOM 2987 N N   . PHE A 1 374 ? -1.019  -9.134  8.636   1.00 98.27 374 A 1 
+ATOM 2988 C CA  . PHE A 1 374 ? -0.951  -9.616  7.258   1.00 98.36 374 A 1 
+ATOM 2989 C C   . PHE A 1 374 ? -0.538  -11.093 7.211   1.00 98.34 374 A 1 
+ATOM 2990 O O   . PHE A 1 374 ? -1.168  -11.878 6.507   1.00 97.92 374 A 1 
+ATOM 2991 C CB  . PHE A 1 374 ? 0.006   -8.729  6.451   1.00 98.19 374 A 1 
+ATOM 2992 C CG  . PHE A 1 374 ? -0.150  -8.863  4.946   1.00 98.31 374 A 1 
+ATOM 2993 C CD1 . PHE A 1 374 ? 0.333   -9.999  4.270   1.00 97.52 374 A 1 
+ATOM 2994 C CD2 . PHE A 1 374 ? -0.786  -7.842  4.215   1.00 97.64 374 A 1 
+ATOM 2995 C CE1 . PHE A 1 374 ? 0.170   -10.118 2.876   1.00 97.16 374 A 1 
+ATOM 2996 C CE2 . PHE A 1 374 ? -0.942  -7.956  2.820   1.00 97.05 374 A 1 
+ATOM 2997 C CZ  . PHE A 1 374 ? -0.465  -9.098  2.152   1.00 97.39 374 A 1 
+ATOM 2998 N N   . LYS A 1 375 ? 0.456   -11.506 8.019   1.00 98.10 375 A 1 
+ATOM 2999 C CA  . LYS A 1 375 ? 0.882   -12.910 8.147   1.00 97.85 375 A 1 
+ATOM 3000 C C   . LYS A 1 375 ? -0.244  -13.837 8.602   1.00 97.95 375 A 1 
+ATOM 3001 O O   . LYS A 1 375 ? -0.278  -14.990 8.182   1.00 97.22 375 A 1 
+ATOM 3002 C CB  . LYS A 1 375 ? 2.069   -13.029 9.128   1.00 96.78 375 A 1 
+ATOM 3003 C CG  . LYS A 1 375 ? 3.412   -12.724 8.451   1.00 91.57 375 A 1 
+ATOM 3004 C CD  . LYS A 1 375 ? 4.599   -12.839 9.429   1.00 90.31 375 A 1 
+ATOM 3005 C CE  . LYS A 1 375 ? 5.896   -12.751 8.619   1.00 82.99 375 A 1 
+ATOM 3006 N NZ  . LYS A 1 375 ? 7.129   -12.680 9.435   1.00 76.92 375 A 1 
+ATOM 3007 N N   . GLU A 1 376 ? -1.167  -13.367 9.444   1.00 97.59 376 A 1 
+ATOM 3008 C CA  . GLU A 1 376 ? -2.310  -14.187 9.855   1.00 97.27 376 A 1 
+ATOM 3009 C C   . GLU A 1 376 ? -3.227  -14.510 8.667   1.00 97.47 376 A 1 
+ATOM 3010 O O   . GLU A 1 376 ? -3.599  -15.670 8.471   1.00 96.75 376 A 1 
+ATOM 3011 C CB  . GLU A 1 376 ? -3.099  -13.489 10.974  1.00 96.31 376 A 1 
+ATOM 3012 C CG  . GLU A 1 376 ? -4.058  -14.479 11.655  1.00 87.46 376 A 1 
+ATOM 3013 C CD  . GLU A 1 376 ? -5.174  -13.796 12.446  1.00 85.41 376 A 1 
+ATOM 3014 O OE1 . GLU A 1 376 ? -6.336  -14.262 12.278  1.00 74.24 376 A 1 
+ATOM 3015 O OE2 . GLU A 1 376 ? -4.867  -12.833 13.182  1.00 76.77 376 A 1 
+ATOM 3016 N N   . SER A 1 377 ? -3.556  -13.499 7.859   1.00 97.93 377 A 1 
+ATOM 3017 C CA  . SER A 1 377 ? -4.351  -13.671 6.639   1.00 98.09 377 A 1 
+ATOM 3018 C C   . SER A 1 377 ? -3.588  -14.463 5.578   1.00 98.02 377 A 1 
+ATOM 3019 O O   . SER A 1 377 ? -4.145  -15.382 4.977   1.00 97.53 377 A 1 
+ATOM 3020 C CB  . SER A 1 377 ? -4.779  -12.307 6.097   1.00 98.04 377 A 1 
+ATOM 3021 O OG  . SER A 1 377 ? -5.574  -11.631 7.055   1.00 96.53 377 A 1 
+ATOM 3022 N N   . GLU A 1 378 ? -2.302  -14.197 5.420   1.00 98.09 378 A 1 
+ATOM 3023 C CA  . GLU A 1 378 ? -1.437  -14.893 4.466   1.00 98.02 378 A 1 
+ATOM 3024 C C   . GLU A 1 378 ? -1.322  -16.393 4.774   1.00 97.90 378 A 1 
+ATOM 3025 O O   . GLU A 1 378 ? -1.341  -17.212 3.863   1.00 97.15 378 A 1 
+ATOM 3026 C CB  . GLU A 1 378 ? -0.057  -14.219 4.456   1.00 97.68 378 A 1 
+ATOM 3027 C CG  . GLU A 1 378 ? 0.853   -14.692 3.308   1.00 95.16 378 A 1 
+ATOM 3028 C CD  . GLU A 1 378 ? 0.301   -14.385 1.907   1.00 96.12 378 A 1 
+ATOM 3029 O OE1 . GLU A 1 378 ? 0.782   -15.018 0.947   1.00 88.80 378 A 1 
+ATOM 3030 O OE2 . GLU A 1 378 ? -0.590  -13.523 1.768   1.00 90.98 378 A 1 
+ATOM 3031 N N   . LYS A 1 379 ? -1.324  -16.786 6.051   1.00 97.57 379 A 1 
+ATOM 3032 C CA  . LYS A 1 379 ? -1.388  -18.210 6.438   1.00 97.12 379 A 1 
+ATOM 3033 C C   . LYS A 1 379 ? -2.692  -18.883 5.999   1.00 96.97 379 A 1 
+ATOM 3034 O O   . LYS A 1 379 ? -2.681  -20.075 5.696   1.00 96.20 379 A 1 
+ATOM 3035 C CB  . LYS A 1 379 ? -1.201  -18.351 7.957   1.00 96.55 379 A 1 
+ATOM 3036 C CG  . LYS A 1 379 ? 0.273   -18.190 8.362   1.00 94.41 379 A 1 
+ATOM 3037 C CD  . LYS A 1 379 ? 0.422   -18.157 9.889   1.00 91.12 379 A 1 
+ATOM 3038 C CE  . LYS A 1 379 ? 1.906   -17.948 10.218  1.00 85.78 379 A 1 
+ATOM 3039 N NZ  . LYS A 1 379 ? 2.167   -17.941 11.676  1.00 77.82 379 A 1 
+ATOM 3040 N N   . LYS A 1 380 ? -3.814  -18.152 5.963   1.00 97.02 380 A 1 
+ATOM 3041 C CA  . LYS A 1 380 ? -5.096  -18.664 5.449   1.00 96.81 380 A 1 
+ATOM 3042 C C   . LYS A 1 380 ? -5.035  -18.823 3.929   1.00 96.92 380 A 1 
+ATOM 3043 O O   . LYS A 1 380 ? -5.413  -19.878 3.423   1.00 96.31 380 A 1 
+ATOM 3044 C CB  . LYS A 1 380 ? -6.278  -17.767 5.885   1.00 96.67 380 A 1 
+ATOM 3045 C CG  . LYS A 1 380 ? -6.452  -17.672 7.416   1.00 95.61 380 A 1 
+ATOM 3046 C CD  . LYS A 1 380 ? -7.432  -16.562 7.838   1.00 93.16 380 A 1 
+ATOM 3047 C CE  . LYS A 1 380 ? -7.402  -16.411 9.373   1.00 89.49 380 A 1 
+ATOM 3048 N NZ  . LYS A 1 380 ? -7.944  -15.112 9.872   1.00 81.93 380 A 1 
+ATOM 3049 N N   . THR A 1 381 ? -4.482  -17.838 3.226   1.00 97.32 381 A 1 
+ATOM 3050 C CA  . THR A 1 381 ? -4.188  -17.928 1.785   1.00 97.34 381 A 1 
+ATOM 3051 C C   . THR A 1 381 ? -3.283  -19.113 1.472   1.00 97.25 381 A 1 
+ATOM 3052 O O   . THR A 1 381 ? -3.593  -19.925 0.601   1.00 96.55 381 A 1 
+ATOM 3053 C CB  . THR A 1 381 ? -3.524  -16.631 1.295   1.00 96.93 381 A 1 
+ATOM 3054 O OG1 . THR A 1 381 ? -4.454  -15.588 1.437   1.00 93.22 381 A 1 
+ATOM 3055 C CG2 . THR A 1 381 ? -3.119  -16.665 -0.173  1.00 92.70 381 A 1 
+ATOM 3056 N N   . LEU A 1 382 ? -2.210  -19.267 2.229   1.00 96.72 382 A 1 
+ATOM 3057 C CA  . LEU A 1 382 ? -1.252  -20.342 2.048   1.00 96.60 382 A 1 
+ATOM 3058 C C   . LEU A 1 382 ? -1.889  -21.726 2.212   1.00 96.69 382 A 1 
+ATOM 3059 O O   . LEU A 1 382 ? -1.580  -22.620 1.441   1.00 95.90 382 A 1 
+ATOM 3060 C CB  . LEU A 1 382 ? -0.103  -20.117 3.036   1.00 95.64 382 A 1 
+ATOM 3061 C CG  . LEU A 1 382 ? 1.029   -21.145 2.900   1.00 91.50 382 A 1 
+ATOM 3062 C CD1 . LEU A 1 382 ? 1.770   -21.022 1.572   1.00 87.26 382 A 1 
+ATOM 3063 C CD2 . LEU A 1 382 ? 1.977   -20.949 4.075   1.00 87.51 382 A 1 
+ATOM 3064 N N   . ASN A 1 383 ? -2.823  -21.919 3.147   1.00 96.30 383 A 1 
+ATOM 3065 C CA  . ASN A 1 383 ? -3.545  -23.194 3.268   1.00 95.79 383 A 1 
+ATOM 3066 C C   . ASN A 1 383 ? -4.274  -23.562 1.960   1.00 96.02 383 A 1 
+ATOM 3067 O O   . ASN A 1 383 ? -4.261  -24.726 1.563   1.00 94.97 383 A 1 
+ATOM 3068 C CB  . ASN A 1 383 ? -4.558  -23.132 4.422   1.00 94.56 383 A 1 
+ATOM 3069 C CG  . ASN A 1 383 ? -3.968  -23.081 5.822   1.00 86.04 383 A 1 
+ATOM 3070 O OD1 . ASN A 1 383 ? -2.925  -23.626 6.167   1.00 76.28 383 A 1 
+ATOM 3071 N ND2 . ASN A 1 383 ? -4.679  -22.452 6.727   1.00 74.11 383 A 1 
+ATOM 3072 N N   . ILE A 1 384 ? -4.889  -22.580 1.295   1.00 95.56 384 A 1 
+ATOM 3073 C CA  . ILE A 1 384 ? -5.606  -22.784 0.028   1.00 95.46 384 A 1 
+ATOM 3074 C C   . ILE A 1 384 ? -4.614  -23.049 -1.106  1.00 95.52 384 A 1 
+ATOM 3075 O O   . ILE A 1 384 ? -4.766  -24.031 -1.832  1.00 94.67 384 A 1 
+ATOM 3076 C CB  . ILE A 1 384 ? -6.524  -21.575 -0.266  1.00 94.97 384 A 1 
+ATOM 3077 C CG1 . ILE A 1 384 ? -7.587  -21.456 0.850   1.00 92.73 384 A 1 
+ATOM 3078 C CG2 . ILE A 1 384 ? -7.196  -21.714 -1.649  1.00 92.33 384 A 1 
+ATOM 3079 C CD1 . ILE A 1 384 ? -8.377  -20.150 0.792   1.00 81.04 384 A 1 
+ATOM 3080 N N   . LEU A 1 385 ? -3.564  -22.238 -1.209  1.00 95.78 385 A 1 
+ATOM 3081 C CA  . LEU A 1 385 ? -2.502  -22.420 -2.201  1.00 95.72 385 A 1 
+ATOM 3082 C C   . LEU A 1 385 ? -1.877  -23.815 -2.095  1.00 95.61 385 A 1 
+ATOM 3083 O O   . LEU A 1 385 ? -1.795  -24.527 -3.092  1.00 94.81 385 A 1 
+ATOM 3084 C CB  . LEU A 1 385 ? -1.416  -21.340 -2.022  1.00 95.45 385 A 1 
+ATOM 3085 C CG  . LEU A 1 385 ? -1.832  -19.917 -2.440  1.00 92.82 385 A 1 
+ATOM 3086 C CD1 . LEU A 1 385 ? -0.701  -18.940 -2.113  1.00 88.93 385 A 1 
+ATOM 3087 C CD2 . LEU A 1 385 ? -2.120  -19.826 -3.939  1.00 89.64 385 A 1 
+ATOM 3088 N N   . LEU A 1 386 ? -1.509  -24.245 -0.886  1.00 95.54 386 A 1 
+ATOM 3089 C CA  . LEU A 1 386 ? -0.926  -25.564 -0.647  1.00 95.53 386 A 1 
+ATOM 3090 C C   . LEU A 1 386 ? -1.908  -26.691 -0.955  1.00 95.34 386 A 1 
+ATOM 3091 O O   . LEU A 1 386 ? -1.505  -27.720 -1.491  1.00 94.65 386 A 1 
+ATOM 3092 C CB  . LEU A 1 386 ? -0.456  -25.674 0.811   1.00 95.52 386 A 1 
+ATOM 3093 C CG  . LEU A 1 386 ? 0.759   -24.804 1.167   1.00 94.62 386 A 1 
+ATOM 3094 C CD1 . LEU A 1 386 ? 1.094   -25.015 2.647   1.00 92.07 386 A 1 
+ATOM 3095 C CD2 . LEU A 1 386 ? 1.991   -25.150 0.333   1.00 92.23 386 A 1 
+ATOM 3096 N N   . HIS A 1 387 ? -3.190  -26.507 -0.643  1.00 94.97 387 A 1 
+ATOM 3097 C CA  . HIS A 1 387 ? -4.198  -27.501 -0.995  1.00 94.51 387 A 1 
+ATOM 3098 C C   . HIS A 1 387 ? -4.263  -27.702 -2.510  1.00 94.37 387 A 1 
+ATOM 3099 O O   . HIS A 1 387 ? -4.242  -28.844 -2.963  1.00 93.20 387 A 1 
+ATOM 3100 C CB  . HIS A 1 387 ? -5.559  -27.115 -0.408  1.00 94.01 387 A 1 
+ATOM 3101 C CG  . HIS A 1 387 ? -6.625  -28.139 -0.712  1.00 92.16 387 A 1 
+ATOM 3102 N ND1 . HIS A 1 387 ? -7.280  -28.287 -1.912  1.00 79.86 387 A 1 
+ATOM 3103 C CD2 . HIS A 1 387 ? -7.078  -29.131 0.117   1.00 81.31 387 A 1 
+ATOM 3104 C CE1 . HIS A 1 387 ? -8.102  -29.345 -1.812  1.00 83.17 387 A 1 
+ATOM 3105 N NE2 . HIS A 1 387 ? -8.013  -29.894 -0.589  1.00 85.96 387 A 1 
+ATOM 3106 N N   . ILE A 1 388 ? -4.315  -26.625 -3.293  1.00 93.29 388 A 1 
+ATOM 3107 C CA  . ILE A 1 388 ? -4.370  -26.693 -4.762  1.00 92.71 388 A 1 
+ATOM 3108 C C   . ILE A 1 388 ? -3.045  -27.225 -5.323  1.00 92.84 388 A 1 
+ATOM 3109 O O   . ILE A 1 388 ? -3.050  -28.170 -6.111  1.00 91.95 388 A 1 
+ATOM 3110 C CB  . ILE A 1 388 ? -4.761  -25.321 -5.359  1.00 92.01 388 A 1 
+ATOM 3111 C CG1 . ILE A 1 388 ? -6.153  -24.860 -4.862  1.00 90.53 388 A 1 
+ATOM 3112 C CG2 . ILE A 1 388 ? -4.769  -25.417 -6.898  1.00 90.11 388 A 1 
+ATOM 3113 C CD1 . ILE A 1 388 ? -6.483  -23.403 -5.211  1.00 87.22 388 A 1 
+ATOM 3114 N N   . PHE A 1 389 ? -1.923  -26.702 -4.857  1.00 93.30 389 A 1 
+ATOM 3115 C CA  . PHE A 1 389 ? -0.570  -27.087 -5.269  1.00 93.43 389 A 1 
+ATOM 3116 C C   . PHE A 1 389 ? -0.283  -28.584 -5.067  1.00 93.61 389 A 1 
+ATOM 3117 O O   . PHE A 1 389 ? 0.351   -29.217 -5.906  1.00 92.83 389 A 1 
+ATOM 3118 C CB  . PHE A 1 389 ? 0.426   -26.240 -4.465  1.00 93.55 389 A 1 
+ATOM 3119 C CG  . PHE A 1 389 ? 1.884   -26.507 -4.786  1.00 94.17 389 A 1 
+ATOM 3120 C CD1 . PHE A 1 389 ? 2.653   -27.362 -3.967  1.00 92.59 389 A 1 
+ATOM 3121 C CD2 . PHE A 1 389 ? 2.478   -25.886 -5.897  1.00 93.23 389 A 1 
+ATOM 3122 C CE1 . PHE A 1 389 ? 4.011   -27.583 -4.256  1.00 92.82 389 A 1 
+ATOM 3123 C CE2 . PHE A 1 389 ? 3.839   -26.107 -6.184  1.00 93.12 389 A 1 
+ATOM 3124 C CZ  . PHE A 1 389 ? 4.606   -26.953 -5.362  1.00 93.75 389 A 1 
+ATOM 3125 N N   . ASN A 1 390 ? -0.785  -29.170 -3.976  1.00 93.78 390 A 1 
+ATOM 3126 C CA  . ASN A 1 390 ? -0.568  -30.575 -3.628  1.00 93.79 390 A 1 
+ATOM 3127 C C   . ASN A 1 390 ? -1.466  -31.569 -4.386  1.00 93.60 390 A 1 
+ATOM 3128 O O   . ASN A 1 390 ? -1.303  -32.781 -4.208  1.00 92.17 390 A 1 
+ATOM 3129 C CB  . ASN A 1 390 ? -0.734  -30.724 -2.110  1.00 93.70 390 A 1 
+ATOM 3130 C CG  . ASN A 1 390 ? 0.419   -30.155 -1.301  1.00 93.63 390 A 1 
+ATOM 3131 O OD1 . ASN A 1 390 ? 1.563   -30.136 -1.713  1.00 88.27 390 A 1 
+ATOM 3132 N ND2 . ASN A 1 390 ? 0.166   -29.764 -0.076  1.00 88.95 390 A 1 
+ATOM 3133 N N   . ILE A 1 391 ? -2.439  -31.105 -5.184  1.00 91.53 391 A 1 
+ATOM 3134 C CA  . ILE A 1 391 ? -3.338  -31.995 -5.931  1.00 90.27 391 A 1 
+ATOM 3135 C C   . ILE A 1 391 ? -2.533  -32.795 -6.960  1.00 90.19 391 A 1 
+ATOM 3136 O O   . ILE A 1 391 ? -1.835  -32.247 -7.800  1.00 87.81 391 A 1 
+ATOM 3137 C CB  . ILE A 1 391 ? -4.510  -31.224 -6.580  1.00 88.40 391 A 1 
+ATOM 3138 C CG1 . ILE A 1 391 ? -5.412  -30.622 -5.482  1.00 84.90 391 A 1 
+ATOM 3139 C CG2 . ILE A 1 391 ? -5.352  -32.152 -7.493  1.00 84.30 391 A 1 
+ATOM 3140 C CD1 . ILE A 1 391 ? -6.527  -29.703 -6.010  1.00 77.98 391 A 1 
+ATOM 3141 N N   . GLY A 1 392 ? -2.652  -34.131 -6.903  1.00 88.09 392 A 1 
+ATOM 3142 C CA  . GLY A 1 392 ? -1.973  -35.033 -7.840  1.00 87.74 392 A 1 
+ATOM 3143 C C   . GLY A 1 392 ? -0.472  -35.236 -7.584  1.00 89.50 392 A 1 
+ATOM 3144 O O   . GLY A 1 392 ? 0.141   -36.039 -8.283  1.00 86.67 392 A 1 
+ATOM 3145 N N   . ARG A 1 393 ? 0.109   -34.587 -6.570  1.00 91.16 393 A 1 
+ATOM 3146 C CA  . ARG A 1 393 ? 1.526   -34.761 -6.207  1.00 92.40 393 A 1 
+ATOM 3147 C C   . ARG A 1 393 ? 1.730   -35.933 -5.243  1.00 93.09 393 A 1 
+ATOM 3148 O O   . ARG A 1 393 ? 0.947   -36.146 -4.312  1.00 90.54 393 A 1 
+ATOM 3149 C CB  . ARG A 1 393 ? 2.099   -33.458 -5.634  1.00 91.36 393 A 1 
+ATOM 3150 C CG  . ARG A 1 393 ? 2.110   -32.336 -6.686  1.00 89.43 393 A 1 
+ATOM 3151 C CD  . ARG A 1 393 ? 2.786   -31.081 -6.130  1.00 88.03 393 A 1 
+ATOM 3152 N NE  . ARG A 1 393 ? 2.826   -30.018 -7.149  1.00 85.60 393 A 1 
+ATOM 3153 C CZ  . ARG A 1 393 ? 3.893   -29.450 -7.682  1.00 84.75 393 A 1 
+ATOM 3154 N NH1 . ARG A 1 393 ? 5.112   -29.723 -7.323  1.00 78.56 393 A 1 
+ATOM 3155 N NH2 . ARG A 1 393 ? 3.749   -28.571 -8.617  1.00 78.52 393 A 1 
+ATOM 3156 N N   . SER A 1 394 ? 2.816   -36.680 -5.464  1.00 93.10 394 A 1 
+ATOM 3157 C CA  . SER A 1 394 ? 3.272   -37.739 -4.554  1.00 93.10 394 A 1 
+ATOM 3158 C C   . SER A 1 394 ? 3.906   -37.161 -3.288  1.00 93.44 394 A 1 
+ATOM 3159 O O   . SER A 1 394 ? 3.604   -37.617 -2.182  1.00 89.89 394 A 1 
+ATOM 3160 C CB  . SER A 1 394 ? 4.276   -38.654 -5.265  1.00 91.89 394 A 1 
+ATOM 3161 O OG  . SER A 1 394 ? 5.329   -37.904 -5.840  1.00 81.62 394 A 1 
+ATOM 3162 N N   . GLU A 1 395 ? 4.744   -36.154 -3.459  1.00 92.60 395 A 1 
+ATOM 3163 C CA  . GLU A 1 395 ? 5.327   -35.389 -2.361  1.00 92.56 395 A 1 
+ATOM 3164 C C   . GLU A 1 395 ? 4.518   -34.110 -2.143  1.00 93.26 395 A 1 
+ATOM 3165 O O   . GLU A 1 395 ? 4.234   -33.364 -3.084  1.00 90.61 395 A 1 
+ATOM 3166 C CB  . GLU A 1 395 ? 6.807   -35.119 -2.637  1.00 90.17 395 A 1 
+ATOM 3167 C CG  . GLU A 1 395 ? 7.495   -34.535 -1.396  1.00 79.36 395 A 1 
+ATOM 3168 C CD  . GLU A 1 395 ? 9.025   -34.489 -1.518  1.00 78.53 395 A 1 
+ATOM 3169 O OE1 . GLU A 1 395 ? 9.655   -34.308 -0.453  1.00 70.59 395 A 1 
+ATOM 3170 O OE2 . GLU A 1 395 ? 9.535   -34.685 -2.642  1.00 71.91 395 A 1 
+ATOM 3171 N N   . LYS A 1 396 ? 4.105   -33.892 -0.900  1.00 93.29 396 A 1 
+ATOM 3172 C CA  . LYS A 1 396 ? 3.247   -32.776 -0.502  1.00 93.70 396 A 1 
+ATOM 3173 C C   . LYS A 1 396 ? 4.023   -31.782 0.340   1.00 94.03 396 A 1 
+ATOM 3174 O O   . LYS A 1 396 ? 4.796   -32.178 1.216   1.00 91.43 396 A 1 
+ATOM 3175 C CB  . LYS A 1 396 ? 2.006   -33.280 0.247   1.00 91.98 396 A 1 
+ATOM 3176 C CG  . LYS A 1 396 ? 1.116   -34.130 -0.668  1.00 90.24 396 A 1 
+ATOM 3177 C CD  . LYS A 1 396 ? -0.169  -34.549 0.050   1.00 86.63 396 A 1 
+ATOM 3178 C CE  . LYS A 1 396 ? -0.997  -35.383 -0.927  1.00 82.25 396 A 1 
+ATOM 3179 N NZ  . LYS A 1 396 ? -2.294  -35.777 -0.339  1.00 72.93 396 A 1 
+ATOM 3180 N N   . LEU A 1 397 ? 3.755   -30.515 0.105   1.00 94.46 397 A 1 
+ATOM 3181 C CA  . LEU A 1 397 ? 4.255   -29.418 0.917   1.00 94.60 397 A 1 
+ATOM 3182 C C   . LEU A 1 397 ? 3.255   -29.129 2.045   1.00 94.87 397 A 1 
+ATOM 3183 O O   . LEU A 1 397 ? 2.052   -29.029 1.797   1.00 92.94 397 A 1 
+ATOM 3184 C CB  . LEU A 1 397 ? 4.503   -28.216 -0.013  1.00 93.08 397 A 1 
+ATOM 3185 C CG  . LEU A 1 397 ? 5.354   -27.093 0.602   1.00 89.59 397 A 1 
+ATOM 3186 C CD1 . LEU A 1 397 ? 6.779   -27.554 0.913   1.00 85.63 397 A 1 
+ATOM 3187 C CD2 . LEU A 1 397 ? 5.454   -25.938 -0.395  1.00 86.73 397 A 1 
+ATOM 3188 N N   . ASP A 1 398 ? 3.733   -29.028 3.277   1.00 94.03 398 A 1 
+ATOM 3189 C CA  . ASP A 1 398 ? 2.925   -28.657 4.439   1.00 93.48 398 A 1 
+ATOM 3190 C C   . ASP A 1 398 ? 3.226   -27.208 4.854   1.00 93.81 398 A 1 
+ATOM 3191 O O   . ASP A 1 398 ? 4.311   -26.683 4.623   1.00 92.04 398 A 1 
+ATOM 3192 C CB  . ASP A 1 398 ? 3.146   -29.650 5.599   1.00 91.60 398 A 1 
+ATOM 3193 C CG  . ASP A 1 398 ? 2.126   -29.428 6.722   1.00 85.06 398 A 1 
+ATOM 3194 O OD1 . ASP A 1 398 ? 2.434   -28.657 7.663   1.00 77.14 398 A 1 
+ATOM 3195 O OD2 . ASP A 1 398 ? 0.996   -29.952 6.605   1.00 77.17 398 A 1 
+ATOM 3196 N N   . LYS A 1 399 ? 2.269   -26.557 5.508   1.00 93.77 399 A 1 
+ATOM 3197 C CA  . LYS A 1 399 ? 2.458   -25.196 6.039   1.00 93.22 399 A 1 
+ATOM 3198 C C   . LYS A 1 399 ? 3.595   -25.074 7.063   1.00 93.84 399 A 1 
+ATOM 3199 O O   . LYS A 1 399 ? 4.081   -23.977 7.295   1.00 92.08 399 A 1 
+ATOM 3200 C CB  . LYS A 1 399 ? 1.133   -24.699 6.633   1.00 91.04 399 A 1 
+ATOM 3201 C CG  . LYS A 1 399 ? 0.717   -25.495 7.879   1.00 84.16 399 A 1 
+ATOM 3202 C CD  . LYS A 1 399 ? -0.643  -25.029 8.378   1.00 81.99 399 A 1 
+ATOM 3203 C CE  . LYS A 1 399 ? -1.037  -25.861 9.600   1.00 73.78 399 A 1 
+ATOM 3204 N NZ  . LYS A 1 399 ? -2.408  -25.512 10.030  1.00 67.05 399 A 1 
+ATOM 3205 N N   . LEU A 1 400 ? 3.973   -26.187 7.699   1.00 93.47 400 A 1 
+ATOM 3206 C CA  . LEU A 1 400 ? 5.098   -26.238 8.635   1.00 93.13 400 A 1 
+ATOM 3207 C C   . LEU A 1 400 ? 6.458   -26.307 7.925   1.00 93.00 400 A 1 
+ATOM 3208 O O   . LEU A 1 400 ? 7.475   -26.056 8.563   1.00 91.03 400 A 1 
+ATOM 3209 C CB  . LEU A 1 400 ? 4.925   -27.443 9.577   1.00 92.70 400 A 1 
+ATOM 3210 C CG  . LEU A 1 400 ? 3.674   -27.402 10.474  1.00 90.08 400 A 1 
+ATOM 3211 C CD1 . LEU A 1 400 ? 3.606   -28.684 11.307  1.00 84.04 400 A 1 
+ATOM 3212 C CD2 . LEU A 1 400 ? 3.681   -26.211 11.435  1.00 84.52 400 A 1 
+ATOM 3213 N N   . ASP A 1 401 ? 6.465   -26.646 6.638   1.00 93.93 401 A 1 
+ATOM 3214 C CA  . ASP A 1 401 ? 7.695   -26.719 5.845   1.00 93.43 401 A 1 
+ATOM 3215 C C   . ASP A 1 401 ? 8.211   -25.333 5.424   1.00 93.44 401 A 1 
+ATOM 3216 O O   . ASP A 1 401 ? 9.365   -25.215 5.004   1.00 91.97 401 A 1 
+ATOM 3217 C CB  . ASP A 1 401 ? 7.462   -27.594 4.598   1.00 92.96 401 A 1 
+ATOM 3218 C CG  . ASP A 1 401 ? 7.235   -29.084 4.890   1.00 91.99 401 A 1 
+ATOM 3219 O OD1 . ASP A 1 401 ? 8.020   -29.684 5.659   1.00 87.13 401 A 1 
+ATOM 3220 O OD2 . ASP A 1 401 ? 6.360   -29.699 4.235   1.00 88.04 401 A 1 
+ATOM 3221 N N   . LEU A 1 402 ? 7.377   -24.288 5.523   1.00 93.95 402 A 1 
+ATOM 3222 C CA  . LEU A 1 402 ? 7.699   -22.952 5.035   1.00 93.99 402 A 1 
+ATOM 3223 C C   . LEU A 1 402 ? 7.326   -21.845 6.033   1.00 94.48 402 A 1 
+ATOM 3224 O O   . LEU A 1 402 ? 6.448   -22.002 6.882   1.00 92.74 402 A 1 
+ATOM 3225 C CB  . LEU A 1 402 ? 7.087   -22.780 3.628   1.00 91.33 402 A 1 
+ATOM 3226 C CG  . LEU A 1 402 ? 5.557   -22.878 3.564   1.00 88.51 402 A 1 
+ATOM 3227 C CD1 . LEU A 1 402 ? 4.915   -21.538 3.901   1.00 80.98 402 A 1 
+ATOM 3228 C CD2 . LEU A 1 402 ? 5.127   -23.257 2.140   1.00 81.59 402 A 1 
+ATOM 3229 N N   . ASP A 1 403 ? 7.989   -20.712 5.911   1.00 93.88 403 A 1 
+ATOM 3230 C CA  . ASP A 1 403 ? 7.657   -19.468 6.606   1.00 93.81 403 A 1 
+ATOM 3231 C C   . ASP A 1 403 ? 7.463   -18.323 5.595   1.00 94.85 403 A 1 
+ATOM 3232 O O   . ASP A 1 403 ? 7.911   -18.386 4.449   1.00 94.25 403 A 1 
+ATOM 3233 C CB  . ASP A 1 403 ? 8.714   -19.144 7.681   1.00 92.06 403 A 1 
+ATOM 3234 C CG  . ASP A 1 403 ? 8.264   -18.057 8.674   1.00 85.48 403 A 1 
+ATOM 3235 O OD1 . ASP A 1 403 ? 7.043   -17.768 8.757   1.00 80.56 403 A 1 
+ATOM 3236 O OD2 . ASP A 1 403 ? 9.135   -17.492 9.370   1.00 78.91 403 A 1 
+ATOM 3237 N N   . ILE A 1 404 ? 6.757   -17.276 6.027   1.00 94.69 404 A 1 
+ATOM 3238 C CA  . ILE A 1 404 ? 6.413   -16.111 5.211   1.00 95.61 404 A 1 
+ATOM 3239 C C   . ILE A 1 404 ? 7.391   -14.991 5.549   1.00 95.37 404 A 1 
+ATOM 3240 O O   . ILE A 1 404 ? 7.359   -14.441 6.660   1.00 94.07 404 A 1 
+ATOM 3241 C CB  . ILE A 1 404 ? 4.948   -15.684 5.456   1.00 96.01 404 A 1 
+ATOM 3242 C CG1 . ILE A 1 404 ? 3.942   -16.832 5.193   1.00 95.25 404 A 1 
+ATOM 3243 C CG2 . ILE A 1 404 ? 4.607   -14.466 4.582   1.00 94.84 404 A 1 
+ATOM 3244 C CD1 . ILE A 1 404 ? 2.573   -16.578 5.834   1.00 91.27 404 A 1 
+ATOM 3245 N N   . LYS A 1 405 ? 8.227   -14.617 4.598   1.00 94.72 405 A 1 
+ATOM 3246 C CA  . LYS A 1 405 ? 9.230   -13.567 4.774   1.00 93.68 405 A 1 
+ATOM 3247 C C   . LYS A 1 405 ? 8.858   -12.283 4.041   1.00 94.65 405 A 1 
+ATOM 3248 O O   . LYS A 1 405 ? 8.644   -12.273 2.835   1.00 93.83 405 A 1 
+ATOM 3249 C CB  . LYS A 1 405 ? 10.616  -14.098 4.385   1.00 91.01 405 A 1 
+ATOM 3250 C CG  . LYS A 1 405 ? 11.698  -13.073 4.763   1.00 82.11 405 A 1 
+ATOM 3251 C CD  . LYS A 1 405 ? 13.079  -13.721 4.833   1.00 74.30 405 A 1 
+ATOM 3252 C CE  . LYS A 1 405 ? 14.106  -12.697 5.315   1.00 65.06 405 A 1 
+ATOM 3253 N NZ  . LYS A 1 405 ? 15.405  -13.343 5.618   1.00 57.28 405 A 1 
+ATOM 3254 N N   . PHE A 1 406 ? 8.852   -11.196 4.797   1.00 93.79 406 A 1 
+ATOM 3255 C CA  . PHE A 1 406 ? 8.770   -9.835  4.281   1.00 93.55 406 A 1 
+ATOM 3256 C C   . PHE A 1 406 ? 10.187  -9.269  4.182   1.00 91.78 406 A 1 
+ATOM 3257 O O   . PHE A 1 406 ? 10.910  -9.204  5.178   1.00 88.38 406 A 1 
+ATOM 3258 C CB  . PHE A 1 406 ? 7.892   -8.974  5.191   1.00 94.22 406 A 1 
+ATOM 3259 C CG  . PHE A 1 406 ? 6.423   -9.358  5.173   1.00 95.52 406 A 1 
+ATOM 3260 C CD1 . PHE A 1 406 ? 5.495   -8.557  4.477   1.00 94.10 406 A 1 
+ATOM 3261 C CD2 . PHE A 1 406 ? 5.980   -10.513 5.840   1.00 94.59 406 A 1 
+ATOM 3262 C CE1 . PHE A 1 406 ? 4.139   -8.917  4.449   1.00 94.54 406 A 1 
+ATOM 3263 C CE2 . PHE A 1 406 ? 4.625   -10.878 5.800   1.00 95.01 406 A 1 
+ATOM 3264 C CZ  . PHE A 1 406 ? 3.705   -10.082 5.106   1.00 95.85 406 A 1 
+ATOM 3265 N N   . SER A 1 407 ? 10.562  -8.848  2.987   1.00 90.98 407 A 1 
+ATOM 3266 C CA  . SER A 1 407 ? 11.847  -8.196  2.754   1.00 89.13 407 A 1 
+ATOM 3267 C C   . SER A 1 407 ? 11.627  -6.695  2.638   1.00 89.38 407 A 1 
+ATOM 3268 O O   . SER A 1 407 ? 10.859  -6.235  1.798   1.00 85.62 407 A 1 
+ATOM 3269 C CB  . SER A 1 407 ? 12.517  -8.762  1.499   1.00 85.34 407 A 1 
+ATOM 3270 O OG  . SER A 1 407 ? 12.797  -10.133 1.705   1.00 74.90 407 A 1 
+ATOM 3271 N N   . ARG A 1 408 ? 12.300  -5.912  3.476   1.00 86.73 408 A 1 
+ATOM 3272 C CA  . ARG A 1 408 ? 12.275  -4.444  3.382   1.00 84.68 408 A 1 
+ATOM 3273 C C   . ARG A 1 408 ? 13.610  -3.940  2.872   1.00 81.89 408 A 1 
+ATOM 3274 O O   . ARG A 1 408 ? 14.660  -4.465  3.242   1.00 75.40 408 A 1 
+ATOM 3275 C CB  . ARG A 1 408 ? 11.881  -3.806  4.719   1.00 83.44 408 A 1 
+ATOM 3276 C CG  . ARG A 1 408 ? 10.475  -4.240  5.150   1.00 80.96 408 A 1 
+ATOM 3277 C CD  . ARG A 1 408 ? 10.008  -3.483  6.389   1.00 81.32 408 A 1 
+ATOM 3278 N NE  . ARG A 1 408 ? 8.911   -4.223  7.040   1.00 79.44 408 A 1 
+ATOM 3279 C CZ  . ARG A 1 408 ? 8.870   -4.570  8.307   1.00 79.29 408 A 1 
+ATOM 3280 N NH1 . ARG A 1 408 ? 9.686   -4.084  9.189   1.00 70.92 408 A 1 
+ATOM 3281 N NH2 . ARG A 1 408 ? 8.022   -5.460  8.708   1.00 72.48 408 A 1 
+ATOM 3282 N N   . ASN A 1 409 ? 13.551  -2.928  2.028   1.00 76.41 409 A 1 
+ATOM 3283 C CA  . ASN A 1 409 ? 14.759  -2.385  1.418   1.00 71.35 409 A 1 
+ATOM 3284 C C   . ASN A 1 409 ? 15.495  -1.482  2.424   1.00 70.45 409 A 1 
+ATOM 3285 O O   . ASN A 1 409 ? 15.321  -0.269  2.452   1.00 63.69 409 A 1 
+ATOM 3286 C CB  . ASN A 1 409 ? 14.390  -1.722  0.072   1.00 65.23 409 A 1 
+ATOM 3287 C CG  . ASN A 1 409 ? 15.519  -1.800  -0.938  1.00 58.03 409 A 1 
+ATOM 3288 O OD1 . ASN A 1 409 ? 16.599  -2.291  -0.676  1.00 53.44 409 A 1 
+ATOM 3289 N ND2 . ASN A 1 409 ? 15.293  -1.350  -2.147  1.00 51.65 409 A 1 
+ATOM 3290 N N   . LYS A 1 410 ? 16.315  -2.086  3.280   1.00 70.15 410 A 1 
+ATOM 3291 C CA  . LYS A 1 410 ? 17.178  -1.388  4.246   1.00 66.57 410 A 1 
+ATOM 3292 C C   . LYS A 1 410 ? 18.513  -0.997  3.594   1.00 67.17 410 A 1 
+ATOM 3293 O O   . LYS A 1 410 ? 19.581  -1.313  4.113   1.00 60.62 410 A 1 
+ATOM 3294 C CB  . LYS A 1 410 ? 17.362  -2.232  5.517   1.00 60.49 410 A 1 
+ATOM 3295 C CG  . LYS A 1 410 ? 16.063  -2.477  6.299   1.00 54.23 410 A 1 
+ATOM 3296 C CD  . LYS A 1 410 ? 16.377  -3.299  7.553   1.00 53.11 410 A 1 
+ATOM 3297 C CE  . LYS A 1 410 ? 15.101  -3.634  8.328   1.00 47.91 410 A 1 
+ATOM 3298 N NZ  . LYS A 1 410 ? 15.369  -4.692  9.324   1.00 43.82 410 A 1 
+ATOM 3299 N N   . ASN A 1 411 ? 18.452  -0.333  2.444   1.00 65.80 411 A 1 
+ATOM 3300 C CA  . ASN A 1 411 ? 19.655  0.101   1.718   1.00 64.45 411 A 1 
+ATOM 3301 C C   . ASN A 1 411 ? 20.473  1.173   2.459   1.00 65.97 411 A 1 
+ATOM 3302 O O   . ASN A 1 411 ? 21.597  1.474   2.053   1.00 60.80 411 A 1 
+ATOM 3303 C CB  . ASN A 1 411 ? 19.265  0.558   0.297   1.00 59.01 411 A 1 
+ATOM 3304 C CG  . ASN A 1 411 ? 19.088  -0.594  -0.681  1.00 53.90 411 A 1 
+ATOM 3305 O OD1 . ASN A 1 411 ? 19.381  -1.741  -0.412  1.00 50.03 411 A 1 
+ATOM 3306 N ND2 . ASN A 1 411 ? 18.616  -0.307  -1.873  1.00 49.23 411 A 1 
+ATOM 3307 N N   . ASN A 1 412 ? 19.948  1.699   3.568   1.00 65.68 412 A 1 
+ATOM 3308 C CA  . ASN A 1 412 ? 20.709  2.596   4.429   1.00 64.32 412 A 1 
+ATOM 3309 C C   . ASN A 1 412 ? 21.847  1.808   5.097   1.00 65.61 412 A 1 
+ATOM 3310 O O   . ASN A 1 412 ? 21.616  0.884   5.879   1.00 61.18 412 A 1 
+ATOM 3311 C CB  . ASN A 1 412 ? 19.752  3.297   5.412   1.00 59.89 412 A 1 
+ATOM 3312 C CG  . ASN A 1 412 ? 18.789  4.258   4.719   1.00 52.97 412 A 1 
+ATOM 3313 O OD1 . ASN A 1 412 ? 18.910  4.558   3.538   1.00 49.06 412 A 1 
+ATOM 3314 N ND2 . ASN A 1 412 ? 17.811  4.764   5.438   1.00 47.93 412 A 1 
+ATOM 3315 N N   . ASN A 1 413 ? 23.076  2.173   4.764   1.00 68.32 413 A 1 
+ATOM 3316 C CA  . ASN A 1 413 ? 24.329  1.674   5.347   1.00 70.28 413 A 1 
+ATOM 3317 C C   . ASN A 1 413 ? 24.791  0.268   4.923   1.00 75.24 413 A 1 
+ATOM 3318 O O   . ASN A 1 413 ? 25.311  -0.486  5.749   1.00 72.10 413 A 1 
+ATOM 3319 C CB  . ASN A 1 413 ? 24.317  1.882   6.876   1.00 63.89 413 A 1 
+ATOM 3320 C CG  . ASN A 1 413 ? 24.165  3.334   7.273   1.00 57.01 413 A 1 
+ATOM 3321 O OD1 . ASN A 1 413 ? 24.707  4.221   6.635   1.00 54.20 413 A 1 
+ATOM 3322 N ND2 . ASN A 1 413 ? 23.460  3.624   8.341   1.00 51.12 413 A 1 
+ATOM 3323 N N   . LEU A 1 414 ? 24.749  -0.070  3.628   1.00 69.60 414 A 1 
+ATOM 3324 C CA  . LEU A 1 414 ? 25.370  -1.309  3.118   1.00 72.37 414 A 1 
+ATOM 3325 C C   . LEU A 1 414 ? 26.837  -1.470  3.562   1.00 75.62 414 A 1 
+ATOM 3326 O O   . LEU A 1 414 ? 27.241  -2.562  3.955   1.00 75.16 414 A 1 
+ATOM 3327 C CB  . LEU A 1 414 ? 25.245  -1.345  1.580   1.00 69.71 414 A 1 
+ATOM 3328 C CG  . LEU A 1 414 ? 25.757  -2.652  0.935   1.00 65.50 414 A 1 
+ATOM 3329 C CD1 . LEU A 1 414 ? 24.939  -3.872  1.367   1.00 64.19 414 A 1 
+ATOM 3330 C CD2 . LEU A 1 414 ? 25.683  -2.538  -0.588  1.00 61.37 414 A 1 
+ATOM 3331 N N   . LEU A 1 415 ? 27.612  -0.390  3.583   1.00 74.62 415 A 1 
+ATOM 3332 C CA  . LEU A 1 415 ? 29.004  -0.405  4.055   1.00 76.24 415 A 1 
+ATOM 3333 C C   . LEU A 1 415 ? 29.113  -0.817  5.532   1.00 78.31 415 A 1 
+ATOM 3334 O O   . LEU A 1 415 ? 29.939  -1.660  5.878   1.00 78.01 415 A 1 
+ATOM 3335 C CB  . LEU A 1 415 ? 29.629  0.983   3.814   1.00 74.61 415 A 1 
+ATOM 3336 C CG  . LEU A 1 415 ? 31.116  1.085   4.227   1.00 69.82 415 A 1 
+ATOM 3337 C CD1 . LEU A 1 415 ? 32.010  0.173   3.383   1.00 66.89 415 A 1 
+ATOM 3338 C CD2 . LEU A 1 415 ? 31.597  2.528   4.061   1.00 65.53 415 A 1 
+ATOM 3339 N N   . VAL A 1 416 ? 28.255  -0.262  6.394   1.00 75.74 416 A 1 
+ATOM 3340 C CA  . VAL A 1 416 ? 28.235  -0.604  7.830   1.00 76.52 416 A 1 
+ATOM 3341 C C   . VAL A 1 416 ? 27.788  -2.050  8.025   1.00 80.02 416 A 1 
+ATOM 3342 O O   . VAL A 1 416 ? 28.381  -2.782  8.819   1.00 78.94 416 A 1 
+ATOM 3343 C CB  . VAL A 1 416 ? 27.327  0.363   8.619   1.00 72.80 416 A 1 
+ATOM 3344 C CG1 . VAL A 1 416 ? 27.244  0.004   10.106  1.00 68.41 416 A 1 
+ATOM 3345 C CG2 . VAL A 1 416 ? 27.842  1.808   8.512   1.00 70.41 416 A 1 
+ATOM 3346 N N   . LYS A 1 417 ? 26.777  -2.497  7.260   1.00 72.72 417 A 1 
+ATOM 3347 C CA  . LYS A 1 417 ? 26.300  -3.885  7.294   1.00 75.24 417 A 1 
+ATOM 3348 C C   . LYS A 1 417 ? 27.385  -4.872  6.859   1.00 79.98 417 A 1 
+ATOM 3349 O O   . LYS A 1 417 ? 27.618  -5.855  7.556   1.00 81.65 417 A 1 
+ATOM 3350 C CB  . LYS A 1 417 ? 25.049  -4.037  6.424   1.00 71.86 417 A 1 
+ATOM 3351 C CG  . LYS A 1 417 ? 23.810  -3.359  7.030   1.00 69.97 417 A 1 
+ATOM 3352 C CD  . LYS A 1 417 ? 22.579  -3.716  6.186   1.00 70.05 417 A 1 
+ATOM 3353 C CE  . LYS A 1 417 ? 21.298  -3.168  6.808   1.00 64.79 417 A 1 
+ATOM 3354 N NZ  . LYS A 1 417 ? 20.112  -3.739  6.124   1.00 61.06 417 A 1 
+ATOM 3355 N N   . THR A 1 418 ? 28.094  -4.607  5.769   1.00 79.30 418 A 1 
+ATOM 3356 C CA  . THR A 1 418 ? 29.178  -5.486  5.296   1.00 78.81 418 A 1 
+ATOM 3357 C C   . THR A 1 418 ? 30.374  -5.504  6.251   1.00 80.65 418 A 1 
+ATOM 3358 O O   . THR A 1 418 ? 30.921  -6.572  6.523   1.00 80.51 418 A 1 
+ATOM 3359 C CB  . THR A 1 418 ? 29.640  -5.120  3.876   1.00 77.66 418 A 1 
+ATOM 3360 O OG1 . THR A 1 418 ? 29.959  -3.757  3.774   1.00 73.05 418 A 1 
+ATOM 3361 C CG2 . THR A 1 418 ? 28.565  -5.418  2.830   1.00 73.02 418 A 1 
+ATOM 3362 N N   . GLN A 1 419 ? 30.728  -4.368  6.844   1.00 78.15 419 A 1 
+ATOM 3363 C CA  . GLN A 1 419 ? 31.762  -4.305  7.888   1.00 77.77 419 A 1 
+ATOM 3364 C C   . GLN A 1 419 ? 31.344  -5.058  9.161   1.00 80.71 419 A 1 
+ATOM 3365 O O   . GLN A 1 419 ? 32.151  -5.772  9.762   1.00 81.39 419 A 1 
+ATOM 3366 C CB  . GLN A 1 419 ? 32.051  -2.841  8.236   1.00 76.34 419 A 1 
+ATOM 3367 C CG  . GLN A 1 419 ? 32.862  -2.125  7.139   1.00 71.38 419 A 1 
+ATOM 3368 C CD  . GLN A 1 419 ? 33.054  -0.637  7.431   1.00 66.55 419 A 1 
+ATOM 3369 O OE1 . GLN A 1 419 ? 32.462  -0.045  8.320   1.00 62.92 419 A 1 
+ATOM 3370 N NE2 . GLN A 1 419 ? 33.900  0.033   6.686   1.00 59.59 419 A 1 
+ATOM 3371 N N   . SER A 1 420 ? 30.069  -4.926  9.560   1.00 81.69 420 A 1 
+ATOM 3372 C CA  . SER A 1 420 ? 29.509  -5.665  10.696  1.00 81.89 420 A 1 
+ATOM 3373 C C   . SER A 1 420 ? 29.510  -7.168  10.427  1.00 85.05 420 A 1 
+ATOM 3374 O O   . SER A 1 420 ? 29.945  -7.932  11.285  1.00 85.80 420 A 1 
+ATOM 3375 C CB  . SER A 1 420 ? 28.088  -5.190  11.010  1.00 80.14 420 A 1 
+ATOM 3376 O OG  . SER A 1 420 ? 28.091  -3.811  11.319  1.00 74.05 420 A 1 
+ATOM 3377 N N   . TYR A 1 421 ? 29.118  -7.593  9.225   1.00 83.44 421 A 1 
+ATOM 3378 C CA  . TYR A 1 421 ? 29.180  -8.994  8.795   1.00 83.51 421 A 1 
+ATOM 3379 C C   . TYR A 1 421 ? 30.604  -9.556  8.878   1.00 84.95 421 A 1 
+ATOM 3380 O O   . TYR A 1 421 ? 30.829  -10.591 9.508   1.00 85.01 421 A 1 
+ATOM 3381 C CB  . TYR A 1 421 ? 28.624  -9.108  7.370   1.00 83.89 421 A 1 
+ATOM 3382 C CG  . TYR A 1 421 ? 28.697  -10.516 6.803   1.00 85.88 421 A 1 
+ATOM 3383 C CD1 . TYR A 1 421 ? 29.581  -10.813 5.746   1.00 77.47 421 A 1 
+ATOM 3384 C CD2 . TYR A 1 421 ? 27.884  -11.525 7.344   1.00 79.64 421 A 1 
+ATOM 3385 C CE1 . TYR A 1 421 ? 29.640  -12.120 5.223   1.00 77.71 421 A 1 
+ATOM 3386 C CE2 . TYR A 1 421 ? 27.946  -12.836 6.828   1.00 78.42 421 A 1 
+ATOM 3387 C CZ  . TYR A 1 421 ? 28.821  -13.131 5.766   1.00 83.39 421 A 1 
+ATOM 3388 O OH  . TYR A 1 421 ? 28.875  -14.398 5.269   1.00 81.83 421 A 1 
+ATOM 3389 N N   . GLN A 1 422 ? 31.582  -8.838  8.335   1.00 83.05 422 A 1 
+ATOM 3390 C CA  . GLN A 1 422 ? 32.991  -9.231  8.413   1.00 82.15 422 A 1 
+ATOM 3391 C C   . GLN A 1 422 ? 33.477  -9.330  9.869   1.00 82.61 422 A 1 
+ATOM 3392 O O   . GLN A 1 422 ? 34.176  -10.279 10.236  1.00 84.60 422 A 1 
+ATOM 3393 C CB  . GLN A 1 422 ? 33.829  -8.222  7.618   1.00 84.10 422 A 1 
+ATOM 3394 C CG  . GLN A 1 422 ? 35.301  -8.653  7.508   1.00 77.62 422 A 1 
+ATOM 3395 C CD  . GLN A 1 422 ? 36.160  -7.662  6.725   1.00 74.21 422 A 1 
+ATOM 3396 O OE1 . GLN A 1 422 ? 35.764  -6.564  6.374   1.00 68.83 422 A 1 
+ATOM 3397 N NE2 . GLN A 1 422 ? 37.394  -8.014  6.430   1.00 64.56 422 A 1 
+ATOM 3398 N N   . SER A 1 423 ? 33.078  -8.371  10.706  1.00 79.43 423 A 1 
+ATOM 3399 C CA  . SER A 1 423 ? 33.435  -8.347  12.128  1.00 78.73 423 A 1 
+ATOM 3400 C C   . SER A 1 423 ? 32.830  -9.538  12.876  1.00 80.90 423 A 1 
+ATOM 3401 O O   . SER A 1 423 ? 33.547  -10.228 13.600  1.00 80.23 423 A 1 
+ATOM 3402 C CB  . SER A 1 423 ? 32.995  -7.032  12.777  1.00 80.11 423 A 1 
+ATOM 3403 O OG  . SER A 1 423 ? 33.601  -5.932  12.121  1.00 74.95 423 A 1 
+ATOM 3404 N N   . LEU A 1 424 ? 31.539  -9.835  12.654  1.00 79.79 424 A 1 
+ATOM 3405 C CA  . LEU A 1 424 ? 30.851  -10.981 13.254  1.00 77.17 424 A 1 
+ATOM 3406 C C   . LEU A 1 424 ? 31.486  -12.309 12.825  1.00 78.85 424 A 1 
+ATOM 3407 O O   . LEU A 1 424 ? 31.789  -13.138 13.684  1.00 80.42 424 A 1 
+ATOM 3408 C CB  . LEU A 1 424 ? 29.355  -10.943 12.887  1.00 78.65 424 A 1 
+ATOM 3409 C CG  . LEU A 1 424 ? 28.543  -9.836  13.585  1.00 80.86 424 A 1 
+ATOM 3410 C CD1 . LEU A 1 424 ? 27.132  -9.800  12.993  1.00 74.97 424 A 1 
+ATOM 3411 C CD2 . LEU A 1 424 ? 28.423  -10.059 15.095  1.00 78.80 424 A 1 
+ATOM 3412 N N   . LEU A 1 425 ? 31.767  -12.486 11.539  1.00 83.78 425 A 1 
+ATOM 3413 C CA  . LEU A 1 425 ? 32.457  -13.679 11.034  1.00 79.77 425 A 1 
+ATOM 3414 C C   . LEU A 1 425 ? 33.842  -13.867 11.663  1.00 79.19 425 A 1 
+ATOM 3415 O O   . LEU A 1 425 ? 34.227  -14.986 12.003  1.00 78.61 425 A 1 
+ATOM 3416 C CB  . LEU A 1 425 ? 32.601  -13.587 9.509   1.00 80.14 425 A 1 
+ATOM 3417 C CG  . LEU A 1 425 ? 31.339  -13.933 8.708   1.00 75.75 425 A 1 
+ATOM 3418 C CD1 . LEU A 1 425 ? 31.669  -13.731 7.227   1.00 69.12 425 A 1 
+ATOM 3419 C CD2 . LEU A 1 425 ? 30.906  -15.390 8.898   1.00 72.69 425 A 1 
+ATOM 3420 N N   . SER A 1 426 ? 34.579  -12.777 11.870  1.00 82.85 426 A 1 
+ATOM 3421 C CA  . SER A 1 426 ? 35.918  -12.833 12.474  1.00 80.46 426 A 1 
+ATOM 3422 C C   . SER A 1 426 ? 35.925  -13.347 13.921  1.00 80.37 426 A 1 
+ATOM 3423 O O   . SER A 1 426 ? 36.930  -13.899 14.366  1.00 77.13 426 A 1 
+ATOM 3424 C CB  . SER A 1 426 ? 36.609  -11.468 12.373  1.00 81.91 426 A 1 
+ATOM 3425 O OG  . SER A 1 426 ? 36.139  -10.546 13.337  1.00 74.77 426 A 1 
+ATOM 3426 N N   . THR A 1 427 ? 34.784  -13.243 14.637  1.00 84.51 427 A 1 
+ATOM 3427 C CA  . THR A 1 427 ? 34.650  -13.772 16.005  1.00 79.83 427 A 1 
+ATOM 3428 C C   . THR A 1 427 ? 34.664  -15.300 16.058  1.00 80.79 427 A 1 
+ATOM 3429 O O   . THR A 1 427 ? 34.962  -15.868 17.108  1.00 77.16 427 A 1 
+ATOM 3430 C CB  . THR A 1 427 ? 33.371  -13.283 16.708  1.00 80.18 427 A 1 
+ATOM 3431 O OG1 . THR A 1 427 ? 32.220  -13.893 16.162  1.00 76.57 427 A 1 
+ATOM 3432 C CG2 . THR A 1 427 ? 33.184  -11.768 16.685  1.00 73.85 427 A 1 
+ATOM 3433 N N   . ARG A 1 428 ? 34.311  -15.983 14.953  1.00 84.89 428 A 1 
+ATOM 3434 C CA  . ARG A 1 428 ? 34.131  -17.444 14.855  1.00 84.30 428 A 1 
+ATOM 3435 C C   . ARG A 1 428 ? 33.155  -18.042 15.881  1.00 86.34 428 A 1 
+ATOM 3436 O O   . ARG A 1 428 ? 33.190  -19.240 16.138  1.00 80.95 428 A 1 
+ATOM 3437 C CB  . ARG A 1 428 ? 35.490  -18.169 14.873  1.00 84.09 428 A 1 
+ATOM 3438 C CG  . ARG A 1 428 ? 36.428  -17.717 13.747  1.00 83.34 428 A 1 
+ATOM 3439 C CD  . ARG A 1 428 ? 37.704  -18.563 13.793  1.00 76.36 428 A 1 
+ATOM 3440 N NE  . ARG A 1 428 ? 38.608  -18.240 12.677  1.00 72.09 428 A 1 
+ATOM 3441 C CZ  . ARG A 1 428 ? 39.720  -18.884 12.364  1.00 62.29 428 A 1 
+ATOM 3442 N NH1 . ARG A 1 428 ? 40.162  -19.884 13.078  1.00 60.52 428 A 1 
+ATOM 3443 N NH2 . ARG A 1 428 ? 40.410  -18.527 11.314  1.00 58.43 428 A 1 
+ATOM 3444 N N   . THR A 1 429 ? 32.315  -17.205 16.478  1.00 85.20 429 A 1 
+ATOM 3445 C CA  . THR A 1 429 ? 31.330  -17.612 17.495  1.00 83.15 429 A 1 
+ATOM 3446 C C   . THR A 1 429 ? 29.964  -17.902 16.871  1.00 84.56 429 A 1 
+ATOM 3447 O O   . THR A 1 429 ? 29.193  -18.682 17.420  1.00 80.71 429 A 1 
+ATOM 3448 C CB  . THR A 1 429 ? 31.190  -16.520 18.568  1.00 81.98 429 A 1 
+ATOM 3449 O OG1 . THR A 1 429 ? 32.457  -16.122 19.042  1.00 75.70 429 A 1 
+ATOM 3450 C CG2 . THR A 1 429 ? 30.399  -16.975 19.793  1.00 74.21 429 A 1 
+ATOM 3451 N N   . LEU A 1 430 ? 29.669  -17.277 15.737  1.00 78.45 430 A 1 
+ATOM 3452 C CA  . LEU A 1 430 ? 28.408  -17.370 15.014  1.00 77.82 430 A 1 
+ATOM 3453 C C   . LEU A 1 430 ? 28.624  -18.069 13.674  1.00 79.90 430 A 1 
+ATOM 3454 O O   . LEU A 1 430 ? 29.693  -17.944 13.067  1.00 77.68 430 A 1 
+ATOM 3455 C CB  . LEU A 1 430 ? 27.829  -15.959 14.817  1.00 76.33 430 A 1 
+ATOM 3456 C CG  . LEU A 1 430 ? 27.481  -15.216 16.118  1.00 76.29 430 A 1 
+ATOM 3457 C CD1 . LEU A 1 430 ? 27.105  -13.769 15.801  1.00 69.53 430 A 1 
+ATOM 3458 C CD2 . LEU A 1 430 ? 26.314  -15.865 16.865  1.00 74.44 430 A 1 
+ATOM 3459 N N   . SER A 1 431 ? 27.592  -18.776 13.204  1.00 85.22 431 A 1 
+ATOM 3460 C CA  . SER A 1 431 ? 27.584  -19.322 11.852  1.00 83.65 431 A 1 
+ATOM 3461 C C   . SER A 1 431 ? 27.473  -18.195 10.806  1.00 84.90 431 A 1 
+ATOM 3462 O O   . SER A 1 431 ? 26.973  -17.109 11.112  1.00 84.23 431 A 1 
+ATOM 3463 C CB  . SER A 1 431 ? 26.455  -20.353 11.701  1.00 81.25 431 A 1 
+ATOM 3464 O OG  . SER A 1 431 ? 25.203  -19.713 11.642  1.00 76.64 431 A 1 
+ATOM 3465 N N   . PRO A 1 432 ? 27.904  -18.422 9.554   1.00 84.38 432 A 1 
+ATOM 3466 C CA  . PRO A 1 432 ? 27.677  -17.457 8.475   1.00 82.40 432 A 1 
+ATOM 3467 C C   . PRO A 1 432 ? 26.196  -17.093 8.280   1.00 84.56 432 A 1 
+ATOM 3468 O O   . PRO A 1 432 ? 25.879  -15.937 7.998   1.00 83.89 432 A 1 
+ATOM 3469 C CB  . PRO A 1 432 ? 28.263  -18.115 7.224   1.00 80.69 432 A 1 
+ATOM 3470 C CG  . PRO A 1 432 ? 29.338  -19.052 7.774   1.00 79.44 432 A 1 
+ATOM 3471 C CD  . PRO A 1 432 ? 28.720  -19.531 9.090   1.00 84.25 432 A 1 
+ATOM 3472 N N   . GLU A 1 433 ? 25.292  -18.060 8.486   1.00 83.32 433 A 1 
+ATOM 3473 C CA  . GLU A 1 433 ? 23.835  -17.869 8.448   1.00 81.40 433 A 1 
+ATOM 3474 C C   . GLU A 1 433 ? 23.364  -16.896 9.536   1.00 81.82 433 A 1 
+ATOM 3475 O O   . GLU A 1 433 ? 22.653  -15.930 9.242   1.00 79.57 433 A 1 
+ATOM 3476 C CB  . GLU A 1 433 ? 23.161  -19.238 8.624   1.00 79.47 433 A 1 
+ATOM 3477 C CG  . GLU A 1 433 ? 21.629  -19.160 8.610   1.00 68.74 433 A 1 
+ATOM 3478 C CD  . GLU A 1 433 ? 20.963  -20.524 8.868   1.00 66.64 433 A 1 
+ATOM 3479 O OE1 . GLU A 1 433 ? 19.720  -20.582 8.757   1.00 59.89 433 A 1 
+ATOM 3480 O OE2 . GLU A 1 433 ? 21.690  -21.514 9.139   1.00 59.25 433 A 1 
+ATOM 3481 N N   . ASP A 1 434 ? 23.801  -17.112 10.778  1.00 83.60 434 A 1 
+ATOM 3482 C CA  . ASP A 1 434 ? 23.475  -16.225 11.894  1.00 83.01 434 A 1 
+ATOM 3483 C C   . ASP A 1 434 ? 23.991  -14.807 11.632  1.00 84.84 434 A 1 
+ATOM 3484 O O   . ASP A 1 434 ? 23.286  -13.824 11.858  1.00 83.46 434 A 1 
+ATOM 3485 C CB  . ASP A 1 434 ? 24.097  -16.732 13.202  1.00 81.48 434 A 1 
+ATOM 3486 C CG  . ASP A 1 434 ? 23.579  -18.094 13.653  1.00 80.22 434 A 1 
+ATOM 3487 O OD1 . ASP A 1 434 ? 22.352  -18.294 13.619  1.00 74.40 434 A 1 
+ATOM 3488 O OD2 . ASP A 1 434 ? 24.454  -18.912 14.042  1.00 76.16 434 A 1 
+ATOM 3489 N N   . CYS A 1 435 ? 25.210  -14.693 11.111  1.00 80.27 435 A 1 
+ATOM 3490 C CA  . CYS A 1 435 ? 25.806  -13.401 10.779  1.00 80.03 435 A 1 
+ATOM 3491 C C   . CYS A 1 435 ? 25.005  -12.656 9.698   1.00 81.54 435 A 1 
+ATOM 3492 O O   . CYS A 1 435 ? 24.723  -11.469 9.858   1.00 81.71 435 A 1 
+ATOM 3493 C CB  . CYS A 1 435 ? 27.260  -13.605 10.330  1.00 80.42 435 A 1 
+ATOM 3494 S SG  . CYS A 1 435 ? 28.285  -14.234 11.688  1.00 80.30 435 A 1 
+ATOM 3495 N N   . LEU A 1 436 ? 24.606  -13.341 8.614   1.00 82.33 436 A 1 
+ATOM 3496 C CA  . LEU A 1 436 ? 23.769  -12.753 7.559   1.00 78.74 436 A 1 
+ATOM 3497 C C   . LEU A 1 436 ? 22.382  -12.361 8.078   1.00 77.66 436 A 1 
+ATOM 3498 O O   . LEU A 1 436 ? 21.859  -11.312 7.696   1.00 75.47 436 A 1 
+ATOM 3499 C CB  . LEU A 1 436 ? 23.632  -13.739 6.385   1.00 77.95 436 A 1 
+ATOM 3500 C CG  . LEU A 1 436 ? 24.881  -13.859 5.496   1.00 76.79 436 A 1 
+ATOM 3501 C CD1 . LEU A 1 436 ? 24.662  -14.950 4.449   1.00 70.85 436 A 1 
+ATOM 3502 C CD2 . LEU A 1 436 ? 25.191  -12.558 4.745   1.00 73.26 436 A 1 
+ATOM 3503 N N   . SER A 1 437 ? 21.819  -13.177 8.978   1.00 83.06 437 A 1 
+ATOM 3504 C CA  . SER A 1 437 ? 20.515  -12.931 9.599   1.00 79.53 437 A 1 
+ATOM 3505 C C   . SER A 1 437 ? 20.545  -11.722 10.537  1.00 78.72 437 A 1 
+ATOM 3506 O O   . SER A 1 437 ? 19.670  -10.864 10.466  1.00 76.71 437 A 1 
+ATOM 3507 C CB  . SER A 1 437 ? 20.057  -14.176 10.365  1.00 77.78 437 A 1 
+ATOM 3508 O OG  . SER A 1 437 ? 19.907  -15.257 9.473   1.00 67.47 437 A 1 
+ATOM 3509 N N   . ILE A 1 438 ? 21.572  -11.614 11.384  1.00 80.08 438 A 1 
+ATOM 3510 C CA  . ILE A 1 438 ? 21.749  -10.492 12.323  1.00 79.09 438 A 1 
+ATOM 3511 C C   . ILE A 1 438 ? 21.955  -9.172  11.576  1.00 79.69 438 A 1 
+ATOM 3512 O O   . ILE A 1 438 ? 21.398  -8.147  11.959  1.00 77.07 438 A 1 
+ATOM 3513 C CB  . ILE A 1 438 ? 22.927  -10.786 13.284  1.00 80.30 438 A 1 
+ATOM 3514 C CG1 . ILE A 1 438 ? 22.544  -11.913 14.271  1.00 80.50 438 A 1 
+ATOM 3515 C CG2 . ILE A 1 438 ? 23.355  -9.530  14.074  1.00 78.32 438 A 1 
+ATOM 3516 C CD1 . ILE A 1 438 ? 23.741  -12.503 15.028  1.00 75.62 438 A 1 
+ATOM 3517 N N   . VAL A 1 439 ? 22.759  -9.193  10.521  1.00 81.87 439 A 1 
+ATOM 3518 C CA  . VAL A 1 439 ? 23.074  -7.975  9.754   1.00 77.62 439 A 1 
+ATOM 3519 C C   . VAL A 1 439 ? 21.960  -7.618  8.758   1.00 76.16 439 A 1 
+ATOM 3520 O O   . VAL A 1 439 ? 21.898  -6.482  8.282   1.00 71.14 439 A 1 
+ATOM 3521 C CB  . VAL A 1 439 ? 24.467  -8.112  9.105   1.00 77.78 439 A 1 
+ATOM 3522 C CG1 . VAL A 1 439 ? 24.891  -6.841  8.378   1.00 72.06 439 A 1 
+ATOM 3523 C CG2 . VAL A 1 439 ? 25.550  -8.358  10.168  1.00 73.14 439 A 1 
+ATOM 3524 N N   . ASP A 1 440 ? 21.037  -8.547  8.485   1.00 77.63 440 A 1 
+ATOM 3525 C CA  . ASP A 1 440 ? 19.877  -8.373  7.601   1.00 74.35 440 A 1 
+ATOM 3526 C C   . ASP A 1 440 ? 20.291  -7.857  6.206   1.00 74.87 440 A 1 
+ATOM 3527 O O   . ASP A 1 440 ? 19.842  -6.809  5.731   1.00 71.51 440 A 1 
+ATOM 3528 C CB  . ASP A 1 440 ? 18.828  -7.523  8.345   1.00 70.40 440 A 1 
+ATOM 3529 C CG  . ASP A 1 440 ? 17.455  -7.452  7.675   1.00 64.91 440 A 1 
+ATOM 3530 O OD1 . ASP A 1 440 ? 17.078  -8.381  6.940   1.00 62.96 440 A 1 
+ATOM 3531 O OD2 . ASP A 1 440 ? 16.749  -6.450  7.977   1.00 60.30 440 A 1 
+ATOM 3532 N N   . LEU A 1 441 ? 21.257  -8.563  5.600   1.00 71.42 441 A 1 
+ATOM 3533 C CA  . LEU A 1 441 ? 21.816  -8.244  4.279   1.00 70.07 441 A 1 
+ATOM 3534 C C   . LEU A 1 441 ? 21.036  -8.889  3.133   1.00 70.27 441 A 1 
+ATOM 3535 O O   . LEU A 1 441 ? 20.989  -8.325  2.042   1.00 66.21 441 A 1 
+ATOM 3536 C CB  . LEU A 1 441 ? 23.284  -8.708  4.218   1.00 67.39 441 A 1 
+ATOM 3537 C CG  . LEU A 1 441 ? 24.300  -7.730  4.834   1.00 65.65 441 A 1 
+ATOM 3538 C CD1 . LEU A 1 441 ? 25.678  -8.390  4.901   1.00 62.86 441 A 1 
+ATOM 3539 C CD2 . LEU A 1 441 ? 24.438  -6.461  3.995   1.00 62.88 441 A 1 
+ATOM 3540 N N   . VAL A 1 442 ? 20.476  -10.077 3.356   1.00 71.71 442 A 1 
+ATOM 3541 C CA  . VAL A 1 442 ? 19.849  -10.909 2.323   1.00 69.48 442 A 1 
+ATOM 3542 C C   . VAL A 1 442 ? 18.491  -11.427 2.786   1.00 69.31 442 A 1 
+ATOM 3543 O O   . VAL A 1 442 ? 18.230  -11.554 3.985   1.00 64.42 442 A 1 
+ATOM 3544 C CB  . VAL A 1 442 ? 20.771  -12.066 1.885   1.00 66.09 442 A 1 
+ATOM 3545 C CG1 . VAL A 1 442 ? 22.092  -11.542 1.295   1.00 62.59 442 A 1 
+ATOM 3546 C CG2 . VAL A 1 442 ? 21.094  -13.042 3.019   1.00 62.41 442 A 1 
+ATOM 3547 N N   . SER A 1 443 ? 17.610  -11.722 1.823   1.00 69.80 443 A 1 
+ATOM 3548 C CA  . SER A 1 443 ? 16.271  -12.253 2.089   1.00 67.66 443 A 1 
+ATOM 3549 C C   . SER A 1 443 ? 16.301  -13.715 2.547   1.00 69.76 443 A 1 
+ATOM 3550 O O   . SER A 1 443 ? 15.557  -14.056 3.454   1.00 65.85 443 A 1 
+ATOM 3551 C CB  . SER A 1 443 ? 15.382  -12.101 0.851   1.00 62.64 443 A 1 
+ATOM 3552 O OG  . SER A 1 443 ? 16.048  -12.616 -0.284  1.00 56.68 443 A 1 
+ATOM 3553 N N   . ASP A 1 444 ? 17.184  -14.542 2.000   1.00 70.22 444 A 1 
+ATOM 3554 C CA  . ASP A 1 444 ? 17.372  -15.931 2.431   1.00 71.18 444 A 1 
+ATOM 3555 C C   . ASP A 1 444 ? 18.868  -16.209 2.675   1.00 74.90 444 A 1 
+ATOM 3556 O O   . ASP A 1 444 ? 19.615  -16.427 1.724   1.00 73.58 444 A 1 
+ATOM 3557 C CB  . ASP A 1 444 ? 16.751  -16.892 1.407   1.00 66.68 444 A 1 
+ATOM 3558 C CG  . ASP A 1 444 ? 16.783  -18.352 1.892   1.00 61.10 444 A 1 
+ATOM 3559 O OD1 . ASP A 1 444 ? 17.542  -18.653 2.846   1.00 59.93 444 A 1 
+ATOM 3560 O OD2 . ASP A 1 444 ? 16.027  -19.157 1.307   1.00 56.61 444 A 1 
+ATOM 3561 N N   . PRO A 1 445 ? 19.333  -16.167 3.938   1.00 75.36 445 A 1 
+ATOM 3562 C CA  . PRO A 1 445 ? 20.729  -16.450 4.266   1.00 77.72 445 A 1 
+ATOM 3563 C C   . PRO A 1 445 ? 21.200  -17.834 3.816   1.00 81.23 445 A 1 
+ATOM 3564 O O   . PRO A 1 445 ? 22.325  -17.957 3.337   1.00 80.04 445 A 1 
+ATOM 3565 C CB  . PRO A 1 445 ? 20.832  -16.302 5.788   1.00 75.26 445 A 1 
+ATOM 3566 C CG  . PRO A 1 445 ? 19.705  -15.333 6.124   1.00 72.24 445 A 1 
+ATOM 3567 C CD  . PRO A 1 445 ? 18.621  -15.721 5.131   1.00 75.47 445 A 1 
+ATOM 3568 N N   . ASN A 1 446 ? 20.336  -18.846 3.927   1.00 78.43 446 A 1 
+ATOM 3569 C CA  . ASN A 1 446 ? 20.680  -20.227 3.592   1.00 77.66 446 A 1 
+ATOM 3570 C C   . ASN A 1 446 ? 20.961  -20.396 2.101   1.00 80.07 446 A 1 
+ATOM 3571 O O   . ASN A 1 446 ? 21.997  -20.939 1.723   1.00 78.43 446 A 1 
+ATOM 3572 C CB  . ASN A 1 446 ? 19.546  -21.151 4.074   1.00 74.32 446 A 1 
+ATOM 3573 C CG  . ASN A 1 446 ? 19.664  -21.430 5.556   1.00 68.79 446 A 1 
+ATOM 3574 O OD1 . ASN A 1 446 ? 20.745  -21.716 6.043   1.00 64.78 446 A 1 
+ATOM 3575 N ND2 . ASN A 1 446 ? 18.603  -21.344 6.322   1.00 62.44 446 A 1 
+ATOM 3576 N N   . ASP A 1 447 ? 20.090  -19.851 1.255   1.00 74.99 447 A 1 
+ATOM 3577 C CA  . ASP A 1 447 ? 20.261  -19.912 -0.200  1.00 75.72 447 A 1 
+ATOM 3578 C C   . ASP A 1 447 ? 21.523  -19.172 -0.672  1.00 79.33 447 A 1 
+ATOM 3579 O O   . ASP A 1 447 ? 22.261  -19.643 -1.542  1.00 78.60 447 A 1 
+ATOM 3580 C CB  . ASP A 1 447 ? 19.004  -19.330 -0.850  1.00 71.49 447 A 1 
+ATOM 3581 C CG  . ASP A 1 447 ? 19.140  -19.321 -2.370  1.00 64.45 447 A 1 
+ATOM 3582 O OD1 . ASP A 1 447 ? 19.261  -20.411 -2.965  1.00 62.16 447 A 1 
+ATOM 3583 O OD2 . ASP A 1 447 ? 19.210  -18.207 -2.936  1.00 58.77 447 A 1 
+ATOM 3584 N N   . TYR A 1 448 ? 21.812  -18.022 -0.084  1.00 78.92 448 A 1 
+ATOM 3585 C CA  . TYR A 1 448 ? 23.022  -17.271 -0.430  1.00 82.10 448 A 1 
+ATOM 3586 C C   . TYR A 1 448 ? 24.296  -18.005 -0.004  1.00 85.77 448 A 1 
+ATOM 3587 O O   . TYR A 1 448 ? 25.277  -17.982 -0.745  1.00 84.56 448 A 1 
+ATOM 3588 C CB  . TYR A 1 448 ? 22.968  -15.864 0.174   1.00 78.86 448 A 1 
+ATOM 3589 C CG  . TYR A 1 448 ? 22.233  -14.857 -0.694  1.00 76.74 448 A 1 
+ATOM 3590 C CD1 . TYR A 1 448 ? 22.951  -13.877 -1.406  1.00 72.85 448 A 1 
+ATOM 3591 C CD2 . TYR A 1 448 ? 20.830  -14.895 -0.786  1.00 71.94 448 A 1 
+ATOM 3592 C CE1 . TYR A 1 448 ? 22.266  -12.929 -2.191  1.00 70.02 448 A 1 
+ATOM 3593 C CE2 . TYR A 1 448 ? 20.139  -13.958 -1.576  1.00 69.79 448 A 1 
+ATOM 3594 C CZ  . TYR A 1 448 ? 20.857  -12.964 -2.272  1.00 70.55 448 A 1 
+ATOM 3595 O OH  . TYR A 1 448 ? 20.183  -12.042 -3.011  1.00 67.47 448 A 1 
+ATOM 3596 N N   . ILE A 1 449 ? 24.282  -18.661 1.158   1.00 81.62 449 A 1 
+ATOM 3597 C CA  . ILE A 1 449 ? 25.418  -19.465 1.623   1.00 83.80 449 A 1 
+ATOM 3598 C C   . ILE A 1 449 ? 25.616  -20.681 0.725   1.00 85.89 449 A 1 
+ATOM 3599 O O   . ILE A 1 449 ? 26.737  -20.922 0.288   1.00 85.91 449 A 1 
+ATOM 3600 C CB  . ILE A 1 449 ? 25.231  -19.866 3.101   1.00 83.76 449 A 1 
+ATOM 3601 C CG1 . ILE A 1 449 ? 25.379  -18.605 3.977   1.00 80.66 449 A 1 
+ATOM 3602 C CG2 . ILE A 1 449 ? 26.260  -20.930 3.543   1.00 79.83 449 A 1 
+ATOM 3603 C CD1 . ILE A 1 449 ? 24.826  -18.810 5.385   1.00 73.05 449 A 1 
+ATOM 3604 N N   . GLU A 1 450 ? 24.555  -21.416 0.410   1.00 81.13 450 A 1 
+ATOM 3605 C CA  . GLU A 1 450 ? 24.628  -22.607 -0.442  1.00 79.96 450 A 1 
+ATOM 3606 C C   . GLU A 1 450 ? 25.165  -22.264 -1.836  1.00 81.10 450 A 1 
+ATOM 3607 O O   . GLU A 1 450 ? 26.125  -22.885 -2.304  1.00 79.29 450 A 1 
+ATOM 3608 C CB  . GLU A 1 450 ? 23.230  -23.242 -0.506  1.00 76.99 450 A 1 
+ATOM 3609 C CG  . GLU A 1 450 ? 23.226  -24.585 -1.250  1.00 69.71 450 A 1 
+ATOM 3610 C CD  . GLU A 1 450 ? 21.832  -25.235 -1.293  1.00 68.22 450 A 1 
+ATOM 3611 O OE1 . GLU A 1 450 ? 21.764  -26.436 -1.639  1.00 61.18 450 A 1 
+ATOM 3612 O OE2 . GLU A 1 450 ? 20.824  -24.547 -1.005  1.00 61.49 450 A 1 
+ATOM 3613 N N   . ARG A 1 451 ? 24.624  -21.210 -2.469  1.00 81.36 451 A 1 
+ATOM 3614 C CA  . ARG A 1 451 ? 25.135  -20.716 -3.754  1.00 80.93 451 A 1 
+ATOM 3615 C C   . ARG A 1 451 ? 26.576  -20.221 -3.657  1.00 83.77 451 A 1 
+ATOM 3616 O O   . ARG A 1 451 ? 27.357  -20.448 -4.579  1.00 83.06 451 A 1 
+ATOM 3617 C CB  . ARG A 1 451 ? 24.223  -19.609 -4.293  1.00 78.43 451 A 1 
+ATOM 3618 C CG  . ARG A 1 451 ? 22.888  -20.179 -4.803  1.00 74.31 451 A 1 
+ATOM 3619 C CD  . ARG A 1 451 ? 22.074  -19.120 -5.550  1.00 73.02 451 A 1 
+ATOM 3620 N NE  . ARG A 1 451 ? 21.503  -18.105 -4.655  1.00 67.27 451 A 1 
+ATOM 3621 C CZ  . ARG A 1 451 ? 21.338  -16.824 -4.900  1.00 62.09 451 A 1 
+ATOM 3622 N NH1 . ARG A 1 451 ? 21.807  -16.249 -5.963  1.00 58.91 451 A 1 
+ATOM 3623 N NH2 . ARG A 1 451 ? 20.661  -16.093 -4.070  1.00 55.81 451 A 1 
+ATOM 3624 N N   . GLY A 1 452 ? 26.918  -19.561 -2.563  1.00 81.30 452 A 1 
+ATOM 3625 C CA  . GLY A 1 452 ? 28.284  -19.117 -2.292  1.00 80.89 452 A 1 
+ATOM 3626 C C   . GLY A 1 452 ? 29.258  -20.286 -2.179  1.00 83.24 452 A 1 
+ATOM 3627 O O   . GLY A 1 452 ? 30.282  -20.282 -2.858  1.00 83.82 452 A 1 
+ATOM 3628 N N   . LEU A 1 453 ? 28.911  -21.307 -1.393  1.00 83.58 453 A 1 
+ATOM 3629 C CA  . LEU A 1 453 ? 29.728  -22.514 -1.240  1.00 82.42 453 A 1 
+ATOM 3630 C C   . LEU A 1 453 ? 29.921  -23.233 -2.579  1.00 83.83 453 A 1 
+ATOM 3631 O O   . LEU A 1 453 ? 31.059  -23.499 -2.952  1.00 84.52 453 A 1 
+ATOM 3632 C CB  . LEU A 1 453 ? 29.083  -23.452 -0.200  1.00 82.04 453 A 1 
+ATOM 3633 C CG  . LEU A 1 453 ? 29.185  -22.959 1.261   1.00 76.67 453 A 1 
+ATOM 3634 C CD1 . LEU A 1 453 ? 28.354  -23.872 2.167   1.00 71.57 453 A 1 
+ATOM 3635 C CD2 . LEU A 1 453 ? 30.626  -22.959 1.777   1.00 73.96 453 A 1 
+ATOM 3636 N N   . ALA A 1 454 ? 28.838  -23.448 -3.330  1.00 81.15 454 A 1 
+ATOM 3637 C CA  . ALA A 1 454 ? 28.915  -24.074 -4.652  1.00 80.04 454 A 1 
+ATOM 3638 C C   . ALA A 1 454 ? 29.783  -23.272 -5.641  1.00 82.46 454 A 1 
+ATOM 3639 O O   . ALA A 1 454 ? 30.525  -23.848 -6.438  1.00 80.32 454 A 1 
+ATOM 3640 C CB  . ALA A 1 454 ? 27.481  -24.234 -5.181  1.00 79.47 454 A 1 
+ATOM 3641 N N   . PHE A 1 455 ? 29.709  -21.942 -5.582  1.00 83.04 455 A 1 
+ATOM 3642 C CA  . PHE A 1 455 ? 30.548  -21.076 -6.413  1.00 78.93 455 A 1 
+ATOM 3643 C C   . PHE A 1 455 ? 32.035  -21.201 -6.056  1.00 80.50 455 A 1 
+ATOM 3644 O O   . PHE A 1 455 ? 32.865  -21.342 -6.953  1.00 78.76 455 A 1 
+ATOM 3645 C CB  . PHE A 1 455 ? 30.075  -19.623 -6.274  1.00 77.48 455 A 1 
+ATOM 3646 C CG  . PHE A 1 455 ? 30.967  -18.626 -6.993  1.00 79.03 455 A 1 
+ATOM 3647 C CD1 . PHE A 1 455 ? 32.010  -17.980 -6.299  1.00 73.45 455 A 1 
+ATOM 3648 C CD2 . PHE A 1 455 ? 30.790  -18.380 -8.364  1.00 76.73 455 A 1 
+ATOM 3649 C CE1 . PHE A 1 455 ? 32.869  -17.092 -6.974  1.00 74.90 455 A 1 
+ATOM 3650 C CE2 . PHE A 1 455 ? 31.646  -17.494 -9.041  1.00 76.56 455 A 1 
+ATOM 3651 C CZ  . PHE A 1 455 ? 32.686  -16.847 -8.345  1.00 79.17 455 A 1 
+ATOM 3652 N N   . TRP A 1 456 ? 32.377  -21.167 -4.762  1.00 84.07 456 A 1 
+ATOM 3653 C CA  . TRP A 1 456 ? 33.770  -21.265 -4.317  1.00 81.01 456 A 1 
+ATOM 3654 C C   . TRP A 1 456 ? 34.351  -22.660 -4.549  1.00 81.42 456 A 1 
+ATOM 3655 O O   . TRP A 1 456 ? 35.474  -22.752 -5.034  1.00 79.33 456 A 1 
+ATOM 3656 C CB  . TRP A 1 456 ? 33.890  -20.831 -2.855  1.00 79.62 456 A 1 
+ATOM 3657 C CG  . TRP A 1 456 ? 33.736  -19.352 -2.630  1.00 81.88 456 A 1 
+ATOM 3658 C CD1 . TRP A 1 456 ? 32.726  -18.750 -1.962  1.00 75.75 456 A 1 
+ATOM 3659 C CD2 . TRP A 1 456 ? 34.593  -18.268 -3.110  1.00 81.49 456 A 1 
+ATOM 3660 N NE1 . TRP A 1 456 ? 32.892  -17.378 -1.996  1.00 75.04 456 A 1 
+ATOM 3661 C CE2 . TRP A 1 456 ? 34.026  -17.027 -2.691  1.00 79.09 456 A 1 
+ATOM 3662 C CE3 . TRP A 1 456 ? 35.788  -18.209 -3.862  1.00 76.91 456 A 1 
+ATOM 3663 C CZ2 . TRP A 1 456 ? 34.614  -15.787 -3.001  1.00 78.27 456 A 1 
+ATOM 3664 C CZ3 . TRP A 1 456 ? 36.386  -16.972 -4.180  1.00 73.88 456 A 1 
+ATOM 3665 C CH2 . TRP A 1 456 ? 35.800  -15.765 -3.747  1.00 73.51 456 A 1 
+ATOM 3666 N N   . GLU A 1 457 ? 33.569  -23.720 -4.321  1.00 79.62 457 A 1 
+ATOM 3667 C CA  . GLU A 1 457 ? 33.987  -25.098 -4.614  1.00 77.45 457 A 1 
+ATOM 3668 C C   . GLU A 1 457 ? 34.287  -25.282 -6.108  1.00 76.69 457 A 1 
+ATOM 3669 O O   . GLU A 1 457 ? 35.341  -25.807 -6.482  1.00 76.03 457 A 1 
+ATOM 3670 C CB  . GLU A 1 457 ? 32.878  -26.051 -4.135  1.00 79.11 457 A 1 
+ATOM 3671 C CG  . GLU A 1 457 ? 33.260  -27.535 -4.251  1.00 72.17 457 A 1 
+ATOM 3672 C CD  . GLU A 1 457 ? 32.186  -28.490 -3.691  1.00 67.64 457 A 1 
+ATOM 3673 O OE1 . GLU A 1 457 ? 32.521  -29.684 -3.506  1.00 62.65 457 A 1 
+ATOM 3674 O OE2 . GLU A 1 457 ? 31.043  -28.041 -3.452  1.00 65.95 457 A 1 
+ATOM 3675 N N   . LYS A 1 458 ? 33.407  -24.780 -6.974  1.00 82.34 458 A 1 
+ATOM 3676 C CA  . LYS A 1 458 ? 33.641  -24.806 -8.424  1.00 78.13 458 A 1 
+ATOM 3677 C C   . LYS A 1 458 ? 34.908  -24.039 -8.811  1.00 78.66 458 A 1 
+ATOM 3678 O O   . LYS A 1 458 ? 35.711  -24.543 -9.590  1.00 78.82 458 A 1 
+ATOM 3679 C CB  . LYS A 1 458 ? 32.399  -24.272 -9.148  1.00 78.08 458 A 1 
+ATOM 3680 C CG  . LYS A 1 458 ? 32.572  -24.421 -10.660 1.00 71.49 458 A 1 
+ATOM 3681 C CD  . LYS A 1 458 ? 31.356  -23.902 -11.421 1.00 67.30 458 A 1 
+ATOM 3682 C CE  . LYS A 1 458 ? 31.720  -24.000 -12.901 1.00 62.66 458 A 1 
+ATOM 3683 N NZ  . LYS A 1 458 ? 30.717  -23.377 -13.781 1.00 53.02 458 A 1 
+ATOM 3684 N N   . ARG A 1 459 ? 35.102  -22.862 -8.239  1.00 81.59 459 A 1 
+ATOM 3685 C CA  . ARG A 1 459 ? 36.285  -22.044 -8.508  1.00 78.42 459 A 1 
+ATOM 3686 C C   . ARG A 1 459 ? 37.578  -22.711 -8.026  1.00 78.85 459 A 1 
+ATOM 3687 O O   . ARG A 1 459 ? 38.567  -22.696 -8.756  1.00 79.48 459 A 1 
+ATOM 3688 C CB  . ARG A 1 459 ? 36.069  -20.668 -7.886  1.00 78.61 459 A 1 
+ATOM 3689 C CG  . ARG A 1 459 ? 37.255  -19.758 -8.183  1.00 72.13 459 A 1 
+ATOM 3690 C CD  . ARG A 1 459 ? 36.995  -18.367 -7.619  1.00 68.51 459 A 1 
+ATOM 3691 N NE  . ARG A 1 459 ? 38.224  -17.586 -7.731  1.00 62.89 459 A 1 
+ATOM 3692 C CZ  . ARG A 1 459 ? 38.349  -16.285 -7.821  1.00 56.74 459 A 1 
+ATOM 3693 N NH1 . ARG A 1 459 ? 37.316  -15.480 -7.757  1.00 53.64 459 A 1 
+ATOM 3694 N NH2 . ARG A 1 459 ? 39.540  -15.794 -7.975  1.00 51.47 459 A 1 
+ATOM 3695 N N   . GLU A 1 460 ? 37.577  -23.326 -6.844  1.00 77.37 460 A 1 
+ATOM 3696 C CA  . GLU A 1 460 ? 38.726  -24.085 -6.342  1.00 74.85 460 A 1 
+ATOM 3697 C C   . GLU A 1 460 ? 39.052  -25.274 -7.258  1.00 73.33 460 A 1 
+ATOM 3698 O O   . GLU A 1 460 ? 40.217  -25.511 -7.573  1.00 72.15 460 A 1 
+ATOM 3699 C CB  . GLU A 1 460 ? 38.459  -24.574 -4.908  1.00 75.40 460 A 1 
+ATOM 3700 C CG  . GLU A 1 460 ? 38.582  -23.446 -3.863  1.00 71.24 460 A 1 
+ATOM 3701 C CD  . GLU A 1 460 ? 38.306  -23.900 -2.414  1.00 65.23 460 A 1 
+ATOM 3702 O OE1 . GLU A 1 460 ? 38.333  -23.015 -1.521  1.00 61.02 460 A 1 
+ATOM 3703 O OE2 . GLU A 1 460 ? 38.094  -25.110 -2.183  1.00 65.17 460 A 1 
+ATOM 3704 N N   . THR A 1 461 ? 38.034  -25.990 -7.753  1.00 84.03 461 A 1 
+ATOM 3705 C CA  . THR A 1 461 ? 38.253  -27.076 -8.725  1.00 80.64 461 A 1 
+ATOM 3706 C C   . THR A 1 461 ? 38.801  -26.575 -10.067 1.00 79.78 461 A 1 
+ATOM 3707 O O   . THR A 1 461 ? 39.690  -27.221 -10.634 1.00 76.32 461 A 1 
+ATOM 3708 C CB  . THR A 1 461 ? 37.002  -27.936 -8.954  1.00 79.39 461 A 1 
+ATOM 3709 O OG1 . THR A 1 461 ? 35.842  -27.196 -9.229  1.00 72.28 461 A 1 
+ATOM 3710 C CG2 . THR A 1 461 ? 36.684  -28.820 -7.746  1.00 69.74 461 A 1 
+ATOM 3711 N N   . GLU A 1 462 ? 38.340  -25.428 -10.549 1.00 76.41 462 A 1 
+ATOM 3712 C CA  . GLU A 1 462 ? 38.868  -24.789 -11.764 1.00 73.16 462 A 1 
+ATOM 3713 C C   . GLU A 1 462 ? 40.334  -24.352 -11.571 1.00 72.14 462 A 1 
+ATOM 3714 O O   . GLU A 1 462 ? 41.191  -24.735 -12.376 1.00 69.25 462 A 1 
+ATOM 3715 C CB  . GLU A 1 462 ? 37.953  -23.623 -12.195 1.00 74.21 462 A 1 
+ATOM 3716 C CG  . GLU A 1 462 ? 36.634  -24.113 -12.831 1.00 70.18 462 A 1 
+ATOM 3717 C CD  . GLU A 1 462 ? 35.576  -23.012 -13.098 1.00 64.74 462 A 1 
+ATOM 3718 O OE1 . GLU A 1 462 ? 34.511  -23.351 -13.685 1.00 61.50 462 A 1 
+ATOM 3719 O OE2 . GLU A 1 462 ? 35.759  -21.846 -12.683 1.00 64.72 462 A 1 
+ATOM 3720 N N   . GLU A 1 463 ? 40.660  -23.690 -10.461 1.00 76.78 463 A 1 
+ATOM 3721 C CA  . GLU A 1 463 ? 42.035  -23.266 -10.138 1.00 74.38 463 A 1 
+ATOM 3722 C C   . GLU A 1 463 ? 42.998  -24.464 -9.974  1.00 71.79 463 A 1 
+ATOM 3723 O O   . GLU A 1 463 ? 44.149  -24.417 -10.426 1.00 68.03 463 A 1 
+ATOM 3724 C CB  . GLU A 1 463 ? 42.029  -22.392 -8.860  1.00 74.06 463 A 1 
+ATOM 3725 C CG  . GLU A 1 463 ? 41.469  -20.967 -9.085  1.00 67.97 463 A 1 
+ATOM 3726 C CD  . GLU A 1 463 ? 41.412  -20.074 -7.818  1.00 62.59 463 A 1 
+ATOM 3727 O OE1 . GLU A 1 463 ? 40.851  -18.938 -7.901  1.00 58.63 463 A 1 
+ATOM 3728 O OE2 . GLU A 1 463 ? 41.934  -20.490 -6.754  1.00 62.97 463 A 1 
+ATOM 3729 N N   . VAL A 1 464 ? 42.535  -25.580 -9.382  1.00 77.07 464 A 1 
+ATOM 3730 C CA  . VAL A 1 464 ? 43.330  -26.823 -9.292  1.00 75.50 464 A 1 
+ATOM 3731 C C   . VAL A 1 464 ? 43.548  -27.441 -10.678 1.00 74.11 464 A 1 
+ATOM 3732 O O   . VAL A 1 464 ? 44.641  -27.938 -10.960 1.00 71.26 464 A 1 
+ATOM 3733 C CB  . VAL A 1 464 ? 42.676  -27.825 -8.317  1.00 73.72 464 A 1 
+ATOM 3734 C CG1 . VAL A 1 464 ? 43.323  -29.221 -8.352  1.00 66.89 464 A 1 
+ATOM 3735 C CG2 . VAL A 1 464 ? 42.799  -27.327 -6.868  1.00 68.88 464 A 1 
+ATOM 3736 N N   . SER A 1 465 ? 42.545  -27.405 -11.551 1.00 75.02 465 A 1 
+ATOM 3737 C CA  . SER A 1 465 ? 42.663  -27.918 -12.921 1.00 71.91 465 A 1 
+ATOM 3738 C C   . SER A 1 465 ? 43.600  -27.080 -13.798 1.00 69.62 465 A 1 
+ATOM 3739 O O   . SER A 1 465 ? 44.407  -27.649 -14.538 1.00 66.29 465 A 1 
+ATOM 3740 C CB  . SER A 1 465 ? 41.279  -28.094 -13.555 1.00 70.43 465 A 1 
+ATOM 3741 O OG  . SER A 1 465 ? 40.676  -26.885 -13.956 1.00 61.86 465 A 1 
+ATOM 3742 N N   . GLU A 1 466 ? 43.581  -25.762 -13.664 1.00 68.26 466 A 1 
+ATOM 3743 C CA  . GLU A 1 466 ? 44.502  -24.858 -14.366 1.00 66.95 466 A 1 
+ATOM 3744 C C   . GLU A 1 466 ? 45.949  -25.021 -13.873 1.00 64.16 466 A 1 
+ATOM 3745 O O   . GLU A 1 466 ? 46.872  -25.104 -14.692 1.00 58.86 466 A 1 
+ATOM 3746 C CB  . GLU A 1 466 ? 44.048  -23.398 -14.214 1.00 66.22 466 A 1 
+ATOM 3747 C CG  . GLU A 1 466 ? 42.848  -23.053 -15.115 1.00 61.53 466 A 1 
+ATOM 3748 C CD  . GLU A 1 466 ? 42.470  -21.555 -15.097 1.00 56.32 466 A 1 
+ATOM 3749 O OE1 . GLU A 1 466 ? 41.727  -21.137 -16.021 1.00 51.25 466 A 1 
+ATOM 3750 O OE2 . GLU A 1 466 ? 42.921  -20.824 -14.186 1.00 55.65 466 A 1 
+ATOM 3751 N N   . ASN A 1 467 ? 46.149  -25.156 -12.556 1.00 67.45 467 A 1 
+ATOM 3752 C CA  . ASN A 1 467 ? 47.483  -25.408 -12.001 1.00 66.04 467 A 1 
+ATOM 3753 C C   . ASN A 1 467 ? 48.015  -26.803 -12.375 1.00 64.50 467 A 1 
+ATOM 3754 O O   . ASN A 1 467 ? 49.204  -26.949 -12.662 1.00 58.91 467 A 1 
+ATOM 3755 C CB  . ASN A 1 467 ? 47.439  -25.194 -10.479 1.00 64.21 467 A 1 
+ATOM 3756 C CG  . ASN A 1 467 ? 47.348  -23.728 -10.091 1.00 62.57 467 A 1 
+ATOM 3757 O OD1 . ASN A 1 467 ? 47.902  -22.839 -10.715 1.00 55.85 467 A 1 
+ATOM 3758 N ND2 . ASN A 1 467 ? 46.662  -23.414 -9.019  1.00 57.47 467 A 1 
+ATOM 3759 N N   . GLY A 1 468 ? 47.145  -27.826 -12.446 1.00 65.04 468 A 1 
+ATOM 3760 C CA  . GLY A 1 468 ? 47.518  -29.162 -12.930 1.00 65.17 468 A 1 
+ATOM 3761 C C   . GLY A 1 468 ? 47.937  -29.177 -14.403 1.00 64.96 468 A 1 
+ATOM 3762 O O   . GLY A 1 468 ? 48.884  -29.875 -14.770 1.00 59.66 468 A 1 
+ATOM 3763 N N   . LEU A 1 469 ? 47.294  -28.371 -15.248 1.00 62.33 469 A 1 
+ATOM 3764 C CA  . LEU A 1 469 ? 47.678  -28.201 -16.655 1.00 61.58 469 A 1 
+ATOM 3765 C C   . LEU A 1 469 ? 49.023  -27.471 -16.817 1.00 58.55 469 A 1 
+ATOM 3766 O O   . LEU A 1 469 ? 49.773  -27.787 -17.742 1.00 55.38 469 A 1 
+ATOM 3767 C CB  . LEU A 1 469 ? 46.552  -27.447 -17.393 1.00 59.88 469 A 1 
+ATOM 3768 C CG  . LEU A 1 469 ? 45.323  -28.320 -17.718 1.00 53.82 469 A 1 
+ATOM 3769 C CD1 . LEU A 1 469 ? 44.111  -27.438 -18.026 1.00 49.02 469 A 1 
+ATOM 3770 C CD2 . LEU A 1 469 ? 45.581  -29.209 -18.939 1.00 53.79 469 A 1 
+ATOM 3771 N N   . LEU A 1 470 ? 49.344  -26.537 -15.920 1.00 57.29 470 A 1 
+ATOM 3772 C CA  . LEU A 1 470 ? 50.641  -25.850 -15.912 1.00 55.35 470 A 1 
+ATOM 3773 C C   . LEU A 1 470 ? 51.789  -26.782 -15.483 1.00 53.27 470 A 1 
+ATOM 3774 O O   . LEU A 1 470 ? 52.842  -26.784 -16.127 1.00 49.70 470 A 1 
+ATOM 3775 C CB  . LEU A 1 470 ? 50.539  -24.599 -15.015 1.00 53.35 470 A 1 
+ATOM 3776 C CG  . LEU A 1 470 ? 49.745  -23.441 -15.658 1.00 48.17 470 A 1 
+ATOM 3777 C CD1 . LEU A 1 470 ? 49.303  -22.434 -14.596 1.00 43.43 470 A 1 
+ATOM 3778 C CD2 . LEU A 1 470 ? 50.587  -22.693 -16.696 1.00 48.72 470 A 1 
+ATOM 3779 N N   . ASP A 1 471 ? 51.567  -27.648 -14.482 1.00 54.13 471 A 1 
+ATOM 3780 C CA  . ASP A 1 471 ? 52.540  -28.662 -14.034 1.00 55.01 471 A 1 
+ATOM 3781 C C   . ASP A 1 471 ? 52.825  -29.733 -15.105 1.00 53.49 471 A 1 
+ATOM 3782 O O   . ASP A 1 471 ? 53.940  -30.266 -15.184 1.00 49.72 471 A 1 
+ATOM 3783 C CB  . ASP A 1 471 ? 52.013  -29.347 -12.754 1.00 52.84 471 A 1 
+ATOM 3784 C CG  . ASP A 1 471 ? 52.510  -28.757 -11.423 1.00 48.54 471 A 1 
+ATOM 3785 O OD1 . ASP A 1 471 ? 53.259  -27.758 -11.425 1.00 43.80 471 A 1 
+ATOM 3786 O OD2 . ASP A 1 471 ? 52.206  -29.400 -10.388 1.00 45.61 471 A 1 
+ATOM 3787 N N   . ASP A 1 472 ? 51.849  -30.077 -15.944 1.00 56.00 472 A 1 
+ATOM 3788 C CA  . ASP A 1 472 ? 52.028  -31.019 -17.058 1.00 57.13 472 A 1 
+ATOM 3789 C C   . ASP A 1 472 ? 52.767  -30.387 -18.253 1.00 53.87 472 A 1 
+ATOM 3790 O O   . ASP A 1 472 ? 53.476  -31.091 -18.980 1.00 51.42 472 A 1 
+ATOM 3791 C CB  . ASP A 1 472 ? 50.668  -31.612 -17.476 1.00 53.96 472 A 1 
+ATOM 3792 C CG  . ASP A 1 472 ? 50.176  -32.775 -16.594 1.00 49.88 472 A 1 
+ATOM 3793 O OD1 . ASP A 1 472 ? 51.000  -33.374 -15.859 1.00 45.80 472 A 1 
+ATOM 3794 O OD2 . ASP A 1 472 ? 48.981  -33.136 -16.732 1.00 47.62 472 A 1 
+ATOM 3795 N N   . VAL A 1 473 ? 52.664  -29.078 -18.445 1.00 53.57 473 A 1 
+ATOM 3796 C CA  . VAL A 1 473 ? 53.421  -28.341 -19.477 1.00 55.97 473 A 1 
+ATOM 3797 C C   . VAL A 1 473 ? 54.887  -28.152 -19.067 1.00 54.24 473 A 1 
+ATOM 3798 O O   . VAL A 1 473 ? 55.777  -28.325 -19.905 1.00 51.97 473 A 1 
+ATOM 3799 C CB  . VAL A 1 473 ? 52.719  -27.012 -19.837 1.00 54.40 473 A 1 
+ATOM 3800 C CG1 . VAL A 1 473 ? 53.543  -26.135 -20.793 1.00 48.65 473 A 1 
+ATOM 3801 C CG2 . VAL A 1 473 ? 51.379  -27.278 -20.543 1.00 50.82 473 A 1 
+ATOM 3802 N N   . GLU A 1 474 ? 55.179  -27.901 -17.785 1.00 47.32 474 A 1 
+ATOM 3803 C CA  . GLU A 1 474 ? 56.569  -27.796 -17.299 1.00 49.48 474 A 1 
+ATOM 3804 C C   . GLU A 1 474 ? 57.312  -29.150 -17.288 1.00 47.16 474 A 1 
+ATOM 3805 O O   . GLU A 1 474 ? 58.533  -29.191 -17.476 1.00 44.52 474 A 1 
+ATOM 3806 C CB  . GLU A 1 474 ? 56.623  -27.132 -15.911 1.00 47.94 474 A 1 
+ATOM 3807 C CG  . GLU A 1 474 ? 56.420  -25.604 -15.978 1.00 43.79 474 A 1 
+ATOM 3808 C CD  . GLU A 1 474 ? 56.744  -24.869 -14.659 1.00 38.67 474 A 1 
+ATOM 3809 O OE1 . GLU A 1 474 ? 56.932  -23.627 -14.724 1.00 35.64 474 A 1 
+ATOM 3810 O OE2 . GLU A 1 474 ? 56.841  -25.526 -13.602 1.00 40.25 474 A 1 
+ATOM 3811 N N   . LYS A 1 475 ? 56.605  -30.282 -17.155 1.00 50.88 475 A 1 
+ATOM 3812 C CA  . LYS A 1 475 ? 57.216  -31.628 -17.239 1.00 52.52 475 A 1 
+ATOM 3813 C C   . LYS A 1 475 ? 57.414  -32.146 -18.667 1.00 49.98 475 A 1 
+ATOM 3814 O O   . LYS A 1 475 ? 58.049  -33.192 -18.842 1.00 45.95 475 A 1 
+ATOM 3815 C CB  . LYS A 1 475 ? 56.405  -32.615 -16.395 1.00 49.66 475 A 1 
+ATOM 3816 C CG  . LYS A 1 475 ? 56.661  -32.396 -14.904 1.00 45.55 475 A 1 
+ATOM 3817 C CD  . LYS A 1 475 ? 55.730  -33.279 -14.080 1.00 42.10 475 A 1 
+ATOM 3818 C CE  . LYS A 1 475 ? 55.896  -32.938 -12.599 1.00 39.49 475 A 1 
+ATOM 3819 N NZ  . LYS A 1 475 ? 54.649  -33.220 -11.859 1.00 34.91 475 A 1 
+ATOM 3820 N N   . GLY A 1 476 ? 56.880  -31.464 -19.677 1.00 48.98 476 A 1 
+ATOM 3821 C CA  . GLY A 1 476 ? 56.994  -31.845 -21.090 1.00 52.44 476 A 1 
+ATOM 3822 C C   . GLY A 1 476 ? 58.266  -31.369 -21.806 1.00 51.58 476 A 1 
+ATOM 3823 O O   . GLY A 1 476 ? 58.517  -31.834 -22.917 1.00 47.39 476 A 1 
+ATOM 3824 N N   . ASP A 1 477 ? 59.073  -30.500 -21.203 1.00 43.63 477 A 1 
+ATOM 3825 C CA  . ASP A 1 477 ? 60.209  -29.827 -21.880 1.00 47.76 477 A 1 
+ATOM 3826 C C   . ASP A 1 477 ? 61.609  -30.303 -21.420 1.00 46.14 477 A 1 
+ATOM 3827 O O   . ASP A 1 477 ? 62.637  -29.792 -21.862 1.00 43.67 477 A 1 
+ATOM 3828 C CB  . ASP A 1 477 ? 60.015  -28.297 -21.818 1.00 44.83 477 A 1 
+ATOM 3829 C CG  . ASP A 1 477 ? 60.539  -27.527 -23.048 1.00 39.89 477 A 1 
+ATOM 3830 O OD1 . ASP A 1 477 ? 60.740  -28.153 -24.116 1.00 36.43 477 A 1 
+ATOM 3831 O OD2 . ASP A 1 477 ? 60.678  -26.286 -22.936 1.00 35.76 477 A 1 
+ATOM 3832 N N   . GLU A 1 478 ? 61.692  -31.349 -20.572 1.00 43.25 478 A 1 
+ATOM 3833 C CA  . GLU A 1 478 ? 62.972  -32.006 -20.238 1.00 46.61 478 A 1 
+ATOM 3834 C C   . GLU A 1 478 ? 63.144  -33.334 -21.005 1.00 44.74 478 A 1 
+ATOM 3835 O O   . GLU A 1 478 ? 63.143  -34.425 -20.428 1.00 41.81 478 A 1 
+ATOM 3836 C CB  . GLU A 1 478 ? 63.160  -32.176 -18.717 1.00 45.46 478 A 1 
+ATOM 3837 C CG  . GLU A 1 478 ? 63.503  -30.865 -17.988 1.00 40.76 478 A 1 
+ATOM 3838 C CD  . GLU A 1 478 ? 64.032  -31.096 -16.555 1.00 36.99 478 A 1 
+ATOM 3839 O OE1 . GLU A 1 478 ? 64.625  -30.148 -15.987 1.00 35.03 478 A 1 
+ATOM 3840 O OE2 . GLU A 1 478 ? 63.895  -32.227 -16.030 1.00 38.57 478 A 1 
+ATOM 3841 N N   . GLY A 1 479 ? 63.294  -33.269 -22.323 1.00 46.21 479 A 1 
+ATOM 3842 C CA  . GLY A 1 479 ? 63.483  -34.513 -23.080 1.00 51.56 479 A 1 
+ATOM 3843 C C   . GLY A 1 479 ? 63.758  -34.397 -24.572 1.00 51.19 479 A 1 
+ATOM 3844 O O   . GLY A 1 479 ? 63.185  -35.172 -25.332 1.00 46.65 479 A 1 
+ATOM 3845 N N   . ASN A 1 480 ? 64.666  -33.536 -25.019 1.00 41.63 480 A 1 
+ATOM 3846 C CA  . ASN A 1 480 ? 65.407  -33.802 -26.264 1.00 47.06 480 A 1 
+ATOM 3847 C C   . ASN A 1 480 ? 66.711  -32.999 -26.334 1.00 45.71 480 A 1 
+ATOM 3848 O O   . ASN A 1 480 ? 66.745  -31.847 -26.761 1.00 42.33 480 A 1 
+ATOM 3849 C CB  . ASN A 1 480 ? 64.519  -33.615 -27.513 1.00 44.69 480 A 1 
+ATOM 3850 C CG  . ASN A 1 480 ? 64.531  -34.829 -28.433 1.00 38.94 480 A 1 
+ATOM 3851 O OD1 . ASN A 1 480 ? 65.175  -35.842 -28.217 1.00 36.10 480 A 1 
+ATOM 3852 N ND2 . ASN A 1 480 ? 63.800  -34.763 -29.522 1.00 35.86 480 A 1 
+ATOM 3853 N N   . ASN A 1 481 ? 67.790  -33.645 -25.915 1.00 40.25 481 A 1 
+ATOM 3854 C CA  . ASN A 1 481 ? 69.145  -33.155 -26.127 1.00 46.27 481 A 1 
+ATOM 3855 C C   . ASN A 1 481 ? 69.818  -34.125 -27.099 1.00 44.61 481 A 1 
+ATOM 3856 O O   . ASN A 1 481 ? 70.204  -35.218 -26.688 1.00 41.05 481 A 1 
+ATOM 3857 C CB  . ASN A 1 481 ? 69.843  -33.049 -24.751 1.00 44.45 481 A 1 
+ATOM 3858 C CG  . ASN A 1 481 ? 70.971  -32.034 -24.697 1.00 39.69 481 A 1 
+ATOM 3859 O OD1 . ASN A 1 481 ? 71.173  -31.198 -25.562 1.00 36.91 481 A 1 
+ATOM 3860 N ND2 . ASN A 1 481 ? 71.737  -32.037 -23.630 1.00 36.40 481 A 1 
+ATOM 3861 N N   . ASP A 1 482 ? 69.925  -33.754 -28.367 1.00 41.23 482 A 1 
+ATOM 3862 C CA  . ASP A 1 482 ? 70.874  -34.383 -29.293 1.00 46.69 482 A 1 
+ATOM 3863 C C   . ASP A 1 482 ? 71.486  -33.327 -30.224 1.00 45.05 482 A 1 
+ATOM 3864 O O   . ASP A 1 482 ? 70.840  -32.662 -31.033 1.00 42.07 482 A 1 
+ATOM 3865 C CB  . ASP A 1 482 ? 70.291  -35.606 -30.032 1.00 43.89 482 A 1 
+ATOM 3866 C CG  . ASP A 1 482 ? 70.810  -36.963 -29.506 1.00 39.50 482 A 1 
+ATOM 3867 O OD1 . ASP A 1 482 ? 71.917  -36.998 -28.914 1.00 37.37 482 A 1 
+ATOM 3868 O OD2 . ASP A 1 482 ? 70.139  -37.987 -29.786 1.00 37.47 482 A 1 
+ATOM 3869 N N   . SER A 1 483 ? 72.766  -33.201 -30.037 1.00 36.54 483 A 1 
+ATOM 3870 C CA  . SER A 1 483 ? 73.851  -32.548 -30.777 1.00 42.81 483 A 1 
+ATOM 3871 C C   . SER A 1 483 ? 73.636  -32.293 -32.272 1.00 40.74 483 A 1 
+ATOM 3872 O O   . SER A 1 483 ? 73.405  -33.253 -33.003 1.00 38.80 483 A 1 
+ATOM 3873 C CB  . SER A 1 483 ? 75.012  -33.541 -30.678 1.00 40.88 483 A 1 
+ATOM 3874 O OG  . SER A 1 483 ? 74.622  -34.840 -31.113 1.00 36.64 483 A 1 
+ATOM 3875 N N   . VAL A 1 484 ? 73.972  -31.083 -32.759 1.00 34.00 484 A 1 
+ATOM 3876 C CA  . VAL A 1 484 ? 74.817  -30.868 -33.960 1.00 40.61 484 A 1 
+ATOM 3877 C C   . VAL A 1 484 ? 75.619  -29.549 -33.843 1.00 39.47 484 A 1 
+ATOM 3878 O O   . VAL A 1 484 ? 75.104  -28.514 -33.444 1.00 37.58 484 A 1 
+ATOM 3879 C CB  . VAL A 1 484 ? 74.056  -30.891 -35.314 1.00 38.74 484 A 1 
+ATOM 3880 C CG1 . VAL A 1 484 ? 75.032  -30.774 -36.496 1.00 34.39 484 A 1 
+ATOM 3881 C CG2 . VAL A 1 484 ? 73.261  -32.177 -35.589 1.00 36.92 484 A 1 
+ATOM 3882 N N   . ASP A 1 485 ? 76.886  -29.656 -34.232 1.00 35.29 485 A 1 
+ATOM 3883 C CA  . ASP A 1 485 ? 77.990  -28.697 -34.340 1.00 42.45 485 A 1 
+ATOM 3884 C C   . ASP A 1 485 ? 77.677  -27.264 -34.805 1.00 41.46 485 A 1 
+ATOM 3885 O O   . ASP A 1 485 ? 76.925  -27.007 -35.743 1.00 39.90 485 A 1 
+ATOM 3886 C CB  . ASP A 1 485 ? 78.996  -29.282 -35.348 1.00 40.32 485 A 1 
+ATOM 3887 C CG  . ASP A 1 485 ? 79.975  -30.276 -34.733 1.00 36.15 485 A 1 
+ATOM 3888 O OD1 . ASP A 1 485 ? 80.537  -29.925 -33.669 1.00 34.00 485 A 1 
+ATOM 3889 O OD2 . ASP A 1 485 ? 80.185  -31.343 -35.347 1.00 33.82 485 A 1 
+ATOM 3890 N N   . SER A 1 486 ? 78.449  -26.353 -34.246 1.00 36.60 486 A 1 
+ATOM 3891 C CA  . SER A 1 486 ? 78.748  -25.029 -34.812 1.00 41.69 486 A 1 
+ATOM 3892 C C   . SER A 1 486 ? 79.691  -25.113 -36.029 1.00 38.93 486 A 1 
+ATOM 3893 O O   . SER A 1 486 ? 80.530  -26.011 -36.108 1.00 37.55 486 A 1 
+ATOM 3894 C CB  . SER A 1 486 ? 79.374  -24.152 -33.718 1.00 40.59 486 A 1 
+ATOM 3895 O OG  . SER A 1 486 ? 80.279  -24.881 -32.903 1.00 37.42 486 A 1 
+ATOM 3896 N N   . PRO A 1 487 ? 79.636  -24.132 -36.949 1.00 33.05 487 A 1 
+ATOM 3897 C CA  . PRO A 1 487 ? 80.870  -23.365 -37.124 1.00 40.52 487 A 1 
+ATOM 3898 C C   . PRO A 1 487 ? 80.665  -21.840 -37.189 1.00 39.32 487 A 1 
+ATOM 3899 O O   . PRO A 1 487 ? 79.692  -21.302 -37.692 1.00 38.25 487 A 1 
+ATOM 3900 C CB  . PRO A 1 487 ? 81.518  -23.920 -38.391 1.00 38.39 487 A 1 
+ATOM 3901 C CG  . PRO A 1 487 ? 80.329  -24.359 -39.240 1.00 39.07 487 A 1 
+ATOM 3902 C CD  . PRO A 1 487 ? 79.136  -24.404 -38.289 1.00 44.19 487 A 1 
+ATOM 3903 N N   . ILE A 1 488 ? 81.707  -21.202 -36.684 1.00 27.13 488 A 1 
+ATOM 3904 C CA  . ILE A 1 488 ? 82.097  -19.788 -36.747 1.00 36.41 488 A 1 
+ATOM 3905 C C   . ILE A 1 488 ? 82.098  -19.268 -38.200 1.00 33.98 488 A 1 
+ATOM 3906 O O   . ILE A 1 488 ? 82.500  -20.011 -39.089 1.00 32.81 488 A 1 
+ATOM 3907 C CB  . ILE A 1 488 ? 83.547  -19.758 -36.179 1.00 35.67 488 A 1 
+ATOM 3908 C CG1 . ILE A 1 488 ? 83.608  -20.249 -34.707 1.00 32.94 488 A 1 
+ATOM 3909 C CG2 . ILE A 1 488 ? 84.226  -18.389 -36.289 1.00 34.14 488 A 1 
+ATOM 3910 C CD1 . ILE A 1 488 ? 84.999  -20.737 -34.271 1.00 33.20 488 A 1 
+ATOM 3911 N N   . ILE A 1 489 ? 81.755  -17.995 -38.437 1.00 26.64 489 A 1 
+ATOM 3912 C CA  . ILE A 1 489 ? 82.586  -16.987 -39.154 1.00 35.69 489 A 1 
+ATOM 3913 C C   . ILE A 1 489 ? 81.849  -15.631 -39.260 1.00 33.51 489 A 1 
+ATOM 3914 O O   . ILE A 1 489 ? 80.760  -15.556 -39.803 1.00 31.85 489 A 1 
+ATOM 3915 C CB  . ILE A 1 489 ? 83.083  -17.462 -40.559 1.00 34.66 489 A 1 
+ATOM 3916 C CG1 . ILE A 1 489 ? 84.390  -18.293 -40.443 1.00 32.21 489 A 1 
+ATOM 3917 C CG2 . ILE A 1 489 ? 83.416  -16.301 -41.528 1.00 34.00 489 A 1 
+ATOM 3918 C CD1 . ILE A 1 489 ? 84.549  -19.324 -41.569 1.00 32.71 489 A 1 
+ATOM 3919 N N   . ASN A 1 490 ? 82.553  -14.616 -38.771 1.00 21.54 490 A 1 
+ATOM 3920 C CA  . ASN A 1 490 ? 82.483  -13.152 -38.957 1.00 30.77 490 A 1 
+ATOM 3921 C C   . ASN A 1 490 ? 81.181  -12.367 -38.689 1.00 26.92 490 A 1 
+ATOM 3922 O O   . ASN A 1 490 ? 80.251  -12.430 -39.507 1.00 23.99 490 A 1 
+ATOM 3923 C CB  . ASN A 1 490 ? 83.152  -12.744 -40.282 1.00 29.41 490 A 1 
+ATOM 3924 C CG  . ASN A 1 490 ? 84.657  -12.922 -40.280 1.00 27.26 490 A 1 
+ATOM 3925 O OD1 . ASN A 1 490 ? 85.317  -13.119 -39.263 1.00 26.39 490 A 1 
+ATOM 3926 N ND2 . ASN A 1 490 ? 85.284  -12.851 -41.431 1.00 28.05 490 A 1 
+ATOM 3927 O OXT . ASN A 1 490 ? 81.217  -11.681 -37.638 1.00 26.67 490 A 1 
+#

--- a/tests/test_pdb_fromcif.py
+++ b/tests/test_pdb_fromcif.py
@@ -34,8 +34,8 @@ class TestTool(unittest.TestCase):
 
     def setUp(self):
         # Dynamically import the module
-        name = 'pdbtools.pdb_fromcif'
-        self.module = __import__(name, fromlist=[''])
+        name = "pdbtools.pdb_fromcif"
+        self.module = __import__(name, fromlist=[""])
 
     def exec_module(self):
         """
@@ -56,8 +56,8 @@ class TestTool(unittest.TestCase):
     def test_conversion(self):
         """$ pdb_fromcif data/ensemble_OK.pdb"""
 
-        fpath = os.path.join(data_dir, 'ensemble_OK.cif')
-        sys.argv = ['', fpath]
+        fpath = os.path.join(data_dir, "ensemble_OK.cif")
+        sys.argv = ["", fpath]
 
         # Execute the script
         self.exec_module()
@@ -68,8 +68,17 @@ class TestTool(unittest.TestCase):
         self.assertEqual(len(self.stderr), 0)
 
         # Check order of records
-        expected = ['MODEL ', 'ATOM  ', 'ATOM  ', 'ENDMDL',
-                    'MODEL ', 'ATOM  ', 'ATOM  ', 'ENDMDL', 'END   ']
+        expected = [
+            "MODEL ",
+            "ATOM  ",
+            "ATOM  ",
+            "ENDMDL",
+            "MODEL ",
+            "ATOM  ",
+            "ATOM  ",
+            "ENDMDL",
+            "END   ",
+        ]
         records = [l[:6] for l in self.stdout]
         self.assertEqual(records, expected)
 
@@ -77,22 +86,21 @@ class TestTool(unittest.TestCase):
         """$ pdb_fromcif not_existing.pdb"""
 
         # Error (file not found)
-        afile = os.path.join(data_dir, 'not_existing.pdb')
-        sys.argv = ['', afile]
+        afile = os.path.join(data_dir, "not_existing.pdb")
+        sys.argv = ["", afile]
 
         # Execute the script
         self.exec_module()
 
         self.assertEqual(self.retcode, 1)
         self.assertEqual(len(self.stdout), 0)
-        self.assertEqual(self.stderr[0][:22],
-                         "ERROR!! File not found")
+        self.assertEqual(self.stderr[0][:22], "ERROR!! File not found")
 
-    @unittest.skipIf(os.getenv('SKIP_TTY_TESTS'), 'skip on GHA - no TTY')
+    @unittest.skipIf(os.getenv("SKIP_TTY_TESTS"), "skip on GHA - no TTY")
     def test_helptext(self):
         """$ pdb_fromcif"""
 
-        sys.argv = ['']
+        sys.argv = [""]
 
         # Execute the script
         self.exec_module()
@@ -104,21 +112,33 @@ class TestTool(unittest.TestCase):
     def test_invalid_option(self):
         """$ pdb_fromcif -A data/dummy.pdb"""
 
-        sys.argv = ['', '-A', os.path.join(data_dir, 'dummy.pdb')]
+        sys.argv = ["", "-A", os.path.join(data_dir, "dummy.pdb")]
 
         # Execute the script
         self.exec_module()
 
         self.assertEqual(self.retcode, 1)
         self.assertEqual(len(self.stdout), 0)
-        self.assertEqual(self.stderr[0][:36],
-                         "ERROR!! Script takes 1 argument, not")
+        self.assertEqual(self.stderr[0][:36], "ERROR!! Script takes 1 argument, not")
+
+    def test_missing_charge(self):
+        """$ pdb_fromcif data/af3_output.cif"""
+        fpath = os.path.join(data_dir, "af3_output.cif")
+        sys.argv = ["", fpath]
+
+        # Execute the script
+        self.exec_module()
+
+        # Validate results
+        self.assertEqual(self.retcode, 0)
+        self.assertEqual(len(self.stdout), 3928)
+        self.assertEqual(len(self.stderr), 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from config import test_dir
 
-    mpath = os.path.abspath(os.path.join(test_dir, '..'))
+    mpath = os.path.abspath(os.path.join(test_dir, ".."))
     sys.path.insert(0, mpath)  # so we load dev files before  any installation
 
     unittest.main()


### PR DESCRIPTION
Changed the charge exception handling to deal with gif files missing the charge information (e.g. from AF3 and Chai).
Tested and working fine using the provided cif file in issue #168